### PR TITLE
Moved incoming key/verif to active session holder

### DIFF
--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/crypto/CryptoService.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/crypto/CryptoService.kt
@@ -85,6 +85,8 @@ interface CryptoService {
 
     fun addRoomKeysRequestListener(listener: RoomKeysRequestListener)
 
+    fun removeRoomKeysRequestListener(listener: RoomKeysRequestListener)
+
     fun getDevicesList(callback: MatrixCallback<DevicesListResponse>)
 
     fun inboundGroupSessionsCount(onlyBackedUp: Boolean): Int

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/CryptoManager.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/CryptoManager.kt
@@ -1023,7 +1023,7 @@ internal class CryptoManager @Inject constructor(
      *
      * @param listener listener
      */
-    fun removeRoomKeysRequestListener(listener: RoomKeysRequestListener) {
+    override fun removeRoomKeysRequestListener(listener: RoomKeysRequestListener) {
         incomingRoomKeyRequestManager.removeRoomKeysRequestListener(listener)
     }
 

--- a/vector/src/main/java/im/vector/riotx/features/home/HomeActivity.kt
+++ b/vector/src/main/java/im/vector/riotx/features/home/HomeActivity.kt
@@ -39,8 +39,6 @@ import im.vector.riotx.core.platform.OnBackPressed
 import im.vector.riotx.core.platform.ToolbarConfigurable
 import im.vector.riotx.core.platform.VectorBaseActivity
 import im.vector.riotx.core.pushers.PushersManager
-import im.vector.riotx.features.crypto.keysrequest.KeyRequestHandler
-import im.vector.riotx.features.crypto.verification.IncomingVerificationRequestHandler
 import im.vector.riotx.features.disclaimer.showDisclaimerDialog
 import im.vector.riotx.features.notifications.NotificationDrawerManager
 import im.vector.riotx.features.rageshake.VectorUncaughtExceptionHandler
@@ -64,10 +62,6 @@ class HomeActivity : VectorBaseActivity(), ToolbarConfigurable {
     @Inject lateinit var homeActivityViewModelFactory: HomeActivityViewModel.Factory
     @Inject lateinit var homeNavigator: HomeNavigator
     @Inject lateinit var vectorUncaughtExceptionHandler: VectorUncaughtExceptionHandler
-    // TODO Move this elsewhere
-    @Inject lateinit var incomingVerificationRequestHandler: IncomingVerificationRequestHandler
-    // TODO Move this elsewhere
-    @Inject lateinit var keyRequestHandler: KeyRequestHandler
     @Inject lateinit var pushManager: PushersManager
     @Inject lateinit var notificationDrawerManager: NotificationDrawerManager
 


### PR DESCRIPTION
Moved management of incoming Verification / Key  Requests to the active session holder.

Fix cases when incoming verification was not coming on first launch, and also delayed room.key ?  