### PR TITLE
Fix / SyncThread was started in background

### DIFF
--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/Session.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/Session.kt
@@ -84,7 +84,7 @@ interface Session :
     /**
      * This method start the sync thread.
      */
-    fun startSync()
+    fun startSync(fromForeground : Boolean)
 
     /**
      * This method stop the sync thread.

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/DefaultSession.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/DefaultSession.kt
@@ -105,8 +105,10 @@ internal class DefaultSession @Inject constructor(override val sessionParams: Se
         SyncWorker.stopAnyBackgroundSync(context)
     }
 
-    override fun startSync() {
+    override fun startSync(fromForeground : Boolean) {
+        Timber.i("Starting sync thread")
         assert(isOpen)
+        syncThread.setInitialForeground(fromForeground)
         if (!syncThread.isAlive) {
             syncThread.start()
         } else {

--- a/vector/src/main/java/im/vector/riotx/core/extensions/Session.kt
+++ b/vector/src/main/java/im/vector/riotx/core/extensions/Session.kt
@@ -16,14 +16,20 @@
 
 package im.vector.riotx.core.extensions
 
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.ProcessLifecycleOwner
 import im.vector.matrix.android.api.session.Session
 import im.vector.matrix.android.api.session.sync.FilterService
 import im.vector.riotx.features.notifications.PushRuleTriggerListener
+import timber.log.Timber
 
 fun Session.configureAndStart(pushRuleTriggerListener: PushRuleTriggerListener) {
     open()
     setFilter(FilterService.FilterPreset.RiotFilter)
-    startSync()
+    Timber.i("Configure and start session for ${this.myUserId}")
+    val isAtLeastStarted = ProcessLifecycleOwner.get().lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)
+    Timber.v("--> is at least started? $isAtLeastStarted")
+    startSync(isAtLeastStarted)
     refreshPushers()
     pushRuleTriggerListener.startWithSession(this)
     fetchPushRules()


### PR DESCRIPTION
Fixes #376
Upon reception of a push, if the session is instantiated the sync thread was starting to loop (causing the app to permanently sync in background -until eventually killed by system-)
