### PR TITLE
Update timeline on new session

### DIFF
--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/crypto/CryptoService.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/crypto/CryptoService.kt
@@ -25,6 +25,7 @@ import im.vector.matrix.android.api.session.crypto.sas.SasVerificationService
 import im.vector.matrix.android.api.session.events.model.Content
 import im.vector.matrix.android.api.session.events.model.Event
 import im.vector.matrix.android.internal.crypto.MXEventDecryptionResult
+import im.vector.matrix.android.internal.crypto.NewSessionListener
 import im.vector.matrix.android.internal.crypto.model.ImportRoomKeysResult
 import im.vector.matrix.android.internal.crypto.model.MXDeviceInfo
 import im.vector.matrix.android.internal.crypto.model.MXEncryptEventContentResult
@@ -106,5 +107,9 @@ interface CryptoService {
     fun downloadKeys(userIds: List<String>, forceDownload: Boolean, callback: MatrixCallback<MXUsersDevicesMap<MXDeviceInfo>>)
 
     fun clearCryptoCache(callback: MatrixCallback<Unit>)
+
+    fun addNewSessionListener(newSessionListener: NewSessionListener)
+
+    fun removeSessionListener(listener: NewSessionListener)
 
 }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/timeline/TimelineEvent.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/timeline/TimelineEvent.kt
@@ -34,6 +34,7 @@ data class TimelineEvent(
         val isUniqueDisplayName: Boolean,
         val senderAvatar: String?,
         val sendState: SendState,
+        val hasClearEventFlag: Boolean = false,
         val annotations: EventAnnotationsSummary? = null
 ) {
 

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/CryptoManager.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/CryptoManager.kt
@@ -1063,6 +1063,13 @@ internal class CryptoManager @Inject constructor(
                 .executeBy(taskExecutor)
     }
 
+    override fun addNewSessionListener(newSessionListener: NewSessionListener) {
+        roomDecryptorProvider.addNewSessionListener(newSessionListener)
+    }
+
+    override fun removeSessionListener(listener: NewSessionListener) {
+        roomDecryptorProvider.removeSessionListener(listener)
+    }
     /* ==========================================================================================
      * DEBUG INFO
      * ========================================================================================== */

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/NewSessionListener.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/NewSessionListener.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package im.vector.matrix.android.internal.crypto
+
+
+interface NewSessionListener {
+    fun onNewSession(roomId: String?, senderKey: String, sessionId: String)
+}

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/store/IMXCryptoStore.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/store/IMXCryptoStore.kt
@@ -18,6 +18,7 @@
 package im.vector.matrix.android.internal.crypto.store
 
 import im.vector.matrix.android.internal.crypto.IncomingRoomKeyRequest
+import im.vector.matrix.android.internal.crypto.NewSessionListener
 import im.vector.matrix.android.internal.crypto.OutgoingRoomKeyRequest
 import im.vector.matrix.android.internal.crypto.model.MXDeviceInfo
 import im.vector.matrix.android.internal.crypto.model.OlmInboundGroupSessionWrapper
@@ -376,4 +377,8 @@ internal interface IMXCryptoStore {
      * @return an IncomingRoomKeyRequest if it exists, else null
      */
     fun getIncomingRoomKeyRequest(userId: String, deviceId: String, requestId: String): IncomingRoomKeyRequest?
+
+    fun addNewSessionListener(listener: NewSessionListener)
+
+    fun removeSessionListener(listener: NewSessionListener)
 }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/store/db/RealmCryptoStore.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/store/db/RealmCryptoStore.kt
@@ -19,6 +19,7 @@ package im.vector.matrix.android.internal.crypto.store.db
 import android.text.TextUtils
 import im.vector.matrix.android.api.auth.data.Credentials
 import im.vector.matrix.android.internal.crypto.IncomingRoomKeyRequest
+import im.vector.matrix.android.internal.crypto.NewSessionListener
 import im.vector.matrix.android.internal.crypto.OutgoingRoomKeyRequest
 import im.vector.matrix.android.internal.crypto.model.MXDeviceInfo
 import im.vector.matrix.android.internal.crypto.model.OlmInboundGroupSessionWrapper
@@ -56,6 +57,17 @@ internal class RealmCryptoStore(private val enableFileEncryption: Boolean = fals
 
     // Cache for InboundGroupSession, to release them properly
     private val inboundGroupSessionToRelease = HashMap<String, OlmInboundGroupSessionWrapper>()
+
+
+    private val newSessionListeners = ArrayList<NewSessionListener>()
+
+    override fun addNewSessionListener(listener: NewSessionListener) {
+        if (!newSessionListeners.contains(listener)) newSessionListeners.add(listener)
+    }
+
+    override fun removeSessionListener(listener: NewSessionListener) {
+        newSessionListeners.remove(listener)
+    }
 
     /* ==========================================================================================
      * Other data
@@ -718,4 +730,5 @@ internal class RealmCryptoStore(private val enableFileEncryption: Boolean = fals
                 }
                 .toMutableList()
     }
+
 }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/RoomFactory.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/RoomFactory.kt
@@ -64,7 +64,7 @@ internal class RoomFactory @Inject constructor(private val context: Context,
 
     fun create(roomId: String): Room {
         val timelineEventFactory = InMemoryTimelineEventFactory(SenderRoomMemberExtractor(), EventRelationExtractor(), cryptoService)
-        val timelineService = DefaultTimelineService(roomId, monarchy, taskExecutor, timelineEventFactory, contextOfEventTask, paginationTask)
+        val timelineService = DefaultTimelineService(roomId, monarchy, taskExecutor, timelineEventFactory, contextOfEventTask, cryptoService, paginationTask)
         val sendService = DefaultSendService(context, credentials, roomId, eventFactory, cryptoService, monarchy)
         val stateService = DefaultStateService(roomId, taskExecutor, sendStateTask)
         val roomMembersService = DefaultMembershipService(roomId, monarchy, taskExecutor, loadRoomMembersTask, inviteTask, joinRoomTask, leaveRoomTask)

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/timeline/DefaultTimelineService.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/timeline/DefaultTimelineService.kt
@@ -19,6 +19,7 @@ package im.vector.matrix.android.internal.session.room.timeline
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
 import com.zhuinden.monarchy.Monarchy
+import im.vector.matrix.android.api.session.crypto.CryptoService
 import im.vector.matrix.android.api.session.room.timeline.Timeline
 import im.vector.matrix.android.api.session.room.timeline.TimelineEvent
 import im.vector.matrix.android.api.session.room.timeline.TimelineService
@@ -35,11 +36,20 @@ internal class DefaultTimelineService @Inject constructor(private val roomId: St
                                                           private val taskExecutor: TaskExecutor,
                                                           private val timelineEventFactory: CacheableTimelineEventFactory,
                                                           private val contextOfEventTask: GetContextOfEventTask,
+                                                          private val cryptoService: CryptoService,
                                                           private val paginationTask: PaginationTask
 ) : TimelineService {
 
     override fun createTimeline(eventId: String?, allowedTypes: List<String>?): Timeline {
-        return DefaultTimeline(roomId, eventId, monarchy.realmConfiguration, taskExecutor, contextOfEventTask, timelineEventFactory, paginationTask, allowedTypes)
+        return DefaultTimeline(roomId,
+                eventId,
+                monarchy.realmConfiguration,
+                taskExecutor,
+                contextOfEventTask,
+                timelineEventFactory,
+                paginationTask,
+                cryptoService,
+                allowedTypes)
     }
 
     override fun getTimeLineEvent(eventId: String): TimelineEvent? {

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/timeline/TimelineEventFactory.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/timeline/TimelineEventFactory.kt
@@ -69,6 +69,7 @@ internal class SimpleTimelineEventFactory @Inject constructor(private val roomMe
                 isUniqueDisplayName,
                 senderRoomMember?.avatarUrl,
                 eventEntity.sendState,
+                event.mClearEvent != null,
                 relations
         )
     }
@@ -120,6 +121,7 @@ internal class InMemoryTimelineEventFactory @Inject constructor(private val room
                 senderData.isUniqueDisplayName,
                 senderData.senderAvatar,
                 eventEntity.sendState,
+                event.mClearEvent != null,
                 relations
         )
     }
@@ -138,7 +140,7 @@ internal class InMemoryTimelineEventFactory @Inject constructor(private val room
                 }
                 event.setClearData(result)
             } catch (failure: Throwable) {
-                Timber.e(failure, "Encrypted event: decryption failed")
+                Timber.e("Encrypted event: decryption failed ${failure.localizedMessage}")
                 if (failure is MXDecryptionException) {
                     event.setCryptoError(failure.cryptoError)
                 }


### PR DESCRIPTION
Added mechanism to detect when a new key is received in order to refresh current timeline.

How to:
Enter encrypted room on phone, go to other account where a key share popup appears then verify device 
-> Before: you had to exit then enter the room to see devcrypted event
-> Now: Timeline will be refreshed with clear content
