### PR TITLE
Remove unnecessary usage of TaskExecutor

### DIFF
--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/SessionComponent.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/SessionComponent.kt
@@ -44,6 +44,7 @@ import im.vector.matrix.android.internal.session.sync.job.SyncWorker
 import im.vector.matrix.android.internal.session.user.UserModule
 import im.vector.matrix.android.internal.session.user.accountdata.AccountDataModule
 import im.vector.matrix.android.internal.task.TaskExecutor
+import im.vector.matrix.android.internal.util.MatrixCoroutineDispatchers
 
 @Component(dependencies = [MatrixComponent::class],
            modules = [
@@ -74,6 +75,8 @@ internal interface SessionComponent {
     fun networkConnectivityChecker(): NetworkConnectivityChecker
 
     fun taskExecutor(): TaskExecutor
+
+    fun dispatchers(): MatrixCoroutineDispatchers
 
     fun inject(sendEventWorker: SendEventWorker)
 


### PR DESCRIPTION
Signed-off-by: Dominic Fischer <dominicfischer7@gmail.com>

### Pull Request Checklist

<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/riotX-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->

- [ ] Changes has been tested on an Android device or Android emulator with API 16
- [ ] UI change has been tested on both light and dark themes
- [x] Pull request is based on the develop branch
- [ ] Pull request updates [CHANGES.md](https://github.com/vector-im/riotX-android/blob/develop/CHANGES.md)
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#sign-off)

So this PR simplifies some of the code where a `TaskExcecutor` was not required.

~NB: In `SyncWorker`, I removed the global `Cancellable` because `cancelUniqueWork` will now be able to properly cancel the running worker, since it suspends instead of blocking.~ Fixed in PR #460 