### PR TITLE
Local echo for reactions/edits/redacts

### DIFF
--- a/matrix-sdk-android/build.gradle
+++ b/matrix-sdk-android/build.gradle
@@ -48,7 +48,7 @@ android {
             buildConfigField "boolean", "LOG_PRIVATE_DATA", "false"
 
             // Set to BODY instead of NONE to enable logging
-            buildConfigField "okhttp3.logging.HttpLoggingInterceptor.Level", "OKHTTP_LOGGING_LEVEL", "okhttp3.logging.HttpLoggingInterceptor.Level.NONE"
+            buildConfigField "okhttp3.logging.HttpLoggingInterceptor.Level", "OKHTTP_LOGGING_LEVEL", "okhttp3.logging.HttpLoggingInterceptor.Level.BASIC"
         }
 
         release {

--- a/matrix-sdk-android/src/androidTest/java/im/vector/matrix/android/session/room/timeline/TimelineTest.kt
+++ b/matrix-sdk-android/src/androidTest/java/im/vector/matrix/android/session/room/timeline/TimelineTest.kt
@@ -18,12 +18,10 @@ package im.vector.matrix.android.session.room.timeline
 
 import com.zhuinden.monarchy.Monarchy
 import im.vector.matrix.android.InstrumentedTest
-import im.vector.matrix.android.api.auth.data.Credentials
 import im.vector.matrix.android.api.session.room.timeline.Timeline
 import im.vector.matrix.android.api.session.room.timeline.TimelineEvent
 import im.vector.matrix.android.internal.database.model.SessionRealmModule
 import im.vector.matrix.android.internal.session.room.EventRelationExtractor
-import im.vector.matrix.android.internal.session.room.EventRelationsAggregationUpdater
 import im.vector.matrix.android.internal.session.room.membership.SenderRoomMemberExtractor
 import im.vector.matrix.android.internal.session.room.timeline.DefaultTimeline
 import im.vector.matrix.android.internal.session.room.timeline.TimelineEventFactory
@@ -60,8 +58,7 @@ internal class TimelineTest : InstrumentedTest {
 
     private fun createTimeline(initialEventId: String? = null): Timeline {
         val taskExecutor = TaskExecutor(testCoroutineDispatchers)
-        val erau = EventRelationsAggregationUpdater(Credentials("", "", "", null, null))
-        val tokenChunkEventPersistor = TokenChunkEventPersistor(monarchy, erau)
+        val tokenChunkEventPersistor = TokenChunkEventPersistor(monarchy)
         val paginationTask = FakePaginationTask(tokenChunkEventPersistor)
         val getContextOfEventTask = FakeGetContextOfEventTask(tokenChunkEventPersistor)
         val roomMemberExtractor = SenderRoomMemberExtractor(ROOM_ID)

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/model/EditAggregatedSummary.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/model/EditAggregatedSummary.kt
@@ -21,5 +21,6 @@ data class EditAggregatedSummary(
         val aggregatedContent: Content? = null,
         // The list of the eventIDs used to build the summary (might be out of sync if chunked received from message chunk)
         val sourceEvents: List<String>,
+        val localEchos: List<String>,
         val lastEditTs: Long = 0
 )

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/model/ReactionAggregatedSummary.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/model/ReactionAggregatedSummary.kt
@@ -5,5 +5,6 @@ data class ReactionAggregatedSummary(
         val count: Int,                 // 8
         val addedByMe: Boolean,         // true
         val firstTimestamp: Long,       // unix timestamp
-        val sourceEvents: List<String>
+        val sourceEvents: List<String>,
+        val localEchoEvents: List<String>
 )

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/database/mapper/EventAnnotationsSummaryMapper.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/database/mapper/EventAnnotationsSummaryMapper.kt
@@ -15,13 +15,15 @@ internal object EventAnnotationsSummaryMapper {
                             it.count,
                             it.addedByMe,
                             it.firstTimestamp,
-                            it.sourceEvents.toList()
+                            it.sourceEvents.toList(),
+                            it.sourceLocalEcho.toList()
                     )
                 },
                 editSummary = annotationsSummary.editSummary?.let {
                     EditAggregatedSummary(
                             ContentMapper.map(it.aggregatedContent),
                             it.sourceEvents.toList(),
+                            it.sourceLocalEchoEvents.toList(),
                             it.lastEditTs
                     )
                 }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/database/model/EditAggregatedSummaryEntity.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/database/model/EditAggregatedSummaryEntity.kt
@@ -25,6 +25,7 @@ internal open class EditAggregatedSummaryEntity(
         var aggregatedContent: String? = null,
         // The list of the eventIDs used to build the summary (might be out of sync if chunked received from message chunk)
         var sourceEvents: RealmList<String> = RealmList(),
+        var sourceLocalEchoEvents: RealmList<String> = RealmList(),
         var lastEditTs: Long = 0
 ) : RealmObject() {
 

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/database/model/ReactionAggregatedSummaryEntity.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/database/model/ReactionAggregatedSummaryEntity.kt
@@ -16,7 +16,9 @@ internal open class ReactionAggregatedSummaryEntity(
         // The first time this reaction was added (for ordering purpose)
         var firstTimestamp: Long = 0,
         // The list of the eventIDs used to build the summary (might be out of sync if chunked received from message chunk)
-        var sourceEvents: RealmList<String> = RealmList()
+        var sourceEvents: RealmList<String> = RealmList(),
+        // List of transaction ids for local echos
+        var sourceLocalEcho: RealmList<String> = RealmList()
 ) : RealmObject() {
 
     companion object

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/database/query/EventEntityQueries.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/database/query/EventEntityQueries.kt
@@ -16,7 +16,6 @@
 
 package im.vector.matrix.android.internal.database.query
 
-import im.vector.matrix.android.api.session.room.send.SendState
 import im.vector.matrix.android.internal.database.model.ChunkEntity
 import im.vector.matrix.android.internal.database.model.EventEntity
 import im.vector.matrix.android.internal.database.model.EventEntity.LinkFilterMode.*
@@ -43,34 +42,11 @@ internal fun EventEntity.Companion.where(realm: Realm,
         query.equalTo(EventEntityFields.TYPE, type)
     }
     return when (linkFilterMode) {
-        LINKED_ONLY -> query.equalTo(EventEntityFields.IS_UNLINKED, false)
+        LINKED_ONLY   -> query.equalTo(EventEntityFields.IS_UNLINKED, false)
         UNLINKED_ONLY -> query.equalTo(EventEntityFields.IS_UNLINKED, true)
-        BOTH -> query
+        BOTH          -> query
     }
 }
-
-//internal fun EventEntity.Companion.unsent(realm: Realm,
-//                                          roomId: String? = null): RealmQuery<EventEntity> {
-//    val query = realm.where<EventEntity>()
-//    if (roomId != null) {
-//        query.equalTo(EventEntityFields.ROOM_ID, roomId)
-//    }
-//    query.equalTo(EventEntityFields.SEND_STATE_STR, SendState.UNSENT.name)
-//    return query
-//}
-//
-//internal fun EventEntity.Companion.byTypes(realm: Realm,
-//                                           types: List<String>): RealmQuery<EventEntity> {
-//    val query = realm.where<EventEntity>()
-//    types.forEachIndexed { index, type ->
-//        if (index == 0) {
-//            query.equalTo(EventEntityFields.TYPE, type)
-//        } else {
-//            query.or().equalTo(EventEntityFields.TYPE, type)
-//        }
-//    }
-//    return query
-//}
 
 
 internal fun EventEntity.Companion.latestEvent(realm: Realm,

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/database/query/EventEntityQueries.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/database/query/EventEntityQueries.kt
@@ -16,6 +16,7 @@
 
 package im.vector.matrix.android.internal.database.query
 
+import im.vector.matrix.android.api.session.room.send.SendState
 import im.vector.matrix.android.internal.database.model.ChunkEntity
 import im.vector.matrix.android.internal.database.model.EventEntity
 import im.vector.matrix.android.internal.database.model.EventEntity.LinkFilterMode.*
@@ -42,11 +43,35 @@ internal fun EventEntity.Companion.where(realm: Realm,
         query.equalTo(EventEntityFields.TYPE, type)
     }
     return when (linkFilterMode) {
-        LINKED_ONLY   -> query.equalTo(EventEntityFields.IS_UNLINKED, false)
+        LINKED_ONLY -> query.equalTo(EventEntityFields.IS_UNLINKED, false)
         UNLINKED_ONLY -> query.equalTo(EventEntityFields.IS_UNLINKED, true)
-        BOTH          -> query
+        BOTH -> query
     }
 }
+
+//internal fun EventEntity.Companion.unsent(realm: Realm,
+//                                          roomId: String? = null): RealmQuery<EventEntity> {
+//    val query = realm.where<EventEntity>()
+//    if (roomId != null) {
+//        query.equalTo(EventEntityFields.ROOM_ID, roomId)
+//    }
+//    query.equalTo(EventEntityFields.SEND_STATE_STR, SendState.UNSENT.name)
+//    return query
+//}
+//
+//internal fun EventEntity.Companion.byTypes(realm: Realm,
+//                                           types: List<String>): RealmQuery<EventEntity> {
+//    val query = realm.where<EventEntity>()
+//    types.forEachIndexed { index, type ->
+//        if (index == 0) {
+//            query.equalTo(EventEntityFields.TYPE, type)
+//        } else {
+//            query.or().equalTo(EventEntityFields.TYPE, type)
+//        }
+//    }
+//    return query
+//}
+
 
 internal fun EventEntity.Companion.latestEvent(realm: Realm,
                                                roomId: String,

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/SessionModule.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/SessionModule.kt
@@ -106,10 +106,6 @@ internal class SessionModule(private val sessionParams: SessionParams) {
         }
 
         scope(DefaultSession.SCOPE) {
-            EventRelationsAggregationUpdater(get())
-        }
-
-        scope(DefaultSession.SCOPE) {
             DefaultRoomService(get(), get(), get(), get()) as RoomService
         }
 
@@ -168,9 +164,11 @@ internal class SessionModule(private val sessionParams: SessionParams) {
 
         scope(DefaultSession.SCOPE) {
             val groupSummaryUpdater = GroupSummaryUpdater(get())
-            val eventsPruner = EventsPruner(get(), get(), get(), get())
             val userEntityUpdater = UserEntityUpdater(get(), get(), get())
-            listOf<LiveEntityObserver>(groupSummaryUpdater, eventsPruner, userEntityUpdater)
+            val aggregationUpdater = EventRelationsAggregationUpdater(get(), get(), get(), get())
+            //Event pruner must be the last one, because it will clear contents
+            val eventsPruner = EventsPruner(get(), get(), get(), get())
+            listOf<LiveEntityObserver>(groupSummaryUpdater, userEntityUpdater, aggregationUpdater, eventsPruner)
         }
 
 

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/EventRelationsAggregationTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/EventRelationsAggregationTask.kt
@@ -1,0 +1,309 @@
+/*
+ * Copyright 2019 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package im.vector.matrix.android.internal.session.room
+
+import arrow.core.Try
+import com.zhuinden.monarchy.Monarchy
+import im.vector.matrix.android.api.session.events.model.*
+import im.vector.matrix.android.api.session.room.model.message.MessageContent
+import im.vector.matrix.android.api.session.room.model.relation.ReactionContent
+import im.vector.matrix.android.api.session.room.send.SendState
+import im.vector.matrix.android.internal.database.mapper.ContentMapper
+import im.vector.matrix.android.internal.database.mapper.EventMapper
+import im.vector.matrix.android.internal.database.model.*
+import im.vector.matrix.android.internal.database.query.create
+import im.vector.matrix.android.internal.database.query.where
+import im.vector.matrix.android.internal.task.Task
+import im.vector.matrix.android.internal.util.tryTransactionAsync
+import io.realm.Realm
+import timber.log.Timber
+
+internal interface EventRelationsAggregationTask : Task<EventRelationsAggregationTask.Params, Unit> {
+
+    data class Params(
+            val events: List<Pair<Event, SendState>>,
+            val userId: String
+    )
+}
+
+/**
+ * Called by EventRelationAggregationUpdater, when new events that can affect relations are inserted in base.
+ */
+internal class DefaultEventRelationsAggregationTask(private val monarchy: Monarchy) : EventRelationsAggregationTask {
+
+    override fun execute(params: EventRelationsAggregationTask.Params): Try<Unit> {
+        return monarchy.tryTransactionAsync { realm ->
+            update(realm, params.events, params.userId)
+        }
+    }
+
+    fun update(realm: Realm, events: List<Pair<Event, SendState>>?, userId: String) {
+        events?.forEach { pair ->
+            val roomId = pair.first.roomId ?: return@forEach
+            val event = pair.first
+            val sendState = pair.second
+            val isLocalEcho = sendState == SendState.UNSENT
+            when (event.type) {
+                EventType.REACTION -> {
+                    //we got a reaction!!
+                    Timber.v("###REACTION in room $roomId")
+                    handleReaction(event, roomId, realm, userId, isLocalEcho)
+                }
+                EventType.MESSAGE -> {
+                    if (event.unsignedData?.relations?.annotations != null) {
+                        Timber.v("###REACTION Agreggation in room $roomId for event ${event.eventId}")
+                        handleInitialAggregatedRelations(event, roomId, event.unsignedData.relations.annotations, realm)
+                    } else {
+                        val content: MessageContent? = event.content.toModel()
+                        if (content?.relatesTo?.type == RelationType.REPLACE) {
+                            Timber.v("###REPLACE in room $roomId for event ${event.eventId}")
+                            //A replace!
+                            handleReplace(realm, event, content, roomId, isLocalEcho)
+                        }
+                    }
+
+                }
+                EventType.REDACTION -> {
+                    val eventToPrune = event.redacts?.let { EventEntity.where(realm, eventId = it).findFirst() }
+                            ?: return
+                    when (eventToPrune.type) {
+                        EventType.MESSAGE -> {
+                            Timber.d("REDACTION for message ${eventToPrune.eventId}")
+                            val unsignedData = EventMapper.map(eventToPrune).unsignedData
+                                    ?: UnsignedData(null, null)
+
+                            //was this event a m.replace
+                            val contentModel = ContentMapper.map(eventToPrune.content)?.toModel<MessageContent>()
+                            if (RelationType.REPLACE == contentModel?.relatesTo?.type && contentModel.relatesTo?.eventId != null) {
+                                handleRedactionOfReplace(eventToPrune, contentModel.relatesTo!!.eventId!!, realm)
+                            }
+
+                        }
+                        EventType.REACTION -> {
+                            handleReactionRedact(eventToPrune, realm, userId)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private fun handleReplace(realm: Realm, event: Event, content: MessageContent, roomId: String, isLocalEcho: Boolean) {
+        val eventId = event.eventId ?: return
+        val targetEventId = content.relatesTo?.eventId ?: return
+        val newContent = content.newContent ?: return
+        //ok, this is a replace
+        var existing = EventAnnotationsSummaryEntity.where(realm, targetEventId).findFirst()
+        if (existing == null) {
+            Timber.v("###REPLACE creating no relation summary for ${targetEventId}")
+            existing = EventAnnotationsSummaryEntity.create(realm, targetEventId)
+            existing.roomId = roomId
+        }
+
+        //we have it
+        val existingSummary = existing.editSummary
+        if (existingSummary == null) {
+            Timber.v("###REPLACE no edit summary for ${targetEventId}, creating one (localEcho:$isLocalEcho)")
+            //create the edit summary
+            val editSummary = realm.createObject(EditAggregatedSummaryEntity::class.java)
+            editSummary.lastEditTs = event.originServerTs ?: System.currentTimeMillis()
+            editSummary.aggregatedContent = ContentMapper.map(newContent)
+            if (isLocalEcho) {
+                editSummary.sourceLocalEchoEvents.add(eventId)
+            } else {
+                editSummary.sourceEvents.add(eventId)
+            }
+
+            existing.editSummary = editSummary
+        } else {
+            if (existingSummary.sourceEvents.contains(eventId)) {
+                //ignore this event, we already know it (??)
+                Timber.v("###REPLACE ignoring event for summary, it's known ${eventId}")
+                return
+            }
+            val txId = event.unsignedData?.transactionId
+            //is it a remote echo?
+            if (!isLocalEcho && existingSummary.sourceLocalEchoEvents.contains(txId)) {
+                //ok it has already been managed
+                Timber.v("###REPLACE Receiving remote echo of edit (edit already done)")
+                existingSummary.sourceLocalEchoEvents.remove(txId)
+                existingSummary.sourceEvents.add(event.eventId)
+            } else if (event.originServerTs ?: 0 > existingSummary.lastEditTs) {
+                Timber.v("###REPLACE Computing aggregated edit summary (isLocalEcho:$isLocalEcho)")
+                existingSummary.lastEditTs = event.originServerTs ?: System.currentTimeMillis()
+                existingSummary.aggregatedContent = ContentMapper.map(newContent)
+                existingSummary.sourceEvents.add(eventId)
+            } else {
+                //ignore this event for the summary
+                Timber.v("###REPLACE ignoring event for summary, it's to old ${eventId}")
+            }
+        }
+
+    }
+
+    private fun handleInitialAggregatedRelations(event: Event, roomId: String, aggregation: AggregatedAnnotation, realm: Realm) {
+        aggregation.chunk?.forEach {
+            if (it.type == EventType.REACTION) {
+                val eventId = event.eventId ?: ""
+                val existing = EventAnnotationsSummaryEntity.where(realm, eventId).findFirst()
+                if (existing == null) {
+                    val eventSummary = EventAnnotationsSummaryEntity.create(realm, eventId)
+                    eventSummary.roomId = roomId
+                    val sum = realm.createObject(ReactionAggregatedSummaryEntity::class.java)
+                    sum.key = it.key
+                    sum.firstTimestamp = event.originServerTs ?: 0 //TODO how to maintain order?
+                    sum.count = it.count
+                    eventSummary.reactionsSummary.add(sum)
+                } else {
+                    //TODO how to handle that
+                }
+            }
+        }
+    }
+
+    fun handleReaction(event: Event, roomId: String, realm: Realm, userId: String, isLocalEcho: Boolean) {
+        event.content.toModel<ReactionContent>()?.let { content ->
+            //rel_type must be m.annotation
+            if (RelationType.ANNOTATION == content.relatesTo?.type) {
+                val reaction = content.relatesTo.key
+                val eventId = content.relatesTo.eventId
+                val eventSummary = EventAnnotationsSummaryEntity.where(realm, eventId).findFirst()
+                        ?: EventAnnotationsSummaryEntity.create(realm, eventId).apply { this.roomId = roomId }
+
+                var sum = eventSummary.reactionsSummary.find { it.key == reaction }
+                val txId = event.unsignedData?.transactionId
+                if (isLocalEcho && txId.isNullOrBlank()) {
+                    Timber.w("Received a local echo with no transaction ID")
+                }
+                if (sum == null) {
+                    sum = realm.createObject(ReactionAggregatedSummaryEntity::class.java)
+                    sum.key = reaction
+                    sum.firstTimestamp = event.originServerTs ?: 0
+                    if (isLocalEcho) {
+                        Timber.v("Adding local echo reaction $reaction")
+                        sum.sourceLocalEcho.add(txId)
+                        sum.count = 1
+                    } else {
+                        Timber.v("Adding synced reaction $reaction")
+                        sum.count = 1
+                        sum.sourceEvents.add(event.eventId)
+                    }
+                    sum.addedByMe = sum.addedByMe || (userId == event.sender)
+                    eventSummary.reactionsSummary.add(sum)
+                } else {
+                    //is this a known event (is possible? pagination?)
+                    if (!sum.sourceEvents.contains(eventId)) {
+
+                        //check if it's not the sync of a local echo
+                        if (!isLocalEcho && sum.sourceLocalEcho.contains(txId)) {
+                            //ok it has already been counted, just sync the list, do not touch count
+                            Timber.v("Ignoring synced of local echo for reaction $reaction")
+                            sum.sourceLocalEcho.remove(txId)
+                            sum.sourceEvents.add(event.eventId)
+                        } else {
+                            sum.count += 1
+                            if (isLocalEcho) {
+                                Timber.v("Adding local echo reaction $reaction")
+                                sum.sourceLocalEcho.add(txId)
+                            } else {
+                                Timber.v("Adding synced reaction $reaction")
+                                sum.sourceEvents.add(event.eventId)
+                            }
+
+                            sum.addedByMe = sum.addedByMe || (userId == event.sender)
+                        }
+
+                    }
+                }
+
+            }
+        }
+    }
+
+    /**
+     * Called when an event is deleted
+     */
+    fun handleRedactionOfReplace(redacted: EventEntity, relatedEventId: String, realm: Realm) {
+        Timber.d("Handle redaction of m.replace")
+        val eventSummary = EventAnnotationsSummaryEntity.where(realm, relatedEventId).findFirst()
+        if (eventSummary == null) {
+            Timber.w("Redaction of a replace targeting an unknown event $relatedEventId")
+            return
+        }
+        val sourceEvents = eventSummary.editSummary?.sourceEvents
+        val sourceToDiscard = sourceEvents?.indexOf(redacted.eventId)
+        if (sourceToDiscard == null) {
+            Timber.w("Redaction of a replace that was not known in aggregation $sourceToDiscard")
+            return
+        }
+        //Need to remove this event from the redaction list and compute new aggregation state
+        sourceEvents.removeAt(sourceToDiscard)
+        val previousEdit = sourceEvents.mapNotNull { EventEntity.where(realm, it).findFirst() }.sortedBy { it.originServerTs }.lastOrNull()
+        if (previousEdit == null) {
+            //revert to original
+            eventSummary.editSummary?.deleteFromRealm()
+        } else {
+            //I have the last event
+            ContentMapper.map(previousEdit.content)?.toModel<MessageContent>()?.newContent?.let { newContent ->
+                eventSummary.editSummary?.lastEditTs = previousEdit.originServerTs
+                        ?: System.currentTimeMillis()
+                eventSummary.editSummary?.aggregatedContent = ContentMapper.map(newContent)
+            } ?: run {
+                Timber.e("Failed to udate edited summary")
+                //TODO how to reccover that
+            }
+
+        }
+    }
+
+    fun handleReactionRedact(eventToPrune: EventEntity, realm: Realm, userId: String) {
+        Timber.d("REDACTION of reaction ${eventToPrune.eventId}")
+        //delete a reaction, need to update the annotation summary if any
+        val reactionContent: ReactionContent = EventMapper.map(eventToPrune).content.toModel()
+                ?: return
+        val eventThatWasReacted = reactionContent.relatesTo?.eventId ?: return
+
+        val reactionkey = reactionContent.relatesTo.key
+        Timber.d("REMOVE reaction for key $reactionkey")
+        val summary = EventAnnotationsSummaryEntity.where(realm, eventThatWasReacted).findFirst()
+        if (summary != null) {
+            summary.reactionsSummary.where()
+                    .equalTo(ReactionAggregatedSummaryEntityFields.KEY, reactionkey)
+                    .findFirst()?.let { summary ->
+                        Timber.d("Find summary for key with  ${summary.sourceEvents.size} known reactions (count:${summary.count})")
+                        Timber.d("Known reactions  ${summary.sourceEvents.joinToString(",")}")
+                        if (summary.sourceEvents.contains(eventToPrune.eventId)) {
+                            Timber.d("REMOVE reaction for key $reactionkey")
+                            summary.sourceEvents.remove(eventToPrune.eventId)
+                            Timber.d("Known reactions after  ${summary.sourceEvents.joinToString(",")}")
+                            summary.count = summary.count - 1
+                            if (eventToPrune.sender == userId) {
+                                //Was it a redact on my reaction?
+                                summary.addedByMe = false
+                            }
+                            if (summary.count == 0) {
+                                //delete!
+                                summary.deleteFromRealm()
+                            }
+                        } else {
+                            Timber.e("## Cannot remove summary from count, corresponding reaction ${eventToPrune.eventId} is not known")
+                        }
+                    }
+        } else {
+            Timber.e("## Cannot find summary for key $reactionkey")
+        }
+    }
+}

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/EventRelationsAggregationUpdater.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/EventRelationsAggregationUpdater.kt
@@ -15,16 +15,14 @@
  */
 package im.vector.matrix.android.internal.session.room
 
+import com.zhuinden.monarchy.Monarchy
 import im.vector.matrix.android.api.auth.data.Credentials
-import im.vector.matrix.android.api.session.events.model.*
-import im.vector.matrix.android.api.session.room.model.relation.ReactionContent
-import im.vector.matrix.android.api.session.room.model.message.MessageContent
-import im.vector.matrix.android.internal.database.mapper.ContentMapper
-import im.vector.matrix.android.internal.database.mapper.EventMapper
-import im.vector.matrix.android.internal.database.model.*
-import im.vector.matrix.android.internal.database.query.create
+import im.vector.matrix.android.internal.database.RealmLiveEntityObserver
+import im.vector.matrix.android.internal.database.mapper.asDomain
+import im.vector.matrix.android.internal.database.model.EventEntity
 import im.vector.matrix.android.internal.database.query.where
-import io.realm.Realm
+import im.vector.matrix.android.internal.task.TaskExecutor
+import im.vector.matrix.android.internal.task.configureWith
 import timber.log.Timber
 
 /**
@@ -32,198 +30,34 @@ import timber.log.Timber
  * For reactions will build a EventAnnotationsSummaryEntity, ans for edits a EditAggregatedSummaryEntity.
  * The summaries can then be extracted and added (as a decoration) to a TimelineEvent for final display.
  */
-internal class EventRelationsAggregationUpdater(private val credentials: Credentials) {
+internal class EventRelationsAggregationUpdater(monarchy: Monarchy,
+                                                private val credentials: Credentials,
+                                                private val task: EventRelationsAggregationTask,
+                                                private val taskExecutor: TaskExecutor) :
+        RealmLiveEntityObserver<EventEntity>(monarchy) {
 
-    fun update(realm: Realm, roomId: String, events: List<Event>?) {
-        events?.forEach { event ->
-            when (event.type) {
-                EventType.REACTION -> {
-                    //we got a reaction!!
-                    Timber.v("###REACTION in room $roomId")
-                    handleReaction(event, roomId, realm)
-                }
-                EventType.MESSAGE -> {
-                    if (event.unsignedData?.relations?.annotations != null) {
-                        Timber.v("###REACTION Agreggation in room $roomId for event ${event.eventId}")
-                        handleInitialAggregatedRelations(event, roomId, event.unsignedData.relations.annotations, realm)
-                    } else {
-                        val content: MessageContent? = event.content.toModel()
-                        if (content?.relatesTo?.type == RelationType.REPLACE) {
-                            Timber.v("###REPLACE in room $roomId for event ${event.eventId}")
-                            //A replace!
-                            handleReplace(event, content, roomId, realm)
-                        }
-                    }
-                }
-            }
-        }
+    override val query = Monarchy.Query<EventEntity> {
+        EventEntity.where(it)
+        //mmm why is this query not working?
+//        EventEntity.byTypes(it, listOf(
+//                EventType.REDACTION, EventType.MESSAGE, EventType.REDACTION)
+//        )
     }
 
-    private fun handleReplace(event: Event, content: MessageContent, roomId: String, realm: Realm) {
-        val eventId = event.eventId ?: return
-        val targetEventId = content.relatesTo?.eventId ?: return
-        val newContent = content.newContent ?: return
-        //ok, this is a replace
-        var existing = EventAnnotationsSummaryEntity.where(realm, targetEventId).findFirst()
-        if (existing == null) {
-            Timber.v("###REPLACE creating no relation summary for ${targetEventId}")
-            existing = EventAnnotationsSummaryEntity.create(realm, targetEventId)
-            existing.roomId = roomId
-        }
+    override fun processChanges(inserted: List<EventEntity>, updated: List<EventEntity>, deleted: List<EventEntity>) {
+        Timber.v("EventRelationsAggregationUpdater called with ${inserted.size} insertions")
+        val inserted = inserted
+                .mapNotNull { it.asDomain() to it.sendState }
 
-        //we have it
-        val existingSummary = existing.editSummary
-        if (existingSummary == null) {
-            Timber.v("###REPLACE no edit summary for ${targetEventId}, creating one")
-            //create the edit summary
-            val editSummary = realm.createObject(EditAggregatedSummaryEntity::class.java)
-            editSummary.lastEditTs = event.originServerTs ?: System.currentTimeMillis()
-            editSummary.aggregatedContent = ContentMapper.map(newContent)
-            editSummary.sourceEvents.add(eventId)
+        val params = EventRelationsAggregationTask.Params(
+                inserted,
+                credentials.userId
+        )
 
-            existing.editSummary = editSummary
-        } else {
-            if (existingSummary.sourceEvents.contains(eventId)) {
-                //ignore this event, we already know it (??)
-                Timber.v("###REPLACE ignoring event for summary, it's known ${eventId}")
-                return
-            }
-            //This message has already been edited
-            if (event.originServerTs ?: 0 > existingSummary.lastEditTs ?: 0) {
-                Timber.v("###REPLACE Computing aggregated edit summary")
-                existingSummary.lastEditTs = event.originServerTs ?: System.currentTimeMillis()
-                existingSummary.aggregatedContent = ContentMapper.map(newContent)
-                existingSummary.sourceEvents.add(eventId)
-            } else {
-                //ignore this event for the summary
-                Timber.v("###REPLACE ignoring event for summary, it's to old ${eventId}")
-            }
-        }
+        task.configureWith(params)
+                .executeBy(taskExecutor)
 
     }
 
-    private fun handleInitialAggregatedRelations(event: Event, roomId: String, aggregation: AggregatedAnnotation, realm: Realm) {
-        aggregation.chunk?.forEach {
-            if (it.type == EventType.REACTION) {
-                val eventId = event.eventId ?: ""
-                val existing = EventAnnotationsSummaryEntity.where(realm, eventId).findFirst()
-                if (existing == null) {
-                    val eventSummary = EventAnnotationsSummaryEntity.create(realm, eventId)
-                    eventSummary.roomId = roomId
-                    val sum = realm.createObject(ReactionAggregatedSummaryEntity::class.java)
-                    sum.key = it.key
-                    sum.firstTimestamp = event.originServerTs ?: 0 //TODO how to maintain order?
-                    sum.count = it.count
-                    eventSummary.reactionsSummary.add(sum)
-                } else {
-                    //TODO how to handle that
-                }
-            }
-        }
-    }
-
-    fun handleReaction(event: Event, roomId: String, realm: Realm) {
-        event.content.toModel<ReactionContent>()?.let { content ->
-            //rel_type must be m.annotation
-            if (RelationType.ANNOTATION == content.relatesTo?.type) {
-                val reaction = content.relatesTo.key
-                val eventId = content.relatesTo.eventId
-                val eventSummary = EventAnnotationsSummaryEntity.where(realm, eventId).findFirst()
-                        ?: EventAnnotationsSummaryEntity.create(realm, eventId).apply { this.roomId = roomId }
-
-                var sum = eventSummary.reactionsSummary.find { it.key == reaction }
-                if (sum == null) {
-                    sum = realm.createObject(ReactionAggregatedSummaryEntity::class.java)
-                    sum.key = reaction
-                    sum.firstTimestamp = event.originServerTs ?: 0
-                    sum.count = 1
-                    sum.sourceEvents.add(event.eventId)
-                    sum.addedByMe = sum.addedByMe || (credentials.userId == event.sender)
-                    eventSummary.reactionsSummary.add(sum)
-                } else {
-                    //is this a known event (is possible? pagination?)
-                    if (!sum.sourceEvents.contains(eventId)) {
-                        sum.count += 1
-                        sum.sourceEvents.add(event.eventId)
-                        sum.addedByMe = sum.addedByMe || (credentials.userId == event.sender)
-                    }
-                }
-
-            }
-        }
-    }
-
-    /**
-     * Called when an event is deleted
-     */
-    fun handleRedactionOfReplace(redacted: EventEntity, relatedEventId: String, realm: Realm) {
-        Timber.d("Handle redaction of m.replace")
-        val eventSummary = EventAnnotationsSummaryEntity.where(realm, relatedEventId).findFirst()
-        if (eventSummary == null) {
-            Timber.w("Redaction of a replace targeting an unknown event $relatedEventId")
-            return
-        }
-        val sourceEvents = eventSummary.editSummary?.sourceEvents
-        val sourceToDiscard = sourceEvents?.indexOf(redacted.eventId)
-        if (sourceToDiscard == null) {
-            Timber.w("Redaction of a replace that was not known in aggregation $sourceToDiscard")
-            return
-        }
-        //Need to remove this event from the redaction list and compute new aggregation state
-        sourceEvents.removeAt(sourceToDiscard)
-        val previousEdit = sourceEvents.mapNotNull { EventEntity.where(realm, it).findFirst() }.sortedBy { it.originServerTs }.lastOrNull()
-        if (previousEdit == null) {
-            //revert to original
-            eventSummary.editSummary?.deleteFromRealm()
-        } else {
-            //I have the last event
-            ContentMapper.map(previousEdit.content)?.toModel<MessageContent>()?.newContent?.let { newContent ->
-                eventSummary.editSummary?.lastEditTs = previousEdit.originServerTs
-                        ?: System.currentTimeMillis()
-                eventSummary.editSummary?.aggregatedContent = ContentMapper.map(newContent)
-            } ?: run {
-                Timber.e("Failed to udate edited summary")
-                //TODO how to reccover that
-            }
-
-        }
-    }
-
-    fun handleReactionRedact(eventToPrune: EventEntity, realm: Realm, userId: String) {
-        Timber.d("REDACTION of reaction ${eventToPrune.eventId}")
-        //delete a reaction, need to update the annotation summary if any
-        val reactionContent: ReactionContent = EventMapper.map(eventToPrune).content.toModel()
-                ?: return
-        val eventThatWasReacted = reactionContent.relatesTo?.eventId ?: return
-
-        val reactionkey = reactionContent.relatesTo.key
-        Timber.d("REMOVE reaction for key $reactionkey")
-        val summary = EventAnnotationsSummaryEntity.where(realm, eventThatWasReacted).findFirst()
-        if (summary != null) {
-            summary.reactionsSummary.where()
-                    .equalTo(ReactionAggregatedSummaryEntityFields.KEY, reactionkey)
-                    .findFirst()?.let { summary ->
-                        Timber.d("Find summary for key with  ${summary.sourceEvents.size} known reactions (count:${summary.count})")
-                        Timber.d("Known reactions  ${summary.sourceEvents.joinToString(",")}")
-                        if (summary.sourceEvents.contains(eventToPrune.eventId)) {
-                            Timber.d("REMOVE reaction for key $reactionkey")
-                            summary.sourceEvents.remove(eventToPrune.eventId)
-                            Timber.d("Known reactions after  ${summary.sourceEvents.joinToString(",")}")
-                            summary.count = summary.count - 1
-                            if (eventToPrune.sender == userId) {
-                                //Was it a redact on my reaction?
-                                summary.addedByMe = false
-                            }
-                            if (summary.count == 0) {
-                                //delete!
-                                summary.deleteFromRealm()
-                            }
-                        } else {
-                            Timber.e("## Cannot remove summary from count, corresponding reaction ${eventToPrune.eventId} is not known")
-                        }
-                    }
-        } else {
-            Timber.e("## Cannot find summary for key $reactionkey")
-        }
-    }
 }
+

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/RoomModule.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/RoomModule.kt
@@ -17,10 +17,6 @@
 package im.vector.matrix.android.internal.session.room
 
 import im.vector.matrix.android.internal.session.DefaultSession
-import im.vector.matrix.android.internal.session.room.relation.DefaultFindReactionEventForUndoTask
-import im.vector.matrix.android.internal.session.room.relation.DefaultUpdateQuickReactionTask
-import im.vector.matrix.android.internal.session.room.relation.FindReactionEventForUndoTask
-import im.vector.matrix.android.internal.session.room.relation.UpdateQuickReactionTask
 import im.vector.matrix.android.internal.session.room.create.CreateRoomTask
 import im.vector.matrix.android.internal.session.room.create.DefaultCreateRoomTask
 import im.vector.matrix.android.internal.session.room.membership.DefaultLoadRoomMembersTask
@@ -35,6 +31,10 @@ import im.vector.matrix.android.internal.session.room.prune.DefaultPruneEventTas
 import im.vector.matrix.android.internal.session.room.prune.PruneEventTask
 import im.vector.matrix.android.internal.session.room.read.DefaultSetReadMarkersTask
 import im.vector.matrix.android.internal.session.room.read.SetReadMarkersTask
+import im.vector.matrix.android.internal.session.room.relation.DefaultFindReactionEventForUndoTask
+import im.vector.matrix.android.internal.session.room.relation.DefaultUpdateQuickReactionTask
+import im.vector.matrix.android.internal.session.room.relation.FindReactionEventForUndoTask
+import im.vector.matrix.android.internal.session.room.relation.UpdateQuickReactionTask
 import im.vector.matrix.android.internal.session.room.send.LocalEchoEventFactory
 import im.vector.matrix.android.internal.session.room.state.DefaultSendStateTask
 import im.vector.matrix.android.internal.session.room.state.SendStateTask
@@ -57,7 +57,7 @@ class RoomModule {
         }
 
         scope(DefaultSession.SCOPE) {
-            TokenChunkEventPersistor(get(), get())
+            TokenChunkEventPersistor(get())
         }
 
         scope(DefaultSession.SCOPE) {
@@ -109,7 +109,11 @@ class RoomModule {
         }
 
         scope(DefaultSession.SCOPE) {
-            DefaultPruneEventTask(get(), get()) as PruneEventTask
+            DefaultPruneEventTask(get()) as PruneEventTask
+        }
+
+        scope(DefaultSession.SCOPE) {
+            DefaultEventRelationsAggregationTask(get()) as EventRelationsAggregationTask
         }
 
     }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/prune/EventsPruner.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/prune/EventsPruner.kt
@@ -25,8 +25,12 @@ import im.vector.matrix.android.internal.database.model.EventEntity
 import im.vector.matrix.android.internal.database.query.where
 import im.vector.matrix.android.internal.task.TaskExecutor
 import im.vector.matrix.android.internal.task.configureWith
+import timber.log.Timber
 
-
+/**
+ * Listens to the database for the insertion of any redaction event.
+ * As it will actually delete the content, it should be called last in the list of listener.
+ */
 internal class EventsPruner(monarchy: Monarchy,
                             private val credentials: Credentials,
                             private val pruneEventTask: PruneEventTask,
@@ -36,6 +40,7 @@ internal class EventsPruner(monarchy: Monarchy,
     override val query = Monarchy.Query<EventEntity> { EventEntity.where(it, type = EventType.REDACTION) }
 
     override fun processChanges(inserted: List<EventEntity>, updated: List<EventEntity>, deleted: List<EventEntity>) {
+        Timber.v("Event pruner called with ${inserted.size} insertions")
         val redactionEvents = inserted
                 .mapNotNull { it.asDomain() }
 

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/relation/SendRelationWorker.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/relation/SendRelationWorker.kt
@@ -70,7 +70,11 @@ class SendRelationWorker(context: Context, params: WorkerParameters)
         return result.fold({
             when (it) {
                 is Failure.NetworkConnection -> Result.retry()
-                else -> Result.failure()
+                else -> {
+                    //TODO mark as failed to send?
+                    //always return success, or the chain will be stuck for ever!
+                    Result.success()
+                }
             }
         }, { Result.success() })
     }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/send/LocalEchoEventFactory.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/send/LocalEchoEventFactory.kt
@@ -17,7 +17,6 @@
 package im.vector.matrix.android.internal.session.room.send
 
 import android.media.MediaMetadataRetriever
-import android.text.TextUtils
 import com.zhuinden.monarchy.Monarchy
 import im.vector.matrix.android.R
 import im.vector.matrix.android.api.auth.data.Credentials
@@ -39,6 +38,7 @@ import im.vector.matrix.android.internal.util.StringProvider
 import im.vector.matrix.android.internal.util.tryTransactionAsync
 import org.commonmark.parser.Parser
 import org.commonmark.renderer.html.HtmlRenderer
+import java.util.*
 
 /**
  * Creates local echo of events for room events.
@@ -57,7 +57,7 @@ internal class LocalEchoEventFactory(private val credentials: Credentials, priva
             val document = parser.parse(text)
             val renderer = HtmlRenderer.builder().build()
             val htmlText = renderer.render(document)
-            if (isFormattedTextPertinent(text, htmlText)) { //FIX that
+            if (isFormattedTextPertinent(text, htmlText)) { //FIXME
                 return createFormattedTextEvent(roomId, text, htmlText)
             }
         }
@@ -114,7 +114,7 @@ internal class LocalEchoEventFactory(private val credentials: Credentials, priva
             ContentAttachmentData.Type.IMAGE -> createImageEvent(roomId, attachment)
             ContentAttachmentData.Type.VIDEO -> createVideoEvent(roomId, attachment)
             ContentAttachmentData.Type.AUDIO -> createAudioEvent(roomId, attachment)
-            ContentAttachmentData.Type.FILE -> createFileEvent(roomId, attachment)
+            ContentAttachmentData.Type.FILE  -> createFileEvent(roomId, attachment)
         }
     }
 
@@ -234,7 +234,7 @@ internal class LocalEchoEventFactory(private val credentials: Credentials, priva
     }
 
     private fun dummyEventId(roomId: String): String {
-        return "m.${txNCounter++}"
+        return "m.${UUID.randomUUID()}"
     }
 
     fun createReplyTextEvent(roomId: String, eventReplied: Event, replyText: String): Event? {
@@ -299,11 +299,11 @@ internal class LocalEchoEventFactory(private val credentials: Credentials, priva
                 }
                 return content.body to formattedText
             }
-            MessageType.MSGTYPE_FILE -> return stringProvider.getString(R.string.reply_to_a_file) to null
-            MessageType.MSGTYPE_AUDIO -> return stringProvider.getString(R.string.reply_to_an_audio_file) to null
-            MessageType.MSGTYPE_IMAGE -> return stringProvider.getString(R.string.reply_to_an_image) to null
-            MessageType.MSGTYPE_VIDEO -> return stringProvider.getString(R.string.reply_to_a_video) to null
-            else -> return (content?.body ?: "") to null
+            MessageType.MSGTYPE_FILE   -> return stringProvider.getString(R.string.reply_to_a_file) to null
+            MessageType.MSGTYPE_AUDIO  -> return stringProvider.getString(R.string.reply_to_an_audio_file) to null
+            MessageType.MSGTYPE_IMAGE  -> return stringProvider.getString(R.string.reply_to_an_image) to null
+            MessageType.MSGTYPE_VIDEO  -> return stringProvider.getString(R.string.reply_to_a_video) to null
+            else                       -> return (content?.body ?: "") to null
 
         }
 
@@ -350,7 +350,4 @@ internal class LocalEchoEventFactory(private val credentials: Credentials, priva
         }
     }
 
-    companion object {
-        var txNCounter = System.currentTimeMillis()
-    }
 }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/send/SendEventWorker.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/send/SendEventWorker.kt
@@ -61,7 +61,11 @@ internal class SendEventWorker(context: Context, params: WorkerParameters)
         return result.fold({
             when (it) {
                 is Failure.NetworkConnection -> Result.retry()
-                else -> Result.failure()
+                else -> {
+                    //TODO mark as failed to send?
+                    //always return success, or the chain will be stuck for ever!
+                    Result.success()
+                }
             }
         }, { Result.success() })
     }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/timeline/TimelineSendEventWorkCommon.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/timeline/TimelineSendEventWorkCommon.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package im.vector.matrix.android.internal.session.room.timeline
+
+import androidx.work.*
+import java.util.concurrent.TimeUnit
+
+
+private const val SEND_WORK = "SEND_WORK"
+private const val BACKOFF_DELAY = 10_000L
+
+private val WORK_CONSTRAINTS = Constraints.Builder()
+        .setRequiredNetworkType(NetworkType.CONNECTED)
+        .build()
+
+/**
+ * Helper class for sending event related works.
+ * All send event from a room are using the same workchain, in order to ensure order.
+ * WorkRequest must always return success (even if server error, in this case marking the event as failed to send)
+ * , if not the chain will be doomed in failed state.
+ *
+ */
+internal object TimelineSendEventWorkCommon {
+
+    fun postWork(roomId: String, workRequest: OneTimeWorkRequest) {
+        WorkManager.getInstance()
+                .beginUniqueWork(buildWorkIdentifier(roomId), ExistingWorkPolicy.APPEND, workRequest)
+                .enqueue()
+
+    }
+
+    inline fun <reified W : ListenableWorker> createWork(data: Data): OneTimeWorkRequest {
+        return OneTimeWorkRequestBuilder<W>()
+                .setConstraints(WORK_CONSTRAINTS)
+                .setInputData(data)
+                .setBackoffCriteria(BackoffPolicy.LINEAR, BACKOFF_DELAY, TimeUnit.MILLISECONDS)
+                .build()
+    }
+
+    private fun buildWorkIdentifier(roomId: String): String {
+        return "${roomId}_$SEND_WORK"
+    }
+}

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/sync/SyncModule.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/sync/SyncModule.kt
@@ -40,7 +40,7 @@ internal class SyncModule {
         }
 
         scope(DefaultSession.SCOPE) {
-            RoomSyncHandler(get(), get(), get(), get(), get())
+            RoomSyncHandler(get(), get(), get(), get())
         }
 
         scope(DefaultSession.SCOPE) {

--- a/vector/src/main/java/im/vector/riotredesign/features/home/room/detail/timeline/factory/MessageItemFactory.kt
+++ b/vector/src/main/java/im/vector/riotredesign/features/home/room/detail/timeline/factory/MessageItemFactory.kt
@@ -90,7 +90,9 @@ class MessageItemFactory(private val colorProvider: ColorProvider,
                 avatarUrl = avatarUrl,
                 memberName = formattedMemberName,
                 showInformation = showInformation,
-                orderedReactionList = event.annotations?.reactionsSummary?.map { Triple(it.key, it.count, it.addedByMe) },
+                orderedReactionList = event.annotations?.reactionsSummary?.map {
+                    ReactionInfoData(it.key, it.count, it.addedByMe, it.localEchoEvents.isEmpty())
+                },
                 hasBeenEdited = hasBeenEdited
         )
 

--- a/vector/src/main/java/im/vector/riotredesign/features/home/room/detail/timeline/item/AbsMessageItem.kt
+++ b/vector/src/main/java/im/vector/riotredesign/features/home/room/detail/timeline/item/AbsMessageItem.kt
@@ -112,11 +112,12 @@ abstract class AbsMessageItem<H : AbsMessageItem.Holder> : BaseEventItem<H>() {
                 (holder.reactionWrapper?.children?.elementAtOrNull(index) as? ReactionButton)?.let { reactionButton ->
                     reactionButton.isVisible = true
                     reactionButton.reactedListener = reactionClickListener
-                    reactionButton.setTag(R.id.messageBottomInfo, reaction.first)
+                    reactionButton.setTag(R.id.messageBottomInfo, reaction.key)
                     idToRefInFlow.add(reactionButton.id)
-                    reactionButton.reactionString = reaction.first
-                    reactionButton.reactionCount = reaction.second
-                    reactionButton.setChecked(reaction.third)
+                    reactionButton.reactionString = reaction.key
+                    reactionButton.reactionCount = reaction.count
+                    reactionButton.setChecked(reaction.addedByMe)
+                    reactionButton.isEnabled = reaction.synced
                 }
             }
             // Just setting the view as gone will break the FlowHelper (and invisible will take too much space),

--- a/vector/src/main/java/im/vector/riotredesign/features/home/room/detail/timeline/item/MessageInformationData.kt
+++ b/vector/src/main/java/im/vector/riotredesign/features/home/room/detail/timeline/item/MessageInformationData.kt
@@ -16,9 +16,8 @@
 
 package im.vector.riotredesign.features.home.room.detail.timeline.item
 
-import im.vector.matrix.android.api.session.room.send.SendState
-
 import android.os.Parcelable
+import im.vector.matrix.android.api.session.room.send.SendState
 import kotlinx.android.parcel.Parcelize
 
 @Parcelize
@@ -31,6 +30,15 @@ data class MessageInformationData(
         val memberName: CharSequence? = null,
         val showInformation: Boolean = true,
         /*List of reactions (emoji,count,isSelected)*/
-        var orderedReactionList: List<Triple<String,Int,Boolean>>? = null,
+        var orderedReactionList: List<ReactionInfoData>? = null,
         var hasBeenEdited: Boolean = false
+) : Parcelable
+
+
+@Parcelize
+data class ReactionInfoData(
+        val key: String,
+        val count: Int,
+        val addedByMe: Boolean,
+        val synced: Boolean
 ) : Parcelable


### PR DESCRIPTION
Fixes #149

New reactions are immediately reflected in the UI, the created summary keeps track of 'unsynced' events used to build the summary (updated on reception of remote echo). UX use this information to disable the correct reaction button while not synced.

Same for edits. Edits can be stacked (even in offline mode), they will be sent one by one as soon as network is back.

Redacts are reflected as soon as done thanks to local echo (No detection of local vs remote echo, the remote echo will also prune the event, but it's ok)

+ Refactoring: Aggregation Update is implemented as a live event listener (using DB as SSoT)