### PR TITLE
Only show reactions with an emoji key

### DIFF
--- a/vector/src/main/java/im/vector/riotredesign/VectorApplication.kt
+++ b/vector/src/main/java/im/vector/riotredesign/VectorApplication.kt
@@ -54,6 +54,7 @@ import im.vector.riotredesign.push.fcm.FcmHelper
 import timber.log.Timber
 import java.text.SimpleDateFormat
 import java.util.*
+import im.vector.riotredesign.core.utils.initKnownEmojiHashSet
 import javax.inject.Inject
 
 class VectorApplication : Application(), HasVectorInjector, MatrixConfiguration.Provider, androidx.work.Configuration.Provider {
@@ -124,6 +125,8 @@ class VectorApplication : Application(), HasVectorInjector, MatrixConfiguration.
                 FcmHelper.onEnterBackground(appContext, activeSessionHolder)
             }
         })
+        //This should be done as early as possible
+        initKnownEmojiHashSet(appContext)
     }
 
     override fun providesMatrixConfiguration() = MatrixConfiguration(BuildConfig.FLAVOR_DESCRIPTION)

--- a/vector/src/main/java/im/vector/riotredesign/features/home/room/detail/timeline/action/MessageMenuViewModel.kt
+++ b/vector/src/main/java/im/vector/riotredesign/features/home/room/detail/timeline/action/MessageMenuViewModel.kt
@@ -36,6 +36,9 @@ import im.vector.riotredesign.core.resources.StringProvider
 import im.vector.riotredesign.features.home.room.detail.timeline.item.MessageInformationData
 import org.json.JSONObject
 
+import im.vector.riotredesign.core.utils.isSingleEmoji
+
+
 data class SimpleAction(val uid: String, val titleRes: Int, val iconResId: Int?, val data: Any? = null)
 
 data class MessageMenuState(
@@ -92,7 +95,7 @@ class MessageMenuViewModel @AssistedInject constructor(@Assisted initialState: M
         val event = session.getRoom(state.roomId)?.getTimeLineEvent(state.eventId) ?: return state
 
         val messageContent: MessageContent? = event.annotations?.editSummary?.aggregatedContent?.toModel()
-                                              ?: event.root.content.toModel()
+                ?: event.root.content.toModel()
         val type = messageContent?.type
 
         val actions = if (!event.sendState.isSent()) {
@@ -143,8 +146,8 @@ class MessageMenuViewModel @AssistedInject constructor(@Assisted initialState: M
                     if (messageContent is MessageImageContent) {
                         this.add(
                                 SimpleAction(ACTION_SHARE,
-                                             R.string.share, R.drawable.ic_share,
-                                             session.contentUrlResolver().resolveFullSize(messageContent.url))
+                                        R.string.share, R.drawable.ic_share,
+                                        session.contentUrlResolver().resolveFullSize(messageContent.url))
                         )
                     }
                     //TODO
@@ -212,31 +215,31 @@ class MessageMenuViewModel @AssistedInject constructor(@Assisted initialState: M
         }
     }
 
-        private fun canRedact(event: TimelineEvent, myUserId: String): Boolean {
-            //Only event of type Event.EVENT_TYPE_MESSAGE are supported for the moment
-            if (event.root.getClearType() != EventType.MESSAGE) return false
-            //TODO if user is admin or moderator
-            return event.root.senderId == myUserId
-        }
+    private fun canRedact(event: TimelineEvent, myUserId: String): Boolean {
+        //Only event of type Event.EVENT_TYPE_MESSAGE are supported for the moment
+        if (event.root.getClearType() != EventType.MESSAGE) return false
+        //TODO if user is admin or moderator
+        return event.root.senderId == myUserId
+    }
 
     private fun canViewReactions(event: TimelineEvent): Boolean {
         //Only event of type Event.EVENT_TYPE_MESSAGE are supported for the moment
         if (event.root.getClearType() != EventType.MESSAGE) return false
         //TODO if user is admin or moderator
-        return event.annotations?.reactionsSummary?.isNotEmpty() ?: false
+        return event.annotations?.reactionsSummary?.any { isSingleEmoji(it.key) } ?: false
     }
 
 
-        private fun canEdit(event: TimelineEvent, myUserId: String): Boolean {
-            //Only event of type Event.EVENT_TYPE_MESSAGE are supported for the moment
-            if (event.root.getClearType() != EventType.MESSAGE) return false
-            //TODO if user is admin or moderator
-            val messageContent = event.root.content.toModel<MessageContent>()
-            return event.root.senderId == myUserId && (
-                    messageContent?.type == MessageType.MSGTYPE_TEXT
-                            || messageContent?.type == MessageType.MSGTYPE_EMOTE
-                    )
-        }
+    private fun canEdit(event: TimelineEvent, myUserId: String): Boolean {
+        //Only event of type Event.EVENT_TYPE_MESSAGE are supported for the moment
+        if (event.root.getClearType() != EventType.MESSAGE) return false
+        //TODO if user is admin or moderator
+        val messageContent = event.root.content.toModel<MessageContent>()
+        return event.root.senderId == myUserId && (
+                messageContent?.type == MessageType.MSGTYPE_TEXT
+                        || messageContent?.type == MessageType.MSGTYPE_EMOTE
+                )
+    }
 
 
     private fun canCopy(type: String?): Boolean {

--- a/vector/src/main/java/im/vector/riotredesign/features/home/room/detail/timeline/action/ViewReactionViewModel.kt
+++ b/vector/src/main/java/im/vector/riotredesign/features/home/room/detail/timeline/action/ViewReactionViewModel.kt
@@ -8,6 +8,7 @@ import im.vector.matrix.android.api.session.room.model.ReactionAggregatedSummary
 import im.vector.matrix.rx.RxRoom
 import im.vector.riotredesign.core.extensions.localDateTime
 import im.vector.riotredesign.core.platform.VectorViewModel
+import im.vector.riotredesign.core.utils.isSingleEmoji
 import im.vector.riotredesign.features.home.room.detail.timeline.helper.TimelineDateFormatter
 import io.reactivex.Observable
 import io.reactivex.Single
@@ -69,7 +70,9 @@ class ViewReactionViewModel @AssistedInject constructor(@Assisted
                 .flatMapSingle { summaries ->
                     Observable
                             .fromIterable(summaries)
-                            .flatMapIterable {it.reactionsSummary}
+                            .flatMapIterable { it.reactionsSummary
+                                    .filter { reactionAggregatedSummary ->  isSingleEmoji(reactionAggregatedSummary.key) }
+                                }
                             .toReactionInfoList()
                 }
                 .execute {

--- a/vector/src/main/java/im/vector/riotredesign/features/home/room/detail/timeline/util/MessageInformationDataFactory.kt
+++ b/vector/src/main/java/im/vector/riotredesign/features/home/room/detail/timeline/util/MessageInformationDataFactory.kt
@@ -20,6 +20,7 @@ import im.vector.matrix.android.api.session.events.model.EventType
 import im.vector.matrix.android.api.session.room.timeline.TimelineEvent
 import im.vector.riotredesign.core.extensions.localDateTime
 import im.vector.riotredesign.core.resources.ColorProvider
+import im.vector.riotredesign.core.utils.isSingleEmoji
 import im.vector.riotredesign.features.home.getColorFromUserId
 import im.vector.riotredesign.features.home.room.detail.timeline.helper.TimelineDateFormatter
 import im.vector.riotredesign.features.home.room.detail.timeline.item.MessageInformationData
@@ -68,9 +69,11 @@ class MessageInformationDataFactory @Inject constructor(private val timelineDate
                 avatarUrl = avatarUrl,
                 memberName = formattedMemberName,
                 showInformation = showInformation,
-                orderedReactionList = event.annotations?.reactionsSummary?.map {
-                    ReactionInfoData(it.key, it.count, it.addedByMe, it.localEchoEvents.isEmpty())
-                },
+                orderedReactionList = event.annotations?.reactionsSummary
+                        ?.filter { isSingleEmoji(it.key) }
+                        ?.map {
+                            ReactionInfoData(it.key, it.count, it.addedByMe, it.localEchoEvents.isEmpty())
+                        },
                 hasBeenEdited = hasBeenEdited
         )
     }


### PR DESCRIPTION
Fixes #191 

Existing regex used by riot (from legacy riot android) are incomplete. 
Haven't found some easy way to detect if a string is exactly an emoji.
But as we already have a dictionary of emoji, the json source file of emoji picker, i have been able to use it 

<img width="549" alt="image" src="https://user-images.githubusercontent.com/9841565/60102916-e8cd4f00-975e-11e9-8b07-7c3ae1aa375f.png">
