### PR TITLE
Fix / sometime sent reaction is count twice

### DIFF
--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/EventRelationsAggregationUpdater.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/EventRelationsAggregationUpdater.kt
@@ -22,8 +22,6 @@ import im.vector.matrix.android.internal.database.RealmLiveEntityObserver
 import im.vector.matrix.android.internal.database.mapper.asDomain
 import im.vector.matrix.android.internal.database.model.EventEntity
 import im.vector.matrix.android.internal.database.query.types
-import im.vector.matrix.android.internal.database.query.where
-import im.vector.matrix.android.internal.session.SessionScope
 import im.vector.matrix.android.internal.task.TaskExecutor
 import im.vector.matrix.android.internal.task.configureWith
 import timber.log.Timber
@@ -53,7 +51,7 @@ internal class EventRelationsAggregationUpdater @Inject constructor(monarchy: Mo
     override fun processChanges(inserted: List<EventEntity>, updated: List<EventEntity>, deleted: List<EventEntity>) {
         Timber.v("EventRelationsAggregationUpdater called with ${inserted.size} insertions")
         val domainInserted = inserted
-                .map { it.asDomain() to it.sendState }
+                .map { it.asDomain() }
 
         val params = EventRelationsAggregationTask.Params(
                 domainInserted,


### PR DESCRIPTION
Regression due to update of event state to sending. Reaction updated was only checking that state was UNSENT to see if event is local echo.
-> Now we just check the eventID to see if local echo instead of checking state

Example log with bug:
```
DefaultEventRelationsAggregationTask: Reaction local.352593da-d636-4aa2-96e0-3da1ccbd721b relates to $15620633861083705gPnpk:matrix.org
DefaultEventRelationsAggregationTask: Adding synced reaction 😢
```


