### PR TITLE
Fix / composer separator color was using a clear theme color

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ Other changes:
 Bugfix:
  - Fix regression on permalink click
  - Fix crash reported by the PlayStore (#341)
+ - Fix Chat composer separator color in dark/black theme
 
 Translations:
  -

--- a/vector/src/main/res/values/theme_black.xml
+++ b/vector/src/main/res/values/theme_black.xml
@@ -78,7 +78,7 @@
         <!-- activities background -->
         <item name="android:windowBackground">@color/riot_primary_background_color_black</item>
         <item name="vctr_bottom_nav_background_color">@color/primary_color_black</item>
-        <item name="vctr_bottom_nav_background_border_color">#FFE9EDF1</item>
+        <item name="vctr_bottom_nav_background_border_color">#FF15171b</item>
 
         <item name="vctr_direct_chat_circle">@drawable/direct_chat_circle_black</item>
     </style>

--- a/vector/src/main/res/values/theme_dark.xml
+++ b/vector/src/main/res/values/theme_dark.xml
@@ -65,7 +65,7 @@
 
         <!-- default background color -->
         <item name="vctr_bottom_nav_background_color">@color/primary_color_dark</item>
-        <item name="vctr_bottom_nav_background_border_color">#FFE9EDF1</item>
+        <item name="vctr_bottom_nav_background_border_color">#FF15171b</item>
 
         <!-- waiting view background -->
         <item name="vctr_waiting_background_color">#55555555</item>


### PR DESCRIPTION


<img width="506" alt="image" src="https://user-images.githubusercontent.com/9841565/61229672-df655000-a728-11e9-8e3a-2c490341d301.png">
