### PR TITLE
Reuse existing threadpool

### DIFF
--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/verification/DefaultSasVerificationService.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/verification/DefaultSasVerificationService.kt
@@ -16,8 +16,6 @@
 
 package im.vector.matrix.android.internal.crypto.verification
 
-import android.os.Handler
-import android.os.Looper
 import dagger.Lazy
 import im.vector.matrix.android.api.MatrixCallback
 import im.vector.matrix.android.api.auth.data.Credentials
@@ -65,8 +63,6 @@ internal class DefaultSasVerificationService @Inject constructor(private val cre
                                                                  private val taskExecutor: TaskExecutor)
     : VerificationTransaction.Listener, SasVerificationService {
 
-    private val uiHandler = Handler(Looper.getMainLooper())
-
     // map [sender : [transaction]]
     private val txMap = HashMap<String, HashMap<String, VerificationTransaction>>()
 
@@ -99,7 +95,7 @@ internal class DefaultSasVerificationService @Inject constructor(private val cre
     private var listeners = ArrayList<SasVerificationService.SasVerificationListener>()
 
     override fun addListener(listener: SasVerificationService.SasVerificationListener) {
-        uiHandler.post {
+        GlobalScope.launch(coroutineDispatchers.main) {
             if (!listeners.contains(listener)) {
                 listeners.add(listener)
             }
@@ -107,13 +103,13 @@ internal class DefaultSasVerificationService @Inject constructor(private val cre
     }
 
     override fun removeListener(listener: SasVerificationService.SasVerificationListener) {
-        uiHandler.post {
+        GlobalScope.launch(coroutineDispatchers.main) {
             listeners.remove(listener)
         }
     }
 
     private fun dispatchTxAdded(tx: VerificationTransaction) {
-        uiHandler.post {
+        GlobalScope.launch(coroutineDispatchers.main) {
             listeners.forEach {
                 try {
                     it.transactionCreated(tx)
@@ -125,7 +121,7 @@ internal class DefaultSasVerificationService @Inject constructor(private val cre
     }
 
     private fun dispatchTxUpdated(tx: VerificationTransaction) {
-        uiHandler.post {
+        GlobalScope.launch(coroutineDispatchers.main) {
             listeners.forEach {
                 try {
                     it.transactionUpdated(tx)

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/database/RealmLiveEntityObserver.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/database/RealmLiveEntityObserver.kt
@@ -17,11 +17,8 @@
 package im.vector.matrix.android.internal.database
 
 import com.zhuinden.monarchy.Monarchy
-import im.vector.matrix.android.internal.util.createBackgroundHandler
 import io.realm.*
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancelChildren
+import kotlinx.coroutines.*
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
 
@@ -36,7 +33,7 @@ internal abstract class RealmLiveEntityObserver<T : RealmObject>(protected val r
     : LiveEntityObserver, OrderedRealmCollectionChangeListener<RealmResults<T>> {
 
     private companion object {
-        val BACKGROUND_HANDLER = createBackgroundHandler("LIVE_ENTITY_BACKGROUND")
+        val BACKGROUND_CONTEXT = CoroutineName("LIVE_ENTITY_BACKGROUND") + Dispatchers.Main
     }
 
     protected val observerScope = CoroutineScope(SupervisorJob())
@@ -47,11 +44,11 @@ internal abstract class RealmLiveEntityObserver<T : RealmObject>(protected val r
 
     override fun start() {
         if (isStarted.compareAndSet(false, true)) {
-            BACKGROUND_HANDLER.post {
+            GlobalScope.launch(BACKGROUND_CONTEXT) {
                 val realm = Realm.getInstance(realmConfiguration)
                 backgroundRealm.set(realm)
                 val queryResults = query.createQuery(realm).findAll()
-                queryResults.addChangeListener(this)
+                queryResults.addChangeListener(this@RealmLiveEntityObserver)
                 results = AtomicReference(queryResults)
             }
         }
@@ -59,7 +56,7 @@ internal abstract class RealmLiveEntityObserver<T : RealmObject>(protected val r
 
     override fun dispose() {
         if (isStarted.compareAndSet(true, false)) {
-            BACKGROUND_HANDLER.post {
+            GlobalScope.launch(BACKGROUND_CONTEXT) {
                 results.getAndSet(null).removeAllChangeListeners()
                 backgroundRealm.getAndSet(null).also {
                     it.close()


### PR DESCRIPTION
Signed-off-by: Dominic Fischer <dominicfischer7@gmail.com>

### Pull Request Checklist

<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/riotX-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->

- [ ] Changes has been tested on an Android device or Android emulator with API 16
- [ ] UI change has been tested on both light and dark themes
- [x] Pull request is based on the develop branch
- [ ] Pull request updates [CHANGES.md](https://github.com/vector-im/riotX-android/blob/develop/CHANGES.md)
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#sign-off)

Similar to my other PR. We should recycle threads from the `kotlinx.coroutines` threadpool. Less memory ..... and stuff.