### PR TITLE
Convert some callback functions to suspend

### DIFF
--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/RoomService.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/RoomService.kt
@@ -17,7 +17,6 @@
 package im.vector.matrix.android.api.session.room
 
 import androidx.lifecycle.LiveData
-import im.vector.matrix.android.api.MatrixCallback
 import im.vector.matrix.android.api.session.room.model.RoomSummary
 import im.vector.matrix.android.api.session.room.model.create.CreateRoomParams
 
@@ -29,8 +28,7 @@ interface RoomService {
     /**
      * Create a room
      */
-    fun createRoom(createRoomParams: CreateRoomParams,
-                   callback: MatrixCallback<String>)
+    suspend fun createRoom(createRoomParams: CreateRoomParams): String
 
     /**
      * Get a room from a roomId

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/members/MembershipService.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/members/MembershipService.kt
@@ -17,7 +17,6 @@
 package im.vector.matrix.android.api.session.room.members
 
 import androidx.lifecycle.LiveData
-import im.vector.matrix.android.api.MatrixCallback
 import im.vector.matrix.android.api.session.room.model.RoomMember
 import im.vector.matrix.android.api.util.Cancelable
 
@@ -52,16 +51,16 @@ interface MembershipService {
     /**
      * Invite a user in the room
      */
-    fun invite(userId: String, callback: MatrixCallback<Unit>)
+    suspend fun invite(userId: String)
 
     /**
      * Join the room, or accept an invitation.
      */
-    fun join(callback: MatrixCallback<Unit>)
+    suspend fun join()
 
     /**
      * Leave the room, or reject an invitation.
      */
-    fun leave(callback: MatrixCallback<Unit>)
+    suspend fun leave()
 
 }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/read/ReadService.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/read/ReadService.kt
@@ -16,8 +16,6 @@
 
 package im.vector.matrix.android.api.session.room.read
 
-import im.vector.matrix.android.api.MatrixCallback
-
 /**
  * This interface defines methods to handle read receipts and read marker in a room. It's implemented at the room level.
  */
@@ -26,17 +24,17 @@ interface ReadService {
     /**
      * Force the read marker to be set on the latest event.
      */
-    fun markAllAsRead(callback: MatrixCallback<Unit>)
+    suspend fun markAllAsRead()
 
     /**
      * Set the read receipt on the event with provided eventId.
      */
-    fun setReadReceipt(eventId: String, callback: MatrixCallback<Unit>)
+    suspend fun setReadReceipt(eventId: String)
 
     /**
      * Set the read marker on the event with provided eventId.
      */
-    fun setReadMarker(fullyReadEventId: String, callback: MatrixCallback<Unit>)
+    suspend fun setReadMarker(fullyReadEventId: String)
 
     fun isEventRead(eventId: String): Boolean
 }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/state/StateService.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/state/StateService.kt
@@ -16,13 +16,11 @@
 
 package im.vector.matrix.android.api.session.room.state
 
-import im.vector.matrix.android.api.MatrixCallback
-
 interface StateService {
 
     /**
      * Update the topic of the room
      */
-    fun updateTopic(topic: String, callback: MatrixCallback<Unit>)
+    suspend fun updateTopic(topic: String)
 
 }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/util/MatrixCallbackUtils.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/util/MatrixCallbackUtils.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.matrix.android.api.util
+
+import im.vector.matrix.android.api.MatrixCallback
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+suspend fun <T> suspendCallback(block: (MatrixCallback<T>) -> Cancelable) : T = suspendCancellableCoroutine {
+    val cancelable = block(object : MatrixCallback<T> {
+        override fun onSuccess(data: T) {
+            it.resume(data)
+        }
+
+        override fun onFailure(failure: Throwable) {
+            it.resumeWithException(failure)
+        }
+    })
+    it.invokeOnCancellation {
+        cancelable.cancel()
+    }
+}

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/DefaultRoomService.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/DefaultRoomService.kt
@@ -18,11 +18,11 @@ package im.vector.matrix.android.internal.session.room
 
 import androidx.lifecycle.LiveData
 import com.zhuinden.monarchy.Monarchy
-import im.vector.matrix.android.api.MatrixCallback
 import im.vector.matrix.android.api.session.room.Room
 import im.vector.matrix.android.api.session.room.RoomService
 import im.vector.matrix.android.api.session.room.model.RoomSummary
 import im.vector.matrix.android.api.session.room.model.create.CreateRoomParams
+import im.vector.matrix.android.api.util.suspendCallback
 import im.vector.matrix.android.internal.database.mapper.RoomSummaryMapper
 import im.vector.matrix.android.internal.database.model.RoomEntity
 import im.vector.matrix.android.internal.database.model.RoomSummaryEntity
@@ -40,11 +40,12 @@ internal class DefaultRoomService @Inject constructor(private val monarchy: Mona
                                                       private val roomFactory: RoomFactory,
                                                       private val taskExecutor: TaskExecutor) : RoomService {
 
-    override fun createRoom(createRoomParams: CreateRoomParams, callback: MatrixCallback<String>) {
-        createRoomTask
-                .configureWith(createRoomParams)
-                .dispatchTo(callback)
-                .executeBy(taskExecutor)
+    override suspend fun createRoom(createRoomParams: CreateRoomParams): String {
+        return suspendCallback {
+            createRoomTask.configureWith(createRoomParams)
+                    .dispatchTo(it)
+                    .executeBy(taskExecutor)
+        }
     }
 
     override fun getRoom(roomId: String): Room? {

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/membership/DefaultMembershipService.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/membership/DefaultMembershipService.kt
@@ -18,12 +18,12 @@ package im.vector.matrix.android.internal.session.room.membership
 
 import androidx.lifecycle.LiveData
 import com.zhuinden.monarchy.Monarchy
-import im.vector.matrix.android.api.MatrixCallback
 import im.vector.matrix.android.api.session.events.model.toModel
 import im.vector.matrix.android.api.session.room.members.MembershipService
 import im.vector.matrix.android.api.session.room.model.Membership
 import im.vector.matrix.android.api.session.room.model.RoomMember
 import im.vector.matrix.android.api.util.Cancelable
+import im.vector.matrix.android.api.util.suspendCallback
 import im.vector.matrix.android.internal.database.mapper.asDomain
 import im.vector.matrix.android.internal.session.room.membership.joining.InviteTask
 import im.vector.matrix.android.internal.session.room.membership.joining.JoinRoomTask
@@ -73,24 +73,30 @@ internal class DefaultMembershipService @Inject constructor(private val roomId: 
         return result
     }
 
-    override fun invite(userId: String, callback: MatrixCallback<Unit>) {
+    override suspend fun invite(userId: String) {
         val params = InviteTask.Params(roomId, userId)
-        inviteTask.configureWith(params)
-                .dispatchTo(callback)
-                .executeBy(taskExecutor)
+        suspendCallback<Unit> {
+            inviteTask.configureWith(params)
+                    .dispatchTo(it)
+                    .executeBy(taskExecutor)
+        }
     }
 
-    override fun join(callback: MatrixCallback<Unit>) {
+    override suspend fun join() {
         val params = JoinRoomTask.Params(roomId)
-        joinTask.configureWith(params)
-                .dispatchTo(callback)
-                .executeBy(taskExecutor)
+        suspendCallback<Unit> {
+            joinTask.configureWith(params)
+                    .dispatchTo(it)
+                    .executeBy(taskExecutor)
+        }
     }
 
-    override fun leave(callback: MatrixCallback<Unit>) {
+    override suspend fun leave() {
         val params = LeaveRoomTask.Params(roomId)
-        leaveRoomTask.configureWith(params)
-                .dispatchTo(callback)
-                .executeBy(taskExecutor)
+        suspendCallback<Unit> {
+            leaveRoomTask.configureWith(params)
+                    .dispatchTo(it)
+                    .executeBy(taskExecutor)
+        }
     }
 }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/read/DefaultReadService.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/read/DefaultReadService.kt
@@ -17,9 +17,9 @@
 package im.vector.matrix.android.internal.session.room.read
 
 import com.zhuinden.monarchy.Monarchy
-import im.vector.matrix.android.api.MatrixCallback
 import im.vector.matrix.android.api.auth.data.Credentials
 import im.vector.matrix.android.api.session.room.read.ReadService
+import im.vector.matrix.android.api.util.suspendCallback
 import im.vector.matrix.android.internal.database.model.ChunkEntity
 import im.vector.matrix.android.internal.database.model.EventEntity
 import im.vector.matrix.android.internal.database.model.ReadReceiptEntity
@@ -38,21 +38,27 @@ internal class DefaultReadService @Inject constructor(private val roomId: String
                                                       private val setReadMarkersTask: SetReadMarkersTask,
                                                       private val credentials: Credentials) : ReadService {
 
-    override fun markAllAsRead(callback: MatrixCallback<Unit>) {
+    override suspend fun markAllAsRead() {
         //TODO shouldn't it be latest synced event?
         val latestEvent = getLatestEvent()
         val params = SetReadMarkersTask.Params(roomId, fullyReadEventId = latestEvent?.eventId, readReceiptEventId = latestEvent?.eventId)
-        setReadMarkersTask.configureWith(params).dispatchTo(callback).executeBy(taskExecutor)
+        suspendCallback<Unit> {
+            setReadMarkersTask.configureWith(params).dispatchTo(it).executeBy(taskExecutor)
+        }
     }
 
-    override fun setReadReceipt(eventId: String, callback: MatrixCallback<Unit>) {
+    override suspend fun setReadReceipt(eventId: String) {
         val params = SetReadMarkersTask.Params(roomId, fullyReadEventId = null, readReceiptEventId = eventId)
-        setReadMarkersTask.configureWith(params).dispatchTo(callback).executeBy(taskExecutor)
+        suspendCallback<Unit> {
+            setReadMarkersTask.configureWith(params).dispatchTo(it).executeBy(taskExecutor)
+        }
     }
 
-    override fun setReadMarker(fullyReadEventId: String, callback: MatrixCallback<Unit>) {
+    override suspend fun setReadMarker(fullyReadEventId: String) {
         val params = SetReadMarkersTask.Params(roomId, fullyReadEventId = fullyReadEventId, readReceiptEventId = null)
-        setReadMarkersTask.configureWith(params).dispatchTo(callback).executeBy(taskExecutor)
+        suspendCallback<Unit> {
+            setReadMarkersTask.configureWith(params).dispatchTo(it).executeBy(taskExecutor)
+        }
     }
 
     private fun getLatestEvent(): EventEntity? {

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/state/DefaultStateService.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/state/DefaultStateService.kt
@@ -16,9 +16,9 @@
 
 package im.vector.matrix.android.internal.session.room.state
 
-import im.vector.matrix.android.api.MatrixCallback
 import im.vector.matrix.android.api.session.events.model.EventType
 import im.vector.matrix.android.api.session.room.state.StateService
+import im.vector.matrix.android.api.util.suspendCallback
 import im.vector.matrix.android.internal.task.TaskExecutor
 import im.vector.matrix.android.internal.task.configureWith
 import javax.inject.Inject
@@ -27,16 +27,17 @@ internal class DefaultStateService @Inject constructor(private val roomId: Strin
                                                        private val taskExecutor: TaskExecutor,
                                                        private val sendStateTask: SendStateTask) : StateService {
 
-    override fun updateTopic(topic: String, callback: MatrixCallback<Unit>) {
+    override suspend fun updateTopic(topic: String) {
         val params = SendStateTask.Params(roomId,
                 EventType.STATE_ROOM_TOPIC,
                 HashMap<String, String>().apply {
                     put("topic", topic)
                 })
 
-
-        sendStateTask.configureWith(params)
-                .dispatchTo(callback)
-                .executeBy(taskExecutor)
+        suspendCallback<Unit> {
+            sendStateTask.configureWith(params)
+                    .dispatchTo(it)
+                    .executeBy(taskExecutor)
+        }
     }
 }

--- a/matrix-sdk-android/src/test/java/im/vector/matrix/android/api/pushrules/PushrulesConditionTest.kt
+++ b/matrix-sdk-android/src/test/java/im/vector/matrix/android/api/pushrules/PushrulesConditionTest.kt
@@ -18,7 +18,6 @@ package im.vector.matrix.android.api.pushrules
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
-import im.vector.matrix.android.api.MatrixCallback
 import im.vector.matrix.android.api.session.content.ContentAttachmentData
 import im.vector.matrix.android.api.session.events.model.Event
 import im.vector.matrix.android.api.session.events.model.toContent
@@ -35,6 +34,7 @@ import im.vector.matrix.android.api.session.room.timeline.TimelineEvent
 import im.vector.matrix.android.api.util.Cancelable
 import org.junit.Assert
 import org.junit.Test
+import kotlin.coroutines.suspendCoroutine
 
 class PushrulesConditionTest {
 
@@ -167,8 +167,8 @@ class PushrulesConditionTest {
 
     class MockRoomService() : RoomService {
 
-        override fun createRoom(createRoomParams: CreateRoomParams, callback: MatrixCallback<String>) {
-
+        override suspend fun createRoom(createRoomParams: CreateRoomParams): String {
+            return suspendCoroutine {  }
         }
 
         override fun getRoom(roomId: String): Room? {
@@ -230,15 +230,15 @@ class PushrulesConditionTest {
             TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
         }
 
-        override fun markAllAsRead(callback: MatrixCallback<Unit>) {
+        override suspend fun markAllAsRead() {
             TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
         }
 
-        override fun setReadReceipt(eventId: String, callback: MatrixCallback<Unit>) {
+        override suspend fun setReadReceipt(eventId: String) {
             TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
         }
 
-        override fun setReadMarker(fullyReadEventId: String, callback: MatrixCallback<Unit>) {
+        override suspend fun setReadMarker(fullyReadEventId: String) {
             TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
         }
 
@@ -258,19 +258,19 @@ class PushrulesConditionTest {
             TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
         }
 
-        override fun invite(userId: String, callback: MatrixCallback<Unit>) {
+        override suspend fun invite(userId: String) {
             TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
         }
 
-        override fun join(callback: MatrixCallback<Unit>) {
+        override suspend fun join() {
             TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
         }
 
-        override fun leave(callback: MatrixCallback<Unit>) {
+        override suspend fun leave() {
             TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
         }
 
-        override fun updateTopic(topic: String, callback: MatrixCallback<Unit>) {
+        override suspend fun updateTopic(topic: String) {
             TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
         }
 

--- a/vector/src/main/java/im/vector/riotx/features/home/HomeActivityViewModel.kt
+++ b/vector/src/main/java/im/vector/riotx/features/home/HomeActivityViewModel.kt
@@ -25,7 +25,6 @@ import com.airbnb.mvrx.MvRxViewModelFactory
 import com.airbnb.mvrx.ViewModelContext
 import com.squareup.inject.assisted.Assisted
 import com.squareup.inject.assisted.AssistedInject
-import im.vector.matrix.android.api.MatrixCallback
 import im.vector.matrix.android.api.session.Session
 import im.vector.matrix.android.api.session.group.model.GroupSummary
 import im.vector.matrix.android.api.session.room.model.RoomSummary
@@ -36,6 +35,9 @@ import im.vector.riotx.features.home.group.ALL_COMMUNITIES_GROUP_ID
 import im.vector.riotx.features.home.group.SelectedGroupStore
 import io.reactivex.Observable
 import io.reactivex.functions.BiFunction
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
 import java.util.concurrent.TimeUnit
 
 data class EmptyState(val isEmpty: Boolean = true) : MvRxState
@@ -107,16 +109,13 @@ class HomeActivityViewModel @AssistedInject constructor(@Assisted initialState: 
     fun createRoom(createRoomParams: CreateRoomParams = CreateRoomParams()) {
         _isLoading.value = true
 
-        session.createRoom(createRoomParams, object : MatrixCallback<String> {
-            override fun onSuccess(data: String) {
+        GlobalScope.launch(Dispatchers.Main) {
+            try {
+                session.createRoom(createRoomParams)
+            } finally {
                 _isLoading.value = false
             }
-
-            override fun onFailure(failure: Throwable) {
-                _isLoading.value = false
-                super.onFailure(failure)
-            }
-        })
+        }
     }
 
     override fun onCleared() {

--- a/vector/src/main/java/im/vector/riotx/features/home/room/list/RoomListViewModel.kt
+++ b/vector/src/main/java/im/vector/riotx/features/home/room/list/RoomListViewModel.kt
@@ -23,7 +23,6 @@ import com.airbnb.mvrx.MvRxViewModelFactory
 import com.airbnb.mvrx.ViewModelContext
 import com.squareup.inject.assisted.Assisted
 import com.squareup.inject.assisted.AssistedInject
-import im.vector.matrix.android.api.MatrixCallback
 import im.vector.matrix.android.api.session.Session
 import im.vector.matrix.android.api.session.room.model.Membership
 import im.vector.matrix.android.api.session.room.model.RoomSummary
@@ -32,6 +31,8 @@ import im.vector.riotx.core.platform.VectorViewModel
 import im.vector.riotx.core.utils.LiveEvent
 import im.vector.riotx.features.home.HomeRoomListObservableStore
 import io.reactivex.schedulers.Schedulers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
 import timber.log.Timber
 
 class RoomListViewModel @AssistedInject constructor(@Assisted initialState: RoomListViewState,
@@ -122,24 +123,27 @@ class RoomListViewModel @AssistedInject constructor(@Assisted initialState: Room
             )
         }
 
-        session.getRoom(roomId)?.join(object : MatrixCallback<Unit> {
-            override fun onSuccess(data: Unit) {
-                // We do not update the joiningRoomsIds here, because, the room is not joined yet regarding the sync data.
-                // Instead, we wait for the room to be joined
-            }
+        val room = session.getRoom(roomId)
+        if (room != null) {
+            GlobalScope.launch {
+                try {
+                    room.join()
+                    // We do not update the joiningRoomsIds here, because, the room is not joined yet regarding the
+                    // sync data.
+                    // Instead, we wait for the room to be joined
+                } catch (failure: Throwable) {
+                    // Notify the user
+                    _invitationAnswerErrorLiveData.postValue(LiveEvent(failure))
 
-            override fun onFailure(failure: Throwable) {
-                // Notify the user
-                _invitationAnswerErrorLiveData.postValue(LiveEvent(failure))
-
-                setState {
-                    copy(
-                            joiningRoomsIds = joiningRoomsIds.toMutableSet().apply { remove(roomId) },
-                            joiningErrorRoomsIds = joiningErrorRoomsIds.toMutableSet().apply { add(roomId) }
-                    )
+                    setState {
+                        copy(
+                                joiningRoomsIds = joiningRoomsIds.toMutableSet().apply { remove(roomId) },
+                                joiningErrorRoomsIds = joiningErrorRoomsIds.toMutableSet().apply { add(roomId) }
+                        )
+                    }
                 }
             }
-        })
+        }
     }
 
     private fun handleRejectInvitation(action: RoomListActions.RejectInvitation) = withState { state ->
@@ -158,24 +162,27 @@ class RoomListViewModel @AssistedInject constructor(@Assisted initialState: Room
             )
         }
 
-        session.getRoom(roomId)?.leave(object : MatrixCallback<Unit> {
-            override fun onSuccess(data: Unit) {
-                // We do not update the joiningRoomsIds here, because, the room is not joined yet regarding the sync data.
-                // Instead, we wait for the room to be joined
-            }
+        val room = session.getRoom(roomId)
+        if (room != null) {
+            GlobalScope.launch {
+                try {
+                    room.leave()
+                    // We do not update the joiningRoomsIds here, because, the room is not joined yet regarding the
+                    // sync data.
+                    // Instead, we wait for the room to be joined
+                } catch (failure: Throwable) {
+                    // Notify the user
+                    _invitationAnswerErrorLiveData.postValue(LiveEvent(failure))
 
-            override fun onFailure(failure: Throwable) {
-                // Notify the user
-                _invitationAnswerErrorLiveData.postValue(LiveEvent(failure))
-
-                setState {
-                    copy(
-                            rejectingRoomsIds = rejectingRoomsIds.toMutableSet().apply { remove(roomId) },
-                            rejectingErrorRoomsIds = rejectingErrorRoomsIds.toMutableSet().apply { add(roomId) }
-                    )
+                    setState {
+                        copy(
+                                rejectingRoomsIds = rejectingRoomsIds.toMutableSet().apply { remove(roomId) },
+                                rejectingErrorRoomsIds = rejectingErrorRoomsIds.toMutableSet().apply { add(roomId) }
+                        )
+                    }
                 }
             }
-        })
+        }
     }
 
     private fun buildRoomSummaries(rooms: List<RoomSummary>): RoomSummaries {

--- a/vector/src/main/java/im/vector/riotx/features/notifications/NotificationBroadcastReceiver.kt
+++ b/vector/src/main/java/im/vector/riotx/features/notifications/NotificationBroadcastReceiver.kt
@@ -20,12 +20,13 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import androidx.core.app.RemoteInput
-import im.vector.matrix.android.api.MatrixCallback
 import im.vector.matrix.android.api.session.Session
 import im.vector.matrix.android.api.session.room.Room
 import im.vector.riotx.R
 import im.vector.riotx.core.di.ActiveSessionHolder
 import im.vector.riotx.core.extensions.vectorComponent
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
 import timber.log.Timber
 import java.util.*
 import javax.inject.Inject
@@ -74,22 +75,33 @@ class NotificationBroadcastReceiver : BroadcastReceiver() {
 
     private fun handleJoinRoom(roomId: String) {
         activeSessionHolder.getSafeActiveSession()?.let { session ->
-            session.getRoom(roomId)
-                    ?.join(object : MatrixCallback<Unit> {})
+            val room = session.getRoom(roomId)
+            if (room != null) {
+                GlobalScope.launch {
+                    room.join()
+                }
+            }
         }
     }
 
     private fun handleRejectRoom(roomId: String) {
         activeSessionHolder.getSafeActiveSession()?.let { session ->
-            session.getRoom(roomId)
-                    ?.leave(object : MatrixCallback<Unit> {})
+            val room = session.getRoom(roomId)
+            if (room != null) {
+                GlobalScope.launch {
+                    room.leave()
+                }
+            }
         }
     }
 
     private fun handleMarkAsRead(roomId: String) {
-        activeSessionHolder.getActiveSession().let { session ->
-            session.getRoom(roomId)
-                    ?.markAllAsRead(object : MatrixCallback<Unit> {})
+        val session = activeSessionHolder.getActiveSession()
+        val room = session.getRoom(roomId)
+        if (room != null) {
+            GlobalScope.launch {
+                room.markAllAsRead()
+            }
         }
     }
 

--- a/vector/src/main/java/im/vector/riotx/features/roomdirectory/createroom/CreateRoomViewModel.kt
+++ b/vector/src/main/java/im/vector/riotx/features/roomdirectory/createroom/CreateRoomViewModel.kt
@@ -19,12 +19,14 @@ package im.vector.riotx.features.roomdirectory.createroom
 import com.airbnb.mvrx.*
 import com.squareup.inject.assisted.Assisted
 import com.squareup.inject.assisted.AssistedInject
-import im.vector.matrix.android.api.MatrixCallback
 import im.vector.matrix.android.api.session.Session
 import im.vector.matrix.android.api.session.room.model.RoomDirectoryVisibility
 import im.vector.matrix.android.api.session.room.model.create.CreateRoomParams
 import im.vector.matrix.android.api.session.room.model.create.CreateRoomPreset
 import im.vector.riotx.core.platform.VectorViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
 
 class CreateRoomViewModel @AssistedInject constructor(@Assisted initialState: CreateRoomViewState,
                                                       private val session: Session
@@ -69,19 +71,18 @@ class CreateRoomViewModel @AssistedInject constructor(@Assisted initialState: Cr
             preset = if (state.isPublic) CreateRoomPreset.PRESET_PUBLIC_CHAT else CreateRoomPreset.PRESET_PRIVATE_CHAT
         }
 
-        session.createRoom(createRoomParams, object : MatrixCallback<String> {
-            override fun onSuccess(data: String) {
+        GlobalScope.launch(Dispatchers.Main) {
+            try {
+                val data = session.createRoom(createRoomParams)
                 setState {
                     copy(asyncCreateRoomRequest = Success(data))
                 }
-            }
-
-            override fun onFailure(failure: Throwable) {
+            } catch (failure: Throwable) {
                 setState {
                     copy(asyncCreateRoomRequest = Fail(failure))
                 }
             }
-        })
+        }
     }
 
 }


### PR DESCRIPTION
Since this project is in Kotlin, I thought it would be a good idea to use the awesome async features of the language.
I've converted some of the functions that take callbacks like `fun call(callback: MatrixCallback<String>)`  to `suspend call(): String`. This will eventually make it easier to write a nicer version of  https://github.com/vector-im/riotX-android/blob/498b1f2b06e9a62cb1a57c37d480e8ebaff4fe1a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/send/EncryptEventWorker.kt#L71 
For the function callers, I've mostly assumed code needs to finish on the main thread.

Signed-off-by: Dominic Fischer <dominicfischer7@gmail.com>

### Pull Request Checklist

<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/riotX-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->

- [ ] Changes has been tested on an Android device or Android emulator with API 16
- [ ] UI change has been tested on both light and dark themes
- [x] Pull request is based on the develop branch
- [ ] Pull request updates [CHANGES.md](https://github.com/vector-im/riotX-android/blob/develop/CHANGES.md)
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#sign-off)
