### PR TITLE
Start crypto manager before handling first sync events

### DIFF
--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/CryptoManager.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/CryptoManager.kt
@@ -242,16 +242,16 @@ internal class CryptoManager @Inject constructor(
      * @param isInitialSync true if it starts from an initial sync
      */
     fun start(isInitialSync: Boolean) {
+        if (isStarted.get() || isStarting.get()) {
+            return
+        }
+        isStarting.set(true)
         CoroutineScope(coroutineDispatchers.crypto).launch {
             internalStart(isInitialSync)
         }
     }
 
     private suspend fun internalStart(isInitialSync: Boolean) {
-        if (isStarted.get() || isStarting.get()) {
-            return
-        }
-        isStarting.set(true)
         // Open the store
         cryptoStore.open()
         uploadDeviceKeys()

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/sync/SyncResponseHandler.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/sync/SyncResponseHandler.kt
@@ -33,6 +33,11 @@ internal class SyncResponseHandler @Inject constructor(private val roomSyncHandl
     fun handleResponse(syncResponse: SyncResponse, fromToken: String?, isCatchingUp: Boolean): Try<SyncResponse> {
         return Try {
             Timber.v("Start handling sync")
+            val isInitialSync = fromToken == null
+            if (!cryptoManager.isStarted()) {
+                Timber.v("Should start cryptoManager")
+                cryptoManager.start(isInitialSync)
+            }
             val measure = measureTimeMillis {
                 // Handle the to device events before the room ones
                 // to ensure to decrypt them properly
@@ -54,11 +59,6 @@ internal class SyncResponseHandler @Inject constructor(private val roomSyncHandl
                 }
                 Timber.v("On sync completed")
                 cryptoSyncHandler.onSyncCompleted(syncResponse)
-            }
-            val isInitialSync = fromToken == null
-            if (!cryptoManager.isStarted()) {
-                Timber.v("Should start cryptoManager")
-                cryptoManager.start(isInitialSync)
             }
             Timber.v("Finish handling sync in $measure ms")
             syncResponse


### PR DESCRIPTION
The crypto manager was started after room sync was handled, causing the start command to be far away in the queue of commands in the crypto thread
