### PR TITLE
Support incoming message edition

### DIFF
--- a/matrix-sdk-android/src/androidTest/java/im/vector/matrix/android/session/room/timeline/TimelineTest.kt
+++ b/matrix-sdk-android/src/androidTest/java/im/vector/matrix/android/session/room/timeline/TimelineTest.kt
@@ -21,9 +21,10 @@ import im.vector.matrix.android.InstrumentedTest
 import im.vector.matrix.android.api.auth.data.Credentials
 import im.vector.matrix.android.api.session.room.timeline.Timeline
 import im.vector.matrix.android.api.session.room.timeline.TimelineEvent
+import im.vector.matrix.android.internal.database.model.SessionRealmModule
 import im.vector.matrix.android.internal.session.room.EventRelationExtractor
 import im.vector.matrix.android.internal.session.room.EventRelationsAggregationUpdater
-import im.vector.matrix.android.internal.session.room.members.SenderRoomMemberExtractor
+import im.vector.matrix.android.internal.session.room.membership.SenderRoomMemberExtractor
 import im.vector.matrix.android.internal.session.room.timeline.DefaultTimeline
 import im.vector.matrix.android.internal.session.room.timeline.TimelineEventFactory
 import im.vector.matrix.android.internal.session.room.timeline.TokenChunkEventPersistor
@@ -49,7 +50,9 @@ internal class TimelineTest : InstrumentedTest {
     fun setup() {
         Timber.plant(Timber.DebugTree())
         Realm.init(context())
-        val testConfiguration = RealmConfiguration.Builder().name("test-realm").build()
+        val testConfiguration = RealmConfiguration.Builder().name("test-realm")
+                .modules(SessionRealmModule()).build()
+
         Realm.deleteRealm(testConfiguration)
         monarchy = Monarchy.Builder().setRealmConfiguration(testConfiguration).build()
         RoomDataHelper.fakeInitialSync(monarchy, ROOM_ID)

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/model/EditAggregatedSummary.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/model/EditAggregatedSummary.kt
@@ -13,16 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package im.vector.matrix.android.api.session.room.model
 
-package im.vector.matrix.android.api.session.room.model.message
+import im.vector.matrix.android.api.session.events.model.Content
 
-import com.squareup.moshi.Json
-import com.squareup.moshi.JsonClass
-
-@JsonClass(generateAdapter = true)
-data class FileInfo(
-        @Json(name = "mimetype") val mimeType: String?,
-        @Json(name = "size") val size: Long = 0,
-        @Json(name = "thumbnail_info") val thumbnailInfo: ThumbnailInfo? = null,
-        @Json(name = "thumbnail_url") val thumbnailUrl: String? = null
+data class EditAggregatedSummary(
+        val aggregatedContent: Content? = null,
+        // The list of the eventIDs used to build the summary (might be out of sync if chunked received from message chunk)
+        val sourceEvents: List<String>,
+        val lastEditTs: Long = 0
 )

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/model/EventAnnotationsSummary.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/model/EventAnnotationsSummary.kt
@@ -1,7 +1,22 @@
+/*
+ * Copyright 2019 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package im.vector.matrix.android.api.session.room.model
-
 
 data class EventAnnotationsSummary(
         var eventId: String,
-        var reactionsSummary: List<ReactionAggregatedSummary>
+        var reactionsSummary: List<ReactionAggregatedSummary>,
+        var editSummary: EditAggregatedSummary?
 )

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/model/annotation/ReactionInfo.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/model/annotation/ReactionInfo.kt
@@ -5,7 +5,7 @@ import com.squareup.moshi.JsonClass
 
 @JsonClass(generateAdapter = true)
 data class ReactionInfo(
-        @Json(name = "rel_type") override val type: String,
+        @Json(name = "rel_type") override val type: String?,
         @Json(name = "event_id") override val eventId: String,
         val key: String
 ) : RelationContent

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/model/annotation/RelationContent.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/model/annotation/RelationContent.kt
@@ -1,6 +1,6 @@
 package im.vector.matrix.android.api.session.room.model.annotation
 
 interface RelationContent {
-    val type: String
-    val eventId: String
+    val type: String?
+    val eventId: String?
 }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/model/annotation/RelationDefaultContent.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/model/annotation/RelationDefaultContent.kt
@@ -1,8 +1,25 @@
+/*
+ * Copyright 2019 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package im.vector.matrix.android.api.session.room.model.annotation
 
 import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
 
+@JsonClass(generateAdapter = true)
 data class RelationDefaultContent(
-        @Json(name = "rel_type") override val type: String,
-        @Json(name = "event_id") override val eventId: String
+        @Json(name = "rel_type") override val type: String?,
+        @Json(name = "event_id") override val eventId: String?
 ) : RelationContent

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/model/message/MessageAudioContent.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/model/message/MessageAudioContent.kt
@@ -18,11 +18,15 @@ package im.vector.matrix.android.api.session.room.model.message
 
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
+import im.vector.matrix.android.api.session.events.model.Content
+import im.vector.matrix.android.api.session.room.model.annotation.RelationDefaultContent
 
 @JsonClass(generateAdapter = true)
 data class MessageAudioContent(
         @Json(name = "msgtype") override val type: String,
         @Json(name = "body") override val body: String,
         @Json(name = "info") val info: AudioInfo? = null,
-        @Json(name = "url") val url: String? = null
+        @Json(name = "url") val url: String? = null,
+        @Json(name = "m.relates_to") override val relatesTo: RelationDefaultContent? = null,
+        @Json(name = "m.new_content") override val newContent: Content? = null
 ) : MessageContent

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/model/message/MessageContent.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/model/message/MessageContent.kt
@@ -16,8 +16,13 @@
 
 package im.vector.matrix.android.api.session.room.model.message
 
+import im.vector.matrix.android.api.session.events.model.Content
+import im.vector.matrix.android.api.session.room.model.annotation.RelationDefaultContent
+
 
 interface MessageContent {
     val type: String
     val body: String
+    val relatesTo: RelationDefaultContent?
+    val newContent: Content?
 }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/model/message/MessageDefaultContent.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/model/message/MessageDefaultContent.kt
@@ -18,9 +18,13 @@ package im.vector.matrix.android.api.session.room.model.message
 
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
+import im.vector.matrix.android.api.session.events.model.Content
+import im.vector.matrix.android.api.session.room.model.annotation.RelationDefaultContent
 
 @JsonClass(generateAdapter = true)
 data class MessageDefaultContent(
         @Json(name = "msgtype") override val type: String,
-        @Json(name = "body") override val body: String
+        @Json(name = "body") override val body: String,
+        @Json(name = "m.relates_to") override val relatesTo: RelationDefaultContent? = null,
+        @Json(name = "m.new_content") override val newContent: Content? = null
 ) : MessageContent

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/model/message/MessageEmoteContent.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/model/message/MessageEmoteContent.kt
@@ -18,11 +18,15 @@ package im.vector.matrix.android.api.session.room.model.message
 
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
+import im.vector.matrix.android.api.session.events.model.Content
+import im.vector.matrix.android.api.session.room.model.annotation.RelationDefaultContent
 
 @JsonClass(generateAdapter = true)
 data class MessageEmoteContent(
         @Json(name = "msgtype") override val type: String,
         @Json(name = "body") override val body: String,
         @Json(name = "format") val format: String? = null,
-        @Json(name = "formatted_body") val formattedBody: String? = null
+        @Json(name = "formatted_body") val formattedBody: String? = null,
+        @Json(name = "m.relates_to") override val relatesTo: RelationDefaultContent? = null,
+        @Json(name = "m.new_content") override val newContent: Content? = null
 ) : MessageContent

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/model/message/MessageFileContent.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/model/message/MessageFileContent.kt
@@ -18,6 +18,8 @@ package im.vector.matrix.android.api.session.room.model.message
 
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
+import im.vector.matrix.android.api.session.events.model.Content
+import im.vector.matrix.android.api.session.room.model.annotation.RelationDefaultContent
 
 @JsonClass(generateAdapter = true)
 data class MessageFileContent(
@@ -25,5 +27,7 @@ data class MessageFileContent(
         @Json(name = "body") override val body: String,
         @Json(name = "filename") val filename: String? = null,
         @Json(name = "info") val info: FileInfo? = null,
-        @Json(name = "url") val url: String? = null
+        @Json(name = "url") val url: String? = null,
+        @Json(name = "m.relates_to") override val relatesTo: RelationDefaultContent? = null,
+        @Json(name = "m.new_content") override val newContent: Content? = null
 ) : MessageContent

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/model/message/MessageImageContent.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/model/message/MessageImageContent.kt
@@ -18,11 +18,15 @@ package im.vector.matrix.android.api.session.room.model.message
 
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
+import im.vector.matrix.android.api.session.events.model.Content
+import im.vector.matrix.android.api.session.room.model.annotation.RelationDefaultContent
 
 @JsonClass(generateAdapter = true)
 data class MessageImageContent(
         @Json(name = "msgtype") override val type: String,
         @Json(name = "body") override val body: String,
         @Json(name = "info") val info: ImageInfo? = null,
-        @Json(name = "url") val url: String? = null
+        @Json(name = "url") val url: String? = null,
+        @Json(name = "m.relates_to") override val relatesTo: RelationDefaultContent? = null,
+        @Json(name = "m.new_content") override val newContent: Content? = null
 ) : MessageContent

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/model/message/MessageLocationContent.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/model/message/MessageLocationContent.kt
@@ -18,11 +18,15 @@ package im.vector.matrix.android.api.session.room.model.message
 
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
+import im.vector.matrix.android.api.session.events.model.Content
+import im.vector.matrix.android.api.session.room.model.annotation.RelationDefaultContent
 
 @JsonClass(generateAdapter = true)
 data class MessageLocationContent(
         @Json(name = "msgtype") override val type: String,
         @Json(name = "body") override val body: String,
         @Json(name = "geo_uri") val geoUri: String,
-        @Json(name = "info") val info: LocationInfo? = null
+        @Json(name = "info") val info: LocationInfo? = null,
+        @Json(name = "m.relates_to") override val relatesTo: RelationDefaultContent? = null,
+        @Json(name = "m.new_content") override val newContent: Content? = null
 ) : MessageContent

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/model/message/MessageNoticeContent.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/model/message/MessageNoticeContent.kt
@@ -18,11 +18,15 @@ package im.vector.matrix.android.api.session.room.model.message
 
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
+import im.vector.matrix.android.api.session.events.model.Content
+import im.vector.matrix.android.api.session.room.model.annotation.RelationDefaultContent
 
 @JsonClass(generateAdapter = true)
 data class MessageNoticeContent(
         @Json(name = "msgtype") override val type: String,
         @Json(name = "body") override val body: String,
         @Json(name = "format") val format: String? = null,
-        @Json(name = "formatted_body") val formattedBody: String? = null
+        @Json(name = "formatted_body") val formattedBody: String? = null,
+        @Json(name = "m.relates_to") override val relatesTo: RelationDefaultContent? = null,
+        @Json(name = "m.new_content") override val newContent: Content? = null
 ) : MessageContent

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/model/message/MessageTextContent.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/model/message/MessageTextContent.kt
@@ -18,11 +18,15 @@ package im.vector.matrix.android.api.session.room.model.message
 
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
+import im.vector.matrix.android.api.session.events.model.Content
+import im.vector.matrix.android.api.session.room.model.annotation.RelationDefaultContent
 
 @JsonClass(generateAdapter = true)
 data class MessageTextContent(
         @Json(name = "msgtype") override val type: String,
         @Json(name = "body") override val body: String,
         @Json(name = "format") val format: String? = null,
-        @Json(name = "formatted_body") val formattedBody: String? = null
+        @Json(name = "formatted_body") val formattedBody: String? = null,
+        @Json(name = "m.relates_to") override val relatesTo: RelationDefaultContent? = null,
+        @Json(name = "m.new_content") override val newContent: Content? = null
 ) : MessageContent

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/model/message/MessageVideoContent.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/model/message/MessageVideoContent.kt
@@ -18,11 +18,15 @@ package im.vector.matrix.android.api.session.room.model.message
 
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
+import im.vector.matrix.android.api.session.events.model.Content
+import im.vector.matrix.android.api.session.room.model.annotation.RelationDefaultContent
 
 @JsonClass(generateAdapter = true)
 data class MessageVideoContent(
         @Json(name = "msgtype") override val type: String,
         @Json(name = "body") override val body: String,
         @Json(name = "info") val info: VideoInfo? = null,
-        @Json(name = "url") val url: String? = null
+        @Json(name = "url") val url: String? = null,
+        @Json(name = "m.relates_to") override val relatesTo: RelationDefaultContent? = null,
+        @Json(name = "m.new_content") override val newContent: Content? = null
 ) : MessageContent

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/database/mapper/EventAnnotationsSummaryMapper.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/database/mapper/EventAnnotationsSummaryMapper.kt
@@ -1,5 +1,6 @@
 package im.vector.matrix.android.internal.database.mapper
 
+import im.vector.matrix.android.api.session.room.model.EditAggregatedSummary
 import im.vector.matrix.android.api.session.room.model.EventAnnotationsSummary
 import im.vector.matrix.android.api.session.room.model.ReactionAggregatedSummary
 import im.vector.matrix.android.internal.database.model.EventAnnotationsSummaryEntity
@@ -15,6 +16,13 @@ internal object EventAnnotationsSummaryMapper {
                             it.addedByMe,
                             it.firstTimestamp,
                             it.sourceEvents.toList()
+                    )
+                },
+                editSummary = annotationsSummary.editSummary?.let {
+                    EditAggregatedSummary(
+                            ContentMapper.map(it.aggregatedContent),
+                            it.sourceEvents.toList(),
+                            it.lastEditTs
                     )
                 }
         )

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/database/model/EditAggregatedSummaryEntity.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/database/model/EditAggregatedSummaryEntity.kt
@@ -13,16 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package im.vector.matrix.android.internal.database.model
 
-package im.vector.matrix.android.api.session.room.model.message
+import io.realm.RealmList
+import io.realm.RealmObject
 
-import com.squareup.moshi.Json
-import com.squareup.moshi.JsonClass
+/**
+ * Keep the latest state of edition of a message
+ */
+internal open class EditAggregatedSummaryEntity(
+        var aggregatedContent: String? = null,
+        // The list of the eventIDs used to build the summary (might be out of sync if chunked received from message chunk)
+        var sourceEvents: RealmList<String> = RealmList(),
+        var lastEditTs: Long = 0
+) : RealmObject() {
 
-@JsonClass(generateAdapter = true)
-data class FileInfo(
-        @Json(name = "mimetype") val mimeType: String?,
-        @Json(name = "size") val size: Long = 0,
-        @Json(name = "thumbnail_info") val thumbnailInfo: ThumbnailInfo? = null,
-        @Json(name = "thumbnail_url") val thumbnailUrl: String? = null
-)
+    companion object
+
+}

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/database/model/EventAnnotationsSummaryEntity.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/database/model/EventAnnotationsSummaryEntity.kt
@@ -24,7 +24,8 @@ internal open class EventAnnotationsSummaryEntity(
         @PrimaryKey
         var eventId: String = "",
         var roomId: String? = null,
-        var reactionsSummary: RealmList<ReactionAggregatedSummaryEntity> = RealmList()
+        var reactionsSummary: RealmList<ReactionAggregatedSummaryEntity> = RealmList(),
+        var editSummary: EditAggregatedSummaryEntity? = null
 ) : RealmObject() {
 
     companion object

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/database/model/SessionRealmModule.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/database/model/SessionRealmModule.kt
@@ -35,6 +35,7 @@ import io.realm.annotations.RealmModule
             SyncEntity::class,
             UserEntity::class,
             EventAnnotationsSummaryEntity::class,
-            ReactionAggregatedSummaryEntity::class
+            ReactionAggregatedSummaryEntity::class,
+            EditAggregatedSummaryEntity::class
         ])
 internal class SessionRealmModule

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/di/MoshiProvider.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/di/MoshiProvider.kt
@@ -17,19 +17,7 @@
 package im.vector.matrix.android.internal.di
 
 import com.squareup.moshi.Moshi
-import im.vector.matrix.android.api.session.events.model.EventType
-import im.vector.matrix.android.api.session.room.model.annotation.RelationContent
-import im.vector.matrix.android.api.session.room.model.message.MessageAudioContent
-import im.vector.matrix.android.api.session.room.model.message.MessageContent
-import im.vector.matrix.android.api.session.room.model.message.MessageDefaultContent
-import im.vector.matrix.android.api.session.room.model.message.MessageEmoteContent
-import im.vector.matrix.android.api.session.room.model.message.MessageFileContent
-import im.vector.matrix.android.api.session.room.model.message.MessageImageContent
-import im.vector.matrix.android.api.session.room.model.message.MessageLocationContent
-import im.vector.matrix.android.api.session.room.model.message.MessageNoticeContent
-import im.vector.matrix.android.api.session.room.model.message.MessageTextContent
-import im.vector.matrix.android.api.session.room.model.message.MessageType
-import im.vector.matrix.android.api.session.room.model.message.MessageVideoContent
+import im.vector.matrix.android.api.session.room.model.message.*
 import im.vector.matrix.android.internal.network.parsing.RuntimeJsonAdapterFactory
 import im.vector.matrix.android.internal.network.parsing.UriMoshiAdapter
 import im.vector.matrix.android.internal.session.sync.model.UserAccountData
@@ -41,17 +29,17 @@ object MoshiProvider {
     private val moshi: Moshi = Moshi.Builder()
             .add(UriMoshiAdapter())
             .add(RuntimeJsonAdapterFactory.of(UserAccountData::class.java, "type", UserAccountDataFallback::class.java)
-                         .registerSubtype(UserAccountDataDirectMessages::class.java, UserAccountData.TYPE_DIRECT_MESSAGES)
+                    .registerSubtype(UserAccountDataDirectMessages::class.java, UserAccountData.TYPE_DIRECT_MESSAGES)
             )
             .add(RuntimeJsonAdapterFactory.of(MessageContent::class.java, "msgtype", MessageDefaultContent::class.java)
-                         .registerSubtype(MessageTextContent::class.java, MessageType.MSGTYPE_TEXT)
-                         .registerSubtype(MessageNoticeContent::class.java, MessageType.MSGTYPE_NOTICE)
-                         .registerSubtype(MessageEmoteContent::class.java, MessageType.MSGTYPE_EMOTE)
-                         .registerSubtype(MessageAudioContent::class.java, MessageType.MSGTYPE_AUDIO)
-                         .registerSubtype(MessageImageContent::class.java, MessageType.MSGTYPE_IMAGE)
-                         .registerSubtype(MessageVideoContent::class.java, MessageType.MSGTYPE_VIDEO)
-                         .registerSubtype(MessageLocationContent::class.java, MessageType.MSGTYPE_LOCATION)
-                         .registerSubtype(MessageFileContent::class.java, MessageType.MSGTYPE_FILE)
+                    .registerSubtype(MessageTextContent::class.java, MessageType.MSGTYPE_TEXT)
+                    .registerSubtype(MessageNoticeContent::class.java, MessageType.MSGTYPE_NOTICE)
+                    .registerSubtype(MessageEmoteContent::class.java, MessageType.MSGTYPE_EMOTE)
+                    .registerSubtype(MessageAudioContent::class.java, MessageType.MSGTYPE_AUDIO)
+                    .registerSubtype(MessageImageContent::class.java, MessageType.MSGTYPE_IMAGE)
+                    .registerSubtype(MessageVideoContent::class.java, MessageType.MSGTYPE_VIDEO)
+                    .registerSubtype(MessageLocationContent::class.java, MessageType.MSGTYPE_LOCATION)
+                    .registerSubtype(MessageFileContent::class.java, MessageType.MSGTYPE_FILE)
             )
             .build()
 

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/EventRelationExtractor.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/EventRelationExtractor.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package im.vector.matrix.android.internal.session.room
 
 import im.vector.matrix.android.api.session.room.model.EventAnnotationsSummary
@@ -7,7 +22,9 @@ import im.vector.matrix.android.internal.database.model.EventEntity
 import im.vector.matrix.android.internal.database.query.where
 import io.realm.Realm
 
-
+/**
+ * Fetches annotations (reactions, edits...) associated to a given eventEntity from the data layer.
+ */
 internal class EventRelationExtractor {
 
     fun extractFrom(event: EventEntity, realm: Realm = event.realm): EventAnnotationsSummary? {

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/EventRelationsAggregationUpdater.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/EventRelationsAggregationUpdater.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package im.vector.matrix.android.internal.session.room
 
 import im.vector.matrix.android.api.auth.data.Credentials
@@ -13,7 +28,11 @@ import im.vector.matrix.android.internal.database.query.where
 import io.realm.Realm
 import timber.log.Timber
 
-
+/**
+ * Acts as a listener of incoming messages in order to incrementally computes a summary of annotations.
+ * For reactions will build a EventAnnotationsSummaryEntity, ans for edits a EditAggregatedSummaryEntity.
+ * The summaries can then be extracted and added (as a decoration) to a TimelineEvent for final display.
+ */
 internal class EventRelationsAggregationUpdater(private val credentials: Credentials) {
 
     fun update(realm: Realm, roomId: String, events: List<Event>?) {
@@ -79,7 +98,6 @@ internal class EventRelationsAggregationUpdater(private val credentials: Credent
             } else {
                 //ignore this event for the summary
                 Timber.v("###REPLACE ignoring event for summary, it's to old ${eventId}")
-
             }
         }
 

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/RoomModule.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/RoomModule.kt
@@ -109,7 +109,7 @@ class RoomModule {
         }
 
         scope(DefaultSession.SCOPE) {
-            DefaultPruneEventTask(get()) as PruneEventTask
+            DefaultPruneEventTask(get(),get()) as PruneEventTask
         }
 
     }

--- a/vector/src/main/java/im/vector/riotredesign/core/di/AppModule.kt
+++ b/vector/src/main/java/im/vector/riotredesign/core/di/AppModule.kt
@@ -19,7 +19,6 @@ package im.vector.riotredesign.core.di
 import android.content.Context
 import android.content.Context.MODE_PRIVATE
 import im.vector.matrix.android.api.Matrix
-import im.vector.riotredesign.core.resources.ColorProvider
 import im.vector.riotredesign.core.resources.LocaleProvider
 import im.vector.riotredesign.core.resources.StringProvider
 import im.vector.riotredesign.features.home.group.SelectedGroupStore
@@ -40,11 +39,7 @@ class AppModule(private val context: Context) {
         single {
             StringProvider(context.resources)
         }
-
-        single {
-            ColorProvider(context)
-        }
-
+        
         single {
             context.getSharedPreferences("im.vector.riot", MODE_PRIVATE)
         }

--- a/vector/src/main/java/im/vector/riotredesign/core/di/AppModule.kt
+++ b/vector/src/main/java/im/vector/riotredesign/core/di/AppModule.kt
@@ -39,7 +39,7 @@ class AppModule(private val context: Context) {
         single {
             StringProvider(context.resources)
         }
-        
+
         single {
             context.getSharedPreferences("im.vector.riot", MODE_PRIVATE)
         }

--- a/vector/src/main/java/im/vector/riotredesign/core/resources/ColorProvider.kt
+++ b/vector/src/main/java/im/vector/riotredesign/core/resources/ColorProvider.kt
@@ -19,13 +19,28 @@
 package im.vector.riotredesign.core.resources
 
 import android.content.Context
+import androidx.annotation.AttrRes
+import androidx.annotation.ColorInt
 import androidx.annotation.ColorRes
 import androidx.core.content.ContextCompat
+import im.vector.riotredesign.features.themes.ThemeUtils
 
 class ColorProvider(private val context: Context) {
 
     fun getColor(@ColorRes colorRes: Int): Int {
         return ContextCompat.getColor(context, colorRes)
+    }
+
+    /**
+     * Translates color attributes to colors
+     *
+     * @param c              Context
+     * @param colorAttribute Color Attribute
+     * @return Requested Color
+     */
+    @ColorInt
+    fun getColorFromAttribute(@AttrRes colorAttribute: Int): Int {
+        return ThemeUtils.getColor(context, colorAttribute)
     }
 
 }

--- a/vector/src/main/java/im/vector/riotredesign/features/home/HomeModule.kt
+++ b/vector/src/main/java/im/vector/riotredesign/features/home/HomeModule.kt
@@ -18,6 +18,7 @@ package im.vector.riotredesign.features.home
 
 import androidx.fragment.app.Fragment
 import im.vector.riotredesign.core.glide.GlideApp
+import im.vector.riotredesign.core.resources.ColorProvider
 import im.vector.riotredesign.features.autocomplete.command.AutocompleteCommandController
 import im.vector.riotredesign.features.autocomplete.command.AutocompleteCommandPresenter
 import im.vector.riotredesign.features.autocomplete.user.AutocompleteUserController
@@ -58,7 +59,8 @@ class HomeModule {
             val eventHtmlRenderer = EventHtmlRenderer(GlideApp.with(fragment), fragment.requireContext(), get())
             val timelineDateFormatter = TimelineDateFormatter(get())
             val timelineMediaSizeProvider = TimelineMediaSizeProvider()
-            val messageItemFactory = MessageItemFactory(get(), timelineMediaSizeProvider, timelineDateFormatter, eventHtmlRenderer)
+            val colorProvider = ColorProvider(fragment.requireContext())
+            val messageItemFactory = MessageItemFactory(colorProvider, timelineMediaSizeProvider, timelineDateFormatter, eventHtmlRenderer)
 
             val timelineItemFactory = TimelineItemFactory(messageItemFactory = messageItemFactory,
                     roomNameItemFactory = RoomNameItemFactory(get()),

--- a/vector/src/main/java/im/vector/riotredesign/features/home/room/detail/RoomDetailActions.kt
+++ b/vector/src/main/java/im/vector/riotredesign/features/home/room/detail/RoomDetailActions.kt
@@ -17,6 +17,7 @@
 package im.vector.riotredesign.features.home.room.detail
 
 import com.jaiselrahman.filepicker.model.MediaFile
+import im.vector.matrix.android.api.session.room.model.EditAggregatedSummary
 import im.vector.matrix.android.api.session.room.timeline.Timeline
 import im.vector.matrix.android.api.session.room.timeline.TimelineEvent
 
@@ -31,6 +32,7 @@ sealed class RoomDetailActions {
     data class RedactAction(val targetEventId: String, val reason: String? = "") : RoomDetailActions()
     data class UndoReaction(val targetEventId: String, val key: String, val reason: String? = "") : RoomDetailActions()
     data class UpdateQuickReactAction(val targetEventId: String,val selectedReaction: String,val opposite: String) : RoomDetailActions()
+    data class ShowEditHistoryAction(val event: String,val editAggregatedSummary: EditAggregatedSummary) : RoomDetailActions()
     object AcceptInvite : RoomDetailActions()
     object RejectInvite : RoomDetailActions()
 

--- a/vector/src/main/java/im/vector/riotredesign/features/home/room/detail/timeline/TimelineEventController.kt
+++ b/vector/src/main/java/im/vector/riotredesign/features/home/room/detail/timeline/TimelineEventController.kt
@@ -25,6 +25,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.airbnb.epoxy.EpoxyController
 import com.airbnb.epoxy.EpoxyModel
 import im.vector.matrix.android.api.session.events.model.toModel
+import im.vector.matrix.android.api.session.room.model.EditAggregatedSummary
 import im.vector.matrix.android.api.session.room.model.RoomMember
 import im.vector.matrix.android.api.session.room.model.message.*
 import im.vector.matrix.android.api.session.room.timeline.Timeline
@@ -58,6 +59,7 @@ class TimelineEventController(private val dateFormatter: TimelineDateFormatter,
         fun onEventLongClicked(informationData: MessageInformationData, messageContent: MessageContent, view: View): Boolean
         fun onAvatarClicked(informationData: MessageInformationData)
         fun onMemberNameClicked(informationData: MessageInformationData)
+        fun onEditedDecorationClicked(informationData: MessageInformationData, editAggregatedSummary: EditAggregatedSummary?)
     }
 
     interface ReactionPillCallback {

--- a/vector/src/main/java/im/vector/riotredesign/features/home/room/detail/timeline/action/MessageActionsViewModel.kt
+++ b/vector/src/main/java/im/vector/riotredesign/features/home/room/detail/timeline/action/MessageActionsViewModel.kt
@@ -51,7 +51,8 @@ class MessageActionsViewModel(initialState: MessageActionState) : VectorViewMode
 
             val event = currentSession.getRoom(parcel.roomId)?.getTimeLineEvent(parcel.eventId)
             return if (event != null) {
-                val messageContent: MessageContent? = event.root.content.toModel()
+                val messageContent: MessageContent? = event.annotations?.editSummary?.aggregatedContent?.toModel()
+                        ?: event.root.content.toModel()
                 val originTs = event.root.originServerTs
                 MessageActionState(
                         event.root.sender ?: "",

--- a/vector/src/main/java/im/vector/riotredesign/features/home/room/detail/timeline/factory/MessageItemFactory.kt
+++ b/vector/src/main/java/im/vector/riotredesign/features/home/room/detail/timeline/factory/MessageItemFactory.kt
@@ -325,7 +325,10 @@ class MessageItemFactory(private val colorProvider: ColorProvider,
                 }
     }
 
-    private fun annotateWithEdited(linkifiedBody: CharSequence, callback: TimelineEventController.Callback?, informationData: MessageInformationData, editSummary: EditAggregatedSummary?): SpannableStringBuilder {
+    private fun annotateWithEdited(linkifiedBody: CharSequence,
+                                   callback: TimelineEventController.Callback?,
+                                   informationData: MessageInformationData,
+                                   editSummary: EditAggregatedSummary?): SpannableStringBuilder {
         val spannable = SpannableStringBuilder()
         spannable.append(linkifiedBody)
         val editedSuffix = "(edited)"

--- a/vector/src/main/java/im/vector/riotredesign/features/home/room/detail/timeline/item/AbsMessageItem.kt
+++ b/vector/src/main/java/im/vector/riotredesign/features/home/room/detail/timeline/item/AbsMessageItem.kt
@@ -129,7 +129,7 @@ abstract class AbsMessageItem<H : AbsMessageItem.Holder> : BaseEventItem<H>() {
         }
     }
 
-    open fun shouldShowReactionAtBottom() : Boolean {
+    open fun shouldShowReactionAtBottom(): Boolean {
         return true
     }
 

--- a/vector/src/main/java/im/vector/riotredesign/features/home/room/detail/timeline/item/BlankItem.kt
+++ b/vector/src/main/java/im/vector/riotredesign/features/home/room/detail/timeline/item/BlankItem.kt
@@ -13,16 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package im.vector.riotredesign.features.home.room.detail.timeline.item
 
-package im.vector.matrix.android.api.session.room.model.message
+import com.airbnb.epoxy.EpoxyModelClass
+import im.vector.riotredesign.R
+import im.vector.riotredesign.core.epoxy.VectorEpoxyHolder
+import im.vector.riotredesign.core.epoxy.VectorEpoxyModel
 
-import com.squareup.moshi.Json
-import com.squareup.moshi.JsonClass
 
-@JsonClass(generateAdapter = true)
-data class FileInfo(
-        @Json(name = "mimetype") val mimeType: String?,
-        @Json(name = "size") val size: Long = 0,
-        @Json(name = "thumbnail_info") val thumbnailInfo: ThumbnailInfo? = null,
-        @Json(name = "thumbnail_url") val thumbnailUrl: String? = null
-)
+@EpoxyModelClass(layout = R.layout.item_timeline_event_blank_stub)
+abstract class BlankItem : VectorEpoxyModel<BlankItem.BlankHolder>() {
+    class BlankHolder : VectorEpoxyHolder()
+}

--- a/vector/src/main/java/im/vector/riotredesign/features/home/room/detail/timeline/item/MessageInformationData.kt
+++ b/vector/src/main/java/im/vector/riotredesign/features/home/room/detail/timeline/item/MessageInformationData.kt
@@ -31,5 +31,6 @@ data class MessageInformationData(
         val memberName: CharSequence? = null,
         val showInformation: Boolean = true,
         /*List of reactions (emoji,count,isSelected)*/
-        var orderedReactionList: List<Triple<String,Int,Boolean>>? = null
+        var orderedReactionList: List<Triple<String,Int,Boolean>>? = null,
+        var hasBeenEdited: Boolean = false
 ) : Parcelable

--- a/vector/src/main/res/layout/item_timeline_event_base_noinfo.xml
+++ b/vector/src/main/res/layout/item_timeline_event_base_noinfo.xml
@@ -32,6 +32,8 @@
         android:id="@+id/messageContentBlankStub"
         style="@style/TimelineContentStubNoInfoLayoutParams"
         android:layout="@layout/item_timeline_event_blank_stub"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
         tools:ignore="MissingConstraints" />
 
     <ViewStub

--- a/vector/src/main/res/values/strings_riotX.xml
+++ b/vector/src/main/res/values/strings_riotX.xml
@@ -15,5 +15,6 @@
 
     <string name="event_redacted_by_user_reason">Event deleted by user</string>
     <string name="event_redacted_by_admin_reason">Event moderated by room admin</string>
+    <string name="last_edited_info_message">Last edited by %s on %s</string>
 
 </resources>


### PR DESCRIPTION
Fixes #120 

- [x] Support for incoming m.replace
- [x] Show simple change history (author and date of latest edit)
- [x] Redaction (delete) of a m.replace event (edit) is supported

Known Limitations
- On text and emote message are annotated with the (edit) tag. Other replace are supported but no annotation will be shown
- Only reactions added to the original event are displayed (reaction to the replace event are ignored)
- View source only show original source. 

![edit](https://user-images.githubusercontent.com/9841565/58096261-f37f4c00-7bd4-11e9-92a7-10e505daf333.gif)


