### PR TITLE
Make Android 4.4 work with TLSv1.2-only servers

### DIFF
--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/di/NetworkModule.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/di/NetworkModule.kt
@@ -65,10 +65,15 @@ class NetworkModule {
         }
 
         single {
+            TLSSocketFactory()
+        }
+
+        single {
             OkHttpClient.Builder()
                     .connectTimeout(30, TimeUnit.SECONDS)
                     .readTimeout(30, TimeUnit.SECONDS)
                     .writeTimeout(30, TimeUnit.SECONDS)
+                    .sslSocketFactory(get<TLSSocketFactory>())
                     .addNetworkInterceptor(get<StethoInterceptor>())
                     .addInterceptor(get<UserAgentInterceptor>())
                     .addInterceptor(get<AccessTokenInterceptor>())

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/network/TLSSocketFactory.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/network/TLSSocketFactory.kt
@@ -1,0 +1,70 @@
+package im.vector.matrix.android.internal.network
+
+import java.io.IOException
+import java.net.InetAddress
+import java.net.Socket
+import java.net.UnknownHostException
+import java.security.KeyManagementException
+import java.security.NoSuchAlgorithmException
+import javax.net.ssl.SSLContext
+import javax.net.ssl.SSLSocket
+import javax.net.ssl.SSLSocketFactory
+
+
+class TLSSocketFactory @Throws(KeyManagementException::class, NoSuchAlgorithmException::class)
+constructor() : SSLSocketFactory() {
+
+    private val delegate: SSLSocketFactory
+
+    init {
+        val context = SSLContext.getInstance("TLS")
+        context.init(null, null, null)
+        delegate = context.socketFactory
+    }
+
+    override fun getDefaultCipherSuites(): Array<String> {
+        return delegate.defaultCipherSuites
+    }
+
+    override fun getSupportedCipherSuites(): Array<String> {
+        return delegate.supportedCipherSuites
+    }
+
+    @Throws(IOException::class)
+    override fun createSocket(): Socket? {
+        return enableTLSOnSocket(delegate.createSocket())
+    }
+
+    @Throws(IOException::class)
+    override fun createSocket(s: Socket, host: String, port: Int, autoClose: Boolean): Socket? {
+        return enableTLSOnSocket(delegate.createSocket(s, host, port, autoClose))
+    }
+
+    @Throws(IOException::class, UnknownHostException::class)
+    override fun createSocket(host: String, port: Int): Socket? {
+        return enableTLSOnSocket(delegate.createSocket(host, port))
+    }
+
+    @Throws(IOException::class, UnknownHostException::class)
+    override fun createSocket(host: String, port: Int, localHost: InetAddress, localPort: Int): Socket? {
+        return enableTLSOnSocket(delegate.createSocket(host, port, localHost, localPort))
+    }
+
+    @Throws(IOException::class)
+    override fun createSocket(host: InetAddress, port: Int): Socket? {
+        return enableTLSOnSocket(delegate.createSocket(host, port))
+    }
+
+    @Throws(IOException::class)
+    override fun createSocket(address: InetAddress, port: Int, localAddress: InetAddress, localPort: Int): Socket? {
+        return enableTLSOnSocket(delegate.createSocket(address, port, localAddress, localPort))
+    }
+
+    private fun enableTLSOnSocket(socket: Socket?): Socket? {
+        if (socket != null && socket is SSLSocket) {
+            socket.enabledProtocols = arrayOf("TLSv1.1", "TLSv1.2")
+        }
+        return socket
+    }
+
+}


### PR DESCRIPTION
See https://stackoverflow.com/a/46025698/3527128

According to the docs, TLSv1.2 is supported since API 16 (but only enabled by default with API 20) so this might work also on < API 19 (where I tested this)

There's also a deprecation warning in the line with `.sslSocketFactory(get<TLSSocketFactory>())` which should be fixed

The current code disables TLSv1.0 and SSLv3 (just enabled TLSv1.1 and TLSv1.2), which should probably be changed to *add* TLSv1.1 and TLSv1.2

### Pull Request Checklist

<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/riotX-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->

- [ ] Changes has been tested on an Android device or Android emulator with API 16
- [ ] UI change has been tested on both light and dark themes
- [x] Pull request is based on the develop branch
- [ ] Pull request updates [CHANGES.md](https://github.com/vector-im/riotX-android/blob/develop/CHANGES.md)
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#sign-off)
