### PR TITLE
Some more kotlinification.

### DIFF
--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/algorithms/megolm/MXMegolmDecryption.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/algorithms/megolm/MXMegolmDecryption.kt
@@ -40,7 +40,6 @@ import im.vector.matrix.android.internal.util.MatrixCoroutineDispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import timber.log.Timber
-import java.util.*
 import kotlin.collections.HashMap
 
 internal class MXMegolmDecryption(private val credentials: Credentials,
@@ -320,8 +319,7 @@ internal class MXMegolmDecryption(private val credentials: Credentials,
                         if (deviceInfo == null) {
                             throw RuntimeException()
                         } else {
-                            val devicesByUser = HashMap<String, List<MXDeviceInfo>>()
-                            devicesByUser[userId] = ArrayList(Arrays.asList(deviceInfo))
+                            val devicesByUser = mapOf(userId to listOf(deviceInfo))
                             ensureOlmSessionsForDevicesAction
                                     .handle(devicesByUser)
                                     .flatMap {
@@ -335,8 +333,7 @@ internal class MXMegolmDecryption(private val credentials: Credentials,
                                         Timber.v("## shareKeysWithDevice() : sharing keys for session" +
                                                 " ${body?.senderKey}|${body?.sessionId} with device $userId:$deviceId")
 
-                                        val payloadJson = HashMap<String, Any>()
-                                        payloadJson["type"] = EventType.FORWARDED_ROOM_KEY
+                                        val payloadJson = mutableMapOf<String, Any>("type" to EventType.FORWARDED_ROOM_KEY)
 
                                         olmDevice.getInboundGroupSession(body?.sessionId, body?.senderKey, body?.roomId)
                                                 .fold(
@@ -349,7 +346,7 @@ internal class MXMegolmDecryption(private val credentials: Credentials,
                                                         }
                                                 )
 
-                                        val encodedPayload = messageEncrypter.encryptMessage(payloadJson, Arrays.asList(deviceInfo))
+                                        val encodedPayload = messageEncrypter.encryptMessage(payloadJson, listOf(deviceInfo))
                                         val sendToDeviceMap = MXUsersDevicesMap<Any>()
                                         sendToDeviceMap.setObject(userId, deviceId, encodedPayload)
                                         Timber.v("## shareKeysWithDevice() : sending to $userId:$deviceId")

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/algorithms/megolm/MXMegolmDecryption.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/algorithms/megolm/MXMegolmDecryption.kt
@@ -29,7 +29,6 @@ import im.vector.matrix.android.internal.crypto.actions.EnsureOlmSessionsForDevi
 import im.vector.matrix.android.internal.crypto.actions.MessageEncrypter
 import im.vector.matrix.android.internal.crypto.algorithms.IMXDecrypting
 import im.vector.matrix.android.internal.crypto.keysbackup.KeysBackup
-import im.vector.matrix.android.internal.crypto.model.MXDeviceInfo
 import im.vector.matrix.android.internal.crypto.model.MXUsersDevicesMap
 import im.vector.matrix.android.internal.crypto.model.event.EncryptedEventContent
 import im.vector.matrix.android.internal.crypto.model.event.RoomKeyContent
@@ -38,7 +37,7 @@ import im.vector.matrix.android.internal.crypto.model.rest.RoomKeyRequestBody
 import im.vector.matrix.android.internal.crypto.store.IMXCryptoStore
 import im.vector.matrix.android.internal.crypto.tasks.SendToDeviceTask
 import im.vector.matrix.android.internal.util.MatrixCoroutineDispatchers
-import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import java.util.*
@@ -312,7 +311,7 @@ internal class MXMegolmDecryption(private val credentials: Credentials,
             return
         }
         val userId = request.userId ?: return
-        CoroutineScope(coroutineDispatchers.crypto).launch {
+        GlobalScope.launch(coroutineDispatchers.crypto) {
             deviceListManager
                     .downloadKeys(listOf(userId), false)
                     .flatMap {

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/verification/DefaultSasVerificationService.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/verification/DefaultSasVerificationService.kt
@@ -40,7 +40,7 @@ import im.vector.matrix.android.internal.session.SessionScope
 import im.vector.matrix.android.internal.task.TaskExecutor
 import im.vector.matrix.android.internal.task.configureWith
 import im.vector.matrix.android.internal.util.MatrixCoroutineDispatchers
-import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import java.util.*
@@ -71,7 +71,7 @@ internal class DefaultSasVerificationService @Inject constructor(private val cre
 
     // Event received from the sync
     fun onToDeviceEvent(event: Event) {
-        CoroutineScope(coroutineDispatchers.crypto).launch {
+        GlobalScope.launch(coroutineDispatchers.crypto) {
             when (event.getClearType()) {
                 EventType.KEY_VERIFICATION_START  -> {
                     onStartRequestReceived(event)


### PR DESCRIPTION
### Pull Request Checklist

<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/riotX-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->

- [ ] Changes has been tested on an Android device or Android emulator with API 16
- [ ] UI change has been tested on both light and dark themes
- [x] Pull request is based on the develop branch
- [ ] Pull request updates [CHANGES.md](https://github.com/vector-im/riotX-android/blob/develop/CHANGES.md)
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#sign-off)

I have mostly changed `CoroutineScope(coroutineDispatchers.*).launch` to `GlobalScope.launch(coroutineDispatchers.*)`, they effectively do the same thing but the latter uses one less allocation and is a bit clearer imo. (`CoroutineScope`s should not be manually constructed if they are not going to be explicitly cancelled or joined, `GlobalScope` was made for this).

Changed a *private* callback function to a suspend function.

Also, replaced some `TextUtils` usages with the Kotlin equivalents as the Kotlin equivalents support contracts and reduce the need for `!!`s.