### PR TITLE
Remove Try from Tasks

### DIFF
--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/CryptoManager.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/CryptoManager.kt
@@ -689,8 +689,7 @@ internal class CryptoManager @Inject constructor(
     private fun onRoomEncryptionEvent(roomId: String, event: Event) {
         GlobalScope.launch(coroutineDispatchers.crypto) {
             val params = LoadRoomMembersTask.Params(roomId)
-            loadRoomMembersTask
-                    .execute(params)
+            Try { loadRoomMembersTask.execute(params) }
                     .map { _ ->
                         val userIds = getRoomUserIds(roomId)
                         setEncryptionInRoom(roomId, event.content?.get("algorithm")?.toString(), true, userIds)
@@ -770,7 +769,7 @@ internal class CryptoManager @Inject constructor(
         // For now, we set the device id explicitly, as we may not be using the
         // same one as used in login.
         val uploadDeviceKeysParams = UploadKeysTask.Params(getMyDevice().toDeviceKeys(), null, getMyDevice().deviceId)
-        return uploadKeysTask.execute(uploadDeviceKeysParams)
+        return Try { uploadKeysTask.execute(uploadDeviceKeysParams) }
     }
 
     /**

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/DeviceListManager.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/DeviceListManager.kt
@@ -295,7 +295,7 @@ internal class DeviceListManager @Inject constructor(private val cryptoStore: IM
             return Try.just(MXUsersDevicesMap())
         }
         val params = DownloadKeysForUsersTask.Params(filteredUsers, syncTokenStore.getLastToken())
-        return downloadKeysForUsersTask.execute(params)
+        return Try { downloadKeysForUsersTask.execute(params) }
                 .map { response ->
                     Timber.v("## doKeyDownloadForUsers() : Got keys for " + filteredUsers.size + " users")
                     for (userId in filteredUsers) {

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/OneTimeKeysUploader.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/OneTimeKeysUploader.kt
@@ -86,7 +86,7 @@ internal class OneTimeKeysUploader @Inject constructor(
         } else {
             // ask the server how many keys we have
             val uploadKeysParams = UploadKeysTask.Params(null, null, credentials.deviceId!!)
-            uploadKeysTask.execute(uploadKeysParams)
+            Try { uploadKeysTask.execute(uploadKeysParams) }
                     .flatMap {
                         // We need to keep a pool of one time public keys on the server so that
                         // other devices can start conversations with us. But we can only store
@@ -169,8 +169,7 @@ internal class OneTimeKeysUploader @Inject constructor(
         // For now, we set the device id explicitly, as we may not be using the
         // same one as used in login.
         val uploadParams = UploadKeysTask.Params(null, oneTimeJson, credentials.deviceId!!)
-        return uploadKeysTask
-                .execute(uploadParams)
+        return Try { uploadKeysTask.execute(uploadParams) }
                 .map {
                     lastPublishedOneTimeKeys = oneTimeKeys
                     olmDevice.markKeysAsPublished()

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/actions/EnsureOlmSessionsForDevicesAction.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/actions/EnsureOlmSessionsForDevicesAction.kt
@@ -79,8 +79,7 @@ internal class EnsureOlmSessionsForDevicesAction @Inject constructor(private val
         Timber.v("## claimOneTimeKeysForUsersDevices() : $usersDevicesToClaim")
 
         val claimParams = ClaimOneTimeKeysForUsersDeviceTask.Params(usersDevicesToClaim)
-        return oneTimeKeysForUsersDeviceTask
-                .execute(claimParams)
+        return Try { oneTimeKeysForUsersDeviceTask.execute(claimParams) }
                 .map {
                     Timber.v("## claimOneTimeKeysForUsersDevices() : keysClaimResponse.oneTimeKeys: $it")
                     for (userId in userIds) {

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/algorithms/megolm/MXMegolmDecryption.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/algorithms/megolm/MXMegolmDecryption.kt
@@ -351,7 +351,7 @@ internal class MXMegolmDecryption(private val credentials: Credentials,
                                         sendToDeviceMap.setObject(userId, deviceId, encodedPayload)
                                         Timber.v("## shareKeysWithDevice() : sending to $userId:$deviceId")
                                         val sendToDeviceParams = SendToDeviceTask.Params(EventType.ENCRYPTED, sendToDeviceMap)
-                                        sendToDeviceTask.execute(sendToDeviceParams)
+                                        Try { sendToDeviceTask.execute(sendToDeviceParams) }
                                     }
                         }
                     }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/algorithms/megolm/MXMegolmEncryption.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/algorithms/megolm/MXMegolmEncryption.kt
@@ -217,7 +217,7 @@ internal class MXMegolmEncryption(
                             }
                             Timber.v("## shareUserDevicesKey() : Sharing keys with device $userId:$deviceID")
                             //noinspection ArraysAsListWithZeroOrOneArgument,ArraysAsListWithZeroOrOneArgument
-                            contentMap.setObject(userId, deviceID, messageEncrypter.encryptMessage(payload, Arrays.asList(sessionResult.deviceInfo)))
+                            contentMap.setObject(userId, deviceID, messageEncrypter.encryptMessage(payload, listOf(sessionResult.deviceInfo)))
                             haveTargets = true
                         }
                     }
@@ -225,7 +225,7 @@ internal class MXMegolmEncryption(
                         t0 = System.currentTimeMillis()
                         Timber.v("## shareUserDevicesKey() : has target")
                         val sendToDeviceParams = SendToDeviceTask.Params(EventType.ENCRYPTED, contentMap)
-                        sendToDeviceTask.execute(sendToDeviceParams)
+                        Try { sendToDeviceTask.execute(sendToDeviceParams) }
                                 .map {
                                     Timber.v("## shareUserDevicesKey() : sendToDevice succeeds after "
                                             + (System.currentTimeMillis() - t0) + " ms")

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/keysbackup/KeysBackup.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/keysbackup/KeysBackup.kt
@@ -355,10 +355,8 @@ internal class KeysBackup @Inject constructor(
                                     callback: MatrixCallback<KeysBackupVersionTrust>) {
         // TODO Validate with François that this is correct
         object : Task<KeysVersionResult, KeysBackupVersionTrust> {
-            override suspend fun execute(params: KeysVersionResult): Try<KeysBackupVersionTrust> {
-                return Try {
-                    getKeysBackupTrustBg(params)
-                }
+            override suspend fun execute(params: KeysVersionResult): KeysBackupVersionTrust {
+                return getKeysBackupTrustBg(params)
             }
         }
                 .configureWith(keysBackupVersion)

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/keysbackup/tasks/CreateKeysBackupVersionTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/keysbackup/tasks/CreateKeysBackupVersionTask.kt
@@ -16,7 +16,6 @@
 
 package im.vector.matrix.android.internal.crypto.keysbackup.tasks
 
-import arrow.core.Try
 import im.vector.matrix.android.internal.crypto.keysbackup.api.RoomKeysApi
 import im.vector.matrix.android.internal.crypto.keysbackup.model.rest.CreateKeysBackupVersionBody
 import im.vector.matrix.android.internal.crypto.keysbackup.model.rest.KeysVersion
@@ -30,7 +29,7 @@ internal class DefaultCreateKeysBackupVersionTask @Inject constructor(private va
     : CreateKeysBackupVersionTask {
 
 
-    override suspend fun execute(params: CreateKeysBackupVersionBody): Try<KeysVersion> {
+    override suspend fun execute(params: CreateKeysBackupVersionBody): KeysVersion {
         return executeRequest {
             apiCall = roomKeysApi.createKeysBackupVersion(params)
         }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/keysbackup/tasks/DeleteBackupTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/keysbackup/tasks/DeleteBackupTask.kt
@@ -16,7 +16,6 @@
 
 package im.vector.matrix.android.internal.crypto.keysbackup.tasks
 
-import arrow.core.Try
 import im.vector.matrix.android.internal.crypto.keysbackup.api.RoomKeysApi
 import im.vector.matrix.android.internal.network.executeRequest
 import im.vector.matrix.android.internal.session.SessionScope
@@ -33,8 +32,8 @@ internal interface DeleteBackupTask : Task<DeleteBackupTask.Params, Unit> {
 internal class DefaultDeleteBackupTask @Inject constructor(private val roomKeysApi: RoomKeysApi)
     : DeleteBackupTask {
 
-    override suspend fun execute(params: DeleteBackupTask.Params): Try<Unit> {
-        return executeRequest {
+    override suspend fun execute(params: DeleteBackupTask.Params) {
+        executeRequest<Unit> {
             apiCall = roomKeysApi.deleteBackup(
                     params.version)
         }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/keysbackup/tasks/DeleteRoomSessionDataTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/keysbackup/tasks/DeleteRoomSessionDataTask.kt
@@ -34,8 +34,8 @@ internal interface DeleteRoomSessionDataTask : Task<DeleteRoomSessionDataTask.Pa
 internal class DefaultDeleteRoomSessionDataTask @Inject constructor(private val roomKeysApi: RoomKeysApi)
     : DeleteRoomSessionDataTask {
 
-    override suspend fun execute(params: DeleteRoomSessionDataTask.Params): Try<Unit> {
-        return executeRequest {
+    override suspend fun execute(params: DeleteRoomSessionDataTask.Params) {
+        executeRequest<Unit> {
             apiCall = roomKeysApi.deleteRoomSessionData(
                     params.roomId,
                     params.sessionId,

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/keysbackup/tasks/DeleteRoomSessionsDataTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/keysbackup/tasks/DeleteRoomSessionsDataTask.kt
@@ -16,7 +16,6 @@
 
 package im.vector.matrix.android.internal.crypto.keysbackup.tasks
 
-import arrow.core.Try
 import im.vector.matrix.android.internal.crypto.keysbackup.api.RoomKeysApi
 import im.vector.matrix.android.internal.network.executeRequest
 import im.vector.matrix.android.internal.session.SessionScope
@@ -33,8 +32,8 @@ internal interface DeleteRoomSessionsDataTask : Task<DeleteRoomSessionsDataTask.
 internal class DefaultDeleteRoomSessionsDataTask @Inject constructor(private val roomKeysApi: RoomKeysApi)
     : DeleteRoomSessionsDataTask {
 
-    override suspend fun execute(params: DeleteRoomSessionsDataTask.Params): Try<Unit> {
-        return executeRequest {
+    override suspend fun execute(params: DeleteRoomSessionsDataTask.Params) {
+        executeRequest<Unit> {
             apiCall = roomKeysApi.deleteRoomSessionsData(
                     params.roomId,
                     params.version)

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/keysbackup/tasks/DeleteSessionsDataTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/keysbackup/tasks/DeleteSessionsDataTask.kt
@@ -16,7 +16,6 @@
 
 package im.vector.matrix.android.internal.crypto.keysbackup.tasks
 
-import arrow.core.Try
 import im.vector.matrix.android.internal.crypto.keysbackup.api.RoomKeysApi
 import im.vector.matrix.android.internal.network.executeRequest
 import im.vector.matrix.android.internal.session.SessionScope
@@ -32,8 +31,8 @@ internal interface DeleteSessionsDataTask : Task<DeleteSessionsDataTask.Params, 
 internal class DefaultDeleteSessionsDataTask @Inject constructor(private val roomKeysApi: RoomKeysApi)
     : DeleteSessionsDataTask {
 
-    override suspend fun execute(params: DeleteSessionsDataTask.Params): Try<Unit> {
-        return executeRequest {
+    override suspend fun execute(params: DeleteSessionsDataTask.Params) {
+        executeRequest<Unit> {
             apiCall = roomKeysApi.deleteSessionsData(
                     params.version)
         }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/keysbackup/tasks/GetKeysBackupLastVersionTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/keysbackup/tasks/GetKeysBackupLastVersionTask.kt
@@ -16,7 +16,6 @@
 
 package im.vector.matrix.android.internal.crypto.keysbackup.tasks
 
-import arrow.core.Try
 import im.vector.matrix.android.internal.crypto.keysbackup.api.RoomKeysApi
 import im.vector.matrix.android.internal.crypto.keysbackup.model.rest.KeysVersionResult
 import im.vector.matrix.android.internal.network.executeRequest
@@ -29,7 +28,7 @@ internal class DefaultGetKeysBackupLastVersionTask @Inject constructor(private v
     : GetKeysBackupLastVersionTask {
 
 
-    override suspend fun execute(params: Unit): Try<KeysVersionResult> {
+    override suspend fun execute(params: Unit): KeysVersionResult {
         return executeRequest {
             apiCall = roomKeysApi.getKeysBackupLastVersion()
         }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/keysbackup/tasks/GetKeysBackupVersionTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/keysbackup/tasks/GetKeysBackupVersionTask.kt
@@ -16,7 +16,6 @@
 
 package im.vector.matrix.android.internal.crypto.keysbackup.tasks
 
-import arrow.core.Try
 import im.vector.matrix.android.internal.crypto.keysbackup.api.RoomKeysApi
 import im.vector.matrix.android.internal.crypto.keysbackup.model.rest.KeysVersionResult
 import im.vector.matrix.android.internal.network.executeRequest
@@ -29,7 +28,7 @@ internal class DefaultGetKeysBackupVersionTask @Inject constructor(private val r
     : GetKeysBackupVersionTask {
 
 
-    override suspend fun execute(params: String): Try<KeysVersionResult> {
+    override suspend fun execute(params: String): KeysVersionResult {
         return executeRequest {
             apiCall = roomKeysApi.getKeysBackupVersion(params)
         }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/keysbackup/tasks/GetRoomSessionDataTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/keysbackup/tasks/GetRoomSessionDataTask.kt
@@ -16,7 +16,6 @@
 
 package im.vector.matrix.android.internal.crypto.keysbackup.tasks
 
-import arrow.core.Try
 import im.vector.matrix.android.internal.crypto.keysbackup.api.RoomKeysApi
 import im.vector.matrix.android.internal.crypto.keysbackup.model.rest.KeyBackupData
 import im.vector.matrix.android.internal.network.executeRequest
@@ -35,7 +34,7 @@ internal interface GetRoomSessionDataTask : Task<GetRoomSessionDataTask.Params, 
 internal class DefaultGetRoomSessionDataTask @Inject constructor(private val roomKeysApi: RoomKeysApi)
     : GetRoomSessionDataTask {
 
-    override suspend fun execute(params: GetRoomSessionDataTask.Params): Try<KeyBackupData> {
+    override suspend fun execute(params: GetRoomSessionDataTask.Params): KeyBackupData {
         return executeRequest {
             apiCall = roomKeysApi.getRoomSessionData(
                     params.roomId,

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/keysbackup/tasks/GetRoomSessionsDataTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/keysbackup/tasks/GetRoomSessionsDataTask.kt
@@ -16,7 +16,6 @@
 
 package im.vector.matrix.android.internal.crypto.keysbackup.tasks
 
-import arrow.core.Try
 import im.vector.matrix.android.internal.crypto.keysbackup.api.RoomKeysApi
 import im.vector.matrix.android.internal.crypto.keysbackup.model.rest.RoomKeysBackupData
 import im.vector.matrix.android.internal.network.executeRequest
@@ -35,7 +34,7 @@ internal interface GetRoomSessionsDataTask : Task<GetRoomSessionsDataTask.Params
 internal class DefaultGetRoomSessionsDataTask @Inject constructor(private val roomKeysApi: RoomKeysApi)
     : GetRoomSessionsDataTask {
 
-    override suspend fun execute(params: GetRoomSessionsDataTask.Params): Try<RoomKeysBackupData> {
+    override suspend fun execute(params: GetRoomSessionsDataTask.Params): RoomKeysBackupData {
         return executeRequest {
             apiCall = roomKeysApi.getRoomSessionsData(
                     params.roomId,

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/keysbackup/tasks/GetSessionsDataTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/keysbackup/tasks/GetSessionsDataTask.kt
@@ -16,7 +16,6 @@
 
 package im.vector.matrix.android.internal.crypto.keysbackup.tasks
 
-import arrow.core.Try
 import im.vector.matrix.android.internal.crypto.keysbackup.api.RoomKeysApi
 import im.vector.matrix.android.internal.crypto.keysbackup.model.rest.KeysBackupData
 import im.vector.matrix.android.internal.network.executeRequest
@@ -33,7 +32,7 @@ internal interface GetSessionsDataTask : Task<GetSessionsDataTask.Params, KeysBa
 internal class DefaultGetSessionsDataTask @Inject constructor(private val roomKeysApi: RoomKeysApi)
     : GetSessionsDataTask {
 
-    override suspend fun execute(params: GetSessionsDataTask.Params): Try<KeysBackupData> {
+    override suspend fun execute(params: GetSessionsDataTask.Params): KeysBackupData {
         return executeRequest {
             apiCall = roomKeysApi.getSessionsData(
                     params.version)

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/keysbackup/tasks/StoreRoomSessionDataTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/keysbackup/tasks/StoreRoomSessionDataTask.kt
@@ -16,7 +16,6 @@
 
 package im.vector.matrix.android.internal.crypto.keysbackup.tasks
 
-import arrow.core.Try
 import im.vector.matrix.android.internal.crypto.keysbackup.api.RoomKeysApi
 import im.vector.matrix.android.internal.crypto.keysbackup.model.rest.KeyBackupData
 import im.vector.matrix.android.internal.crypto.keysbackup.model.rest.BackupKeysResult
@@ -37,7 +36,7 @@ internal interface StoreRoomSessionDataTask : Task<StoreRoomSessionDataTask.Para
 internal class DefaultStoreRoomSessionDataTask @Inject constructor(private val roomKeysApi: RoomKeysApi)
     : StoreRoomSessionDataTask {
 
-    override suspend fun execute(params: StoreRoomSessionDataTask.Params): Try<BackupKeysResult> {
+    override suspend fun execute(params: StoreRoomSessionDataTask.Params): BackupKeysResult {
         return executeRequest {
             apiCall = roomKeysApi.storeRoomSessionData(
                     params.roomId,

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/keysbackup/tasks/StoreRoomSessionsDataTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/keysbackup/tasks/StoreRoomSessionsDataTask.kt
@@ -16,7 +16,6 @@
 
 package im.vector.matrix.android.internal.crypto.keysbackup.tasks
 
-import arrow.core.Try
 import im.vector.matrix.android.internal.crypto.keysbackup.api.RoomKeysApi
 import im.vector.matrix.android.internal.crypto.keysbackup.model.rest.RoomKeysBackupData
 import im.vector.matrix.android.internal.crypto.keysbackup.model.rest.BackupKeysResult
@@ -36,7 +35,7 @@ internal interface StoreRoomSessionsDataTask : Task<StoreRoomSessionsDataTask.Pa
 internal class DefaultStoreRoomSessionsDataTask @Inject constructor(private val roomKeysApi: RoomKeysApi)
     : StoreRoomSessionsDataTask {
 
-    override suspend fun execute(params: StoreRoomSessionsDataTask.Params): Try<BackupKeysResult> {
+    override suspend fun execute(params: StoreRoomSessionsDataTask.Params): BackupKeysResult {
         return executeRequest {
             apiCall = roomKeysApi.storeRoomSessionsData(
                     params.roomId,

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/keysbackup/tasks/StoreSessionsDataTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/keysbackup/tasks/StoreSessionsDataTask.kt
@@ -16,7 +16,6 @@
 
 package im.vector.matrix.android.internal.crypto.keysbackup.tasks
 
-import arrow.core.Try
 import im.vector.matrix.android.internal.crypto.keysbackup.api.RoomKeysApi
 import im.vector.matrix.android.internal.crypto.keysbackup.model.rest.KeysBackupData
 import im.vector.matrix.android.internal.crypto.keysbackup.model.rest.BackupKeysResult
@@ -35,7 +34,7 @@ internal interface StoreSessionsDataTask : Task<StoreSessionsDataTask.Params, Ba
 internal class DefaultStoreSessionsDataTask @Inject constructor(private val roomKeysApi: RoomKeysApi)
     : StoreSessionsDataTask {
 
-    override suspend fun execute(params: StoreSessionsDataTask.Params): Try<BackupKeysResult> {
+    override suspend fun execute(params: StoreSessionsDataTask.Params): BackupKeysResult {
         return executeRequest {
             apiCall = roomKeysApi.storeSessionsData(
                     params.version,

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/keysbackup/tasks/UpdateKeysBackupVersionTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/keysbackup/tasks/UpdateKeysBackupVersionTask.kt
@@ -16,7 +16,6 @@
 
 package im.vector.matrix.android.internal.crypto.keysbackup.tasks
 
-import arrow.core.Try
 import im.vector.matrix.android.internal.crypto.keysbackup.api.RoomKeysApi
 import im.vector.matrix.android.internal.crypto.keysbackup.model.rest.UpdateKeysBackupVersionBody
 import im.vector.matrix.android.internal.network.executeRequest
@@ -34,7 +33,7 @@ internal class DefaultUpdateKeysBackupVersionTask @Inject constructor(private va
     : UpdateKeysBackupVersionTask {
 
 
-    override suspend fun execute(params: UpdateKeysBackupVersionTask.Params): Try<Unit> {
+    override suspend fun execute(params: UpdateKeysBackupVersionTask.Params) {
         return executeRequest {
             apiCall = roomKeysApi.updateKeysBackupVersion(params.version, params.keysBackupVersionBody)
         }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/tasks/ClaimOneTimeKeysForUsersDeviceTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/tasks/ClaimOneTimeKeysForUsersDeviceTask.kt
@@ -16,7 +16,6 @@
 
 package im.vector.matrix.android.internal.crypto.tasks
 
-import arrow.core.Try
 import im.vector.matrix.android.internal.crypto.api.CryptoApi
 import im.vector.matrix.android.internal.crypto.model.MXKey
 import im.vector.matrix.android.internal.crypto.model.MXUsersDevicesMap
@@ -37,35 +36,35 @@ internal interface ClaimOneTimeKeysForUsersDeviceTask : Task<ClaimOneTimeKeysFor
 internal class DefaultClaimOneTimeKeysForUsersDevice @Inject constructor(private val cryptoApi: CryptoApi)
     : ClaimOneTimeKeysForUsersDeviceTask {
 
-    override suspend fun execute(params: ClaimOneTimeKeysForUsersDeviceTask.Params): Try<MXUsersDevicesMap<MXKey>> {
+    override suspend fun execute(params: ClaimOneTimeKeysForUsersDeviceTask.Params): MXUsersDevicesMap<MXKey> {
         val body = KeysClaimBody(oneTimeKeys = params.usersDevicesKeyTypesMap.map)
 
-        return executeRequest<KeysClaimResponse> {
-            apiCall = cryptoApi.claimOneTimeKeysForUsersDevices(body)
-        }.flatMap { keysClaimResponse ->
-            Try {
-                val map = MXUsersDevicesMap<MXKey>()
+        return runCatching {
+            executeRequest<KeysClaimResponse> {
+                apiCall = cryptoApi.claimOneTimeKeysForUsersDevices(body)
+            }
+        }.mapCatching { keysClaimResponse ->
+            val map = MXUsersDevicesMap<MXKey>()
 
-                keysClaimResponse.oneTimeKeys?.let { oneTimeKeys ->
-                    for (userId in oneTimeKeys.keys) {
-                        val mapByUserId = oneTimeKeys[userId]
+            keysClaimResponse.oneTimeKeys?.let { oneTimeKeys ->
+                for (userId in oneTimeKeys.keys) {
+                    val mapByUserId = oneTimeKeys[userId]
 
-                        if (mapByUserId != null) {
-                            for (deviceId in mapByUserId.keys) {
-                                val mxKey = MXKey.from(mapByUserId[deviceId])
+                    if (mapByUserId != null) {
+                        for (deviceId in mapByUserId.keys) {
+                            val mxKey = MXKey.from(mapByUserId[deviceId])
 
-                                if (mxKey != null) {
-                                    map.setObject(userId, deviceId, mxKey)
-                                } else {
-                                    Timber.e("## claimOneTimeKeysForUsersDevices : fail to create a MXKey")
-                                }
+                            if (mxKey != null) {
+                                map.setObject(userId, deviceId, mxKey)
+                            } else {
+                                Timber.e("## claimOneTimeKeysForUsersDevices : fail to create a MXKey")
                             }
                         }
                     }
                 }
-
-                map
             }
-        }
+
+            map
+        }.getOrThrow()
     }
 }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/tasks/DeleteDeviceWithUserPasswordTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/tasks/DeleteDeviceWithUserPasswordTask.kt
@@ -16,7 +16,6 @@
 
 package im.vector.matrix.android.internal.crypto.tasks
 
-import arrow.core.Try
 import im.vector.matrix.android.api.auth.data.Credentials
 import im.vector.matrix.android.internal.auth.data.LoginFlowTypes
 import im.vector.matrix.android.internal.crypto.api.CryptoApi
@@ -38,8 +37,8 @@ internal class DefaultDeleteDeviceWithUserPasswordTask @Inject constructor(priva
                                                                            private val credentials: Credentials)
     : DeleteDeviceWithUserPasswordTask {
 
-    override suspend fun execute(params: DeleteDeviceWithUserPasswordTask.Params): Try<Unit> {
-        return executeRequest {
+    override suspend fun execute(params: DeleteDeviceWithUserPasswordTask.Params) {
+        executeRequest<Unit> {
             apiCall = cryptoApi.deleteDevice(params.deviceId, DeleteDeviceParams()
                     .apply {
                         deleteDeviceAuth = DeleteDeviceAuth()

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/tasks/DownloadKeysForUsersTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/tasks/DownloadKeysForUsersTask.kt
@@ -17,7 +17,6 @@
 package im.vector.matrix.android.internal.crypto.tasks
 
 import android.text.TextUtils
-import arrow.core.Try
 import im.vector.matrix.android.internal.crypto.api.CryptoApi
 import im.vector.matrix.android.internal.crypto.model.rest.KeysQueryBody
 import im.vector.matrix.android.internal.crypto.model.rest.KeysQueryResponse
@@ -38,7 +37,7 @@ internal interface DownloadKeysForUsersTask : Task<DownloadKeysForUsersTask.Para
 internal class DefaultDownloadKeysForUsers @Inject constructor(private val cryptoApi: CryptoApi)
     : DownloadKeysForUsersTask {
 
-    override suspend fun execute(params: DownloadKeysForUsersTask.Params): Try<KeysQueryResponse> {
+    override suspend fun execute(params: DownloadKeysForUsersTask.Params): KeysQueryResponse {
         val downloadQuery = HashMap<String, Map<String, Any>>()
 
         if (null != params.userIds) {

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/tasks/GetDevicesTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/tasks/GetDevicesTask.kt
@@ -16,7 +16,6 @@
 
 package im.vector.matrix.android.internal.crypto.tasks
 
-import arrow.core.Try
 import im.vector.matrix.android.internal.crypto.api.CryptoApi
 import im.vector.matrix.android.internal.crypto.model.rest.DevicesListResponse
 import im.vector.matrix.android.internal.network.executeRequest
@@ -29,7 +28,7 @@ internal interface GetDevicesTask : Task<Unit, DevicesListResponse>
 internal class DefaultGetDevicesTask @Inject constructor(private val cryptoApi: CryptoApi)
     : GetDevicesTask {
 
-    override suspend fun execute(params: Unit): Try<DevicesListResponse> {
+    override suspend fun execute(params: Unit): DevicesListResponse {
         return executeRequest {
             apiCall = cryptoApi.getDevices()
         }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/tasks/GetKeyChangesTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/tasks/GetKeyChangesTask.kt
@@ -16,7 +16,6 @@
 
 package im.vector.matrix.android.internal.crypto.tasks
 
-import arrow.core.Try
 import im.vector.matrix.android.internal.crypto.api.CryptoApi
 import im.vector.matrix.android.internal.crypto.model.rest.KeyChangesResponse
 import im.vector.matrix.android.internal.network.executeRequest
@@ -36,7 +35,7 @@ internal interface GetKeyChangesTask : Task<GetKeyChangesTask.Params, KeyChanges
 internal class DefaultGetKeyChangesTask @Inject constructor(private val cryptoApi: CryptoApi)
     : GetKeyChangesTask {
 
-    override suspend fun execute(params: GetKeyChangesTask.Params): Try<KeyChangesResponse> {
+    override suspend fun execute(params: GetKeyChangesTask.Params): KeyChangesResponse {
         return executeRequest {
             apiCall = cryptoApi.getKeyChanges(params.from,
                     params.to)

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/tasks/SendToDeviceTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/tasks/SendToDeviceTask.kt
@@ -16,7 +16,6 @@
 
 package im.vector.matrix.android.internal.crypto.tasks
 
-import arrow.core.Try
 import im.vector.matrix.android.internal.crypto.api.CryptoApi
 import im.vector.matrix.android.internal.crypto.model.MXUsersDevicesMap
 import im.vector.matrix.android.internal.crypto.model.rest.SendToDeviceBody
@@ -40,7 +39,7 @@ internal interface SendToDeviceTask : Task<SendToDeviceTask.Params, Unit> {
 internal class DefaultSendToDeviceTask @Inject constructor(private val cryptoApi: CryptoApi)
     : SendToDeviceTask {
 
-    override suspend fun execute(params: SendToDeviceTask.Params): Try<Unit> {
+    override suspend fun execute(params: SendToDeviceTask.Params) {
         val sendToDeviceBody = SendToDeviceBody()
         sendToDeviceBody.messages = params.contentMap.map
 

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/tasks/SetDeviceNameTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/tasks/SetDeviceNameTask.kt
@@ -17,7 +17,6 @@
 package im.vector.matrix.android.internal.crypto.tasks
 
 import android.text.TextUtils
-import arrow.core.Try
 import im.vector.matrix.android.internal.crypto.api.CryptoApi
 import im.vector.matrix.android.internal.crypto.model.rest.UpdateDeviceInfoBody
 import im.vector.matrix.android.internal.network.executeRequest
@@ -37,7 +36,7 @@ internal interface SetDeviceNameTask : Task<SetDeviceNameTask.Params, Unit> {
 internal class DefaultSetDeviceNameTask @Inject constructor(private val cryptoApi: CryptoApi)
     : SetDeviceNameTask {
 
-    override suspend fun execute(params: SetDeviceNameTask.Params): Try<Unit> {
+    override suspend fun execute(params: SetDeviceNameTask.Params) {
         val body = UpdateDeviceInfoBody(
                 displayName = if (TextUtils.isEmpty(params.deviceName)) "" else params.deviceName
         )

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/tasks/UploadKeysTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/tasks/UploadKeysTask.kt
@@ -16,7 +16,6 @@
 
 package im.vector.matrix.android.internal.crypto.tasks
 
-import arrow.core.Try
 import im.vector.matrix.android.api.util.JsonDict
 import im.vector.matrix.android.internal.crypto.api.CryptoApi
 import im.vector.matrix.android.internal.crypto.model.rest.KeysUploadResponse
@@ -41,7 +40,7 @@ internal interface UploadKeysTask : Task<UploadKeysTask.Params, KeysUploadRespon
 internal class DefaultUploadKeysTask @Inject constructor(private val cryptoApi: CryptoApi)
     : UploadKeysTask {
 
-    override suspend fun execute(params: UploadKeysTask.Params): Try<KeysUploadResponse> {
+    override suspend fun execute(params: UploadKeysTask.Params): KeysUploadResponse {
         val encodedDeviceId = convertToUTF8(params.deviceId)
 
         val body = KeysUploadBody()

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/network/Request.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/network/Request.kt
@@ -16,9 +16,6 @@
 
 package im.vector.matrix.android.internal.network
 
-import arrow.core.Try
-import arrow.core.failure
-import arrow.core.recoverWith
 import com.squareup.moshi.JsonDataException
 import com.squareup.moshi.Moshi
 import im.vector.matrix.android.api.failure.Failure
@@ -36,8 +33,8 @@ internal class Request<DATA> {
     private val moshi: Moshi = MoshiProvider.providesMoshi()
     lateinit var apiCall: Call<DATA>
 
-    suspend fun execute(): Try<DATA> {
-        return Try {
+    suspend fun execute(): DATA {
+        return try {
             val response = apiCall.awaitResponse()
             if (response.isSuccessful) {
                 response.body()
@@ -45,13 +42,13 @@ internal class Request<DATA> {
             } else {
                 throw manageFailure(response.errorBody(), response.code())
             }
-        }.recoverWith {
-            when (it) {
+        } catch (it: Throwable) {
+            throw when (it) {
                 is IOException              -> Failure.NetworkConnection(it)
                 is Failure.ServerError,
                 is Failure.OtherServerError -> it
                 else                        -> Failure.Unknown(it)
-            }.failure()
+            }
         }
     }
 

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/cache/ClearCacheTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/cache/ClearCacheTask.kt
@@ -16,7 +16,6 @@
 
 package im.vector.matrix.android.internal.session.cache
 
-import arrow.core.Try
 import im.vector.matrix.android.internal.session.SessionScope
 import im.vector.matrix.android.internal.task.Task
 import io.realm.Realm
@@ -28,15 +27,13 @@ internal interface ClearCacheTask : Task<Unit, Unit>
 
 internal class RealmClearCacheTask @Inject constructor(private val realmConfiguration: RealmConfiguration) : ClearCacheTask {
 
-    override suspend fun execute(params: Unit): Try<Unit> {
-        return Try {
-            val realm = Realm.getInstance(realmConfiguration)
+    override suspend fun execute(params: Unit) {
+        val realm = Realm.getInstance(realmConfiguration)
 
-            realm.executeTransaction {
-                it.deleteAll()
-            }
-
-            realm.close()
+        realm.executeTransaction {
+            it.deleteAll()
         }
+
+        realm.close()
     }
 }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/filter/DefaultSaveFilterTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/filter/DefaultSaveFilterTask.kt
@@ -16,7 +16,6 @@
 
 package im.vector.matrix.android.internal.session.filter
 
-import arrow.core.Try
 import im.vector.matrix.android.api.auth.data.SessionParams
 import im.vector.matrix.android.internal.network.executeRequest
 import im.vector.matrix.android.internal.task.Task
@@ -39,15 +38,12 @@ internal class DefaultSaveFilterTask @Inject constructor(private val sessionPara
                                                          private val filterRepository: FilterRepository
 ) : SaveFilterTask {
 
-    override suspend fun execute(params: SaveFilterTask.Params): Try<Unit> {
-        return executeRequest<FilterResponse> {
+    override suspend fun execute(params: SaveFilterTask.Params) {
+        val filterResponse = executeRequest<FilterResponse> {
             // TODO auto retry
             apiCall = filterAPI.uploadFilter(sessionParams.credentials.userId, params.filter)
-        }.flatMap { filterResponse ->
-            Try {
-                filterRepository.storeFilterId(params.filter, filterResponse.filterId)
-            }
         }
+        filterRepository.storeFilterId(params.filter, filterResponse.filterId)
     }
 
 }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/group/GetGroupDataWorker.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/group/GetGroupDataWorker.kt
@@ -19,7 +19,6 @@ package im.vector.matrix.android.internal.session.group
 import android.content.Context
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
-import arrow.core.Try
 import com.squareup.moshi.JsonClass
 import im.vector.matrix.android.internal.worker.SessionWorkerParams
 import im.vector.matrix.android.internal.worker.WorkerParamsFactory
@@ -45,14 +44,14 @@ internal class GetGroupDataWorker(context: Context, params: WorkerParameters) : 
         sessionComponent.inject(this)
 
         val results = params.groupIds.map { groupId ->
-            fetchGroupData(groupId)
+            runCatching { fetchGroupData(groupId) }
         }
-        val isSuccessful = results.none { it.isFailure() }
+        val isSuccessful = results.none { it.isFailure }
         return if (isSuccessful) Result.success() else Result.retry()
     }
 
-    private suspend fun fetchGroupData(groupId: String): Try<Unit> {
-        return getGroupDataTask.execute(GetGroupDataTask.Params(groupId))
+    private suspend fun fetchGroupData(groupId: String) {
+        getGroupDataTask.execute(GetGroupDataTask.Params(groupId))
     }
 
 }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/notification/ProcessEventForPushTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/notification/ProcessEventForPushTask.kt
@@ -16,7 +16,6 @@
 
 package im.vector.matrix.android.internal.session.notification
 
-import arrow.core.Try
 import im.vector.matrix.android.api.auth.data.SessionParams
 import im.vector.matrix.android.api.pushrules.rest.PushRule
 import im.vector.matrix.android.api.session.events.model.Event
@@ -42,47 +41,45 @@ internal class DefaultProcessEventForPushTask @Inject constructor(
 ) : ProcessEventForPushTask {
 
 
-    override suspend fun execute(params: ProcessEventForPushTask.Params): Try<Unit> {
-        return Try {
-            // Handle left rooms
-            params.syncResponse.leave.keys.forEach {
-                defaultPushRuleService.dispatchRoomLeft(it)
-            }
-            val newJoinEvents = params.syncResponse.join
-                    .map { entries ->
-                        entries.value.timeline?.events?.map { it.copy(roomId = entries.key) }
-                    }
-                    .fold(emptyList<Event>(), { acc, next ->
-                        acc + (next ?: emptyList())
-                    })
-            val inviteEvents = params.syncResponse.invite
-                    .map { entries ->
-                        entries.value.inviteState?.events?.map { it.copy(roomId = entries.key) }
-                    }
-                    .fold(emptyList<Event>(), { acc, next ->
-                        acc + (next ?: emptyList())
-                    })
-            val allEvents = (newJoinEvents + inviteEvents).filter { event ->
-                when (event.type) {
-                    EventType.MESSAGE,
-                    EventType.REDACTION,
-                    EventType.ENCRYPTED,
-                    EventType.STATE_ROOM_MEMBER -> true
-                    else                        -> false
-                }
-            }.filter {
-                it.senderId != sessionParams.credentials.userId
-            }
-            Timber.v("[PushRules] Found ${allEvents.size} out of ${(newJoinEvents + inviteEvents).size}" +
-                    " to check for push rules with ${params.rules.size} rules")
-            allEvents.forEach { event ->
-                fulfilledBingRule(event, params.rules)?.let {
-                    Timber.v("[PushRules] Rule $it match for event ${event.eventId}")
-                    defaultPushRuleService.dispatchBing(event, it)
-                }
-            }
-            defaultPushRuleService.dispatchFinish()
+    override suspend fun execute(params: ProcessEventForPushTask.Params) {
+        // Handle left rooms
+        params.syncResponse.leave.keys.forEach {
+            defaultPushRuleService.dispatchRoomLeft(it)
         }
+        val newJoinEvents = params.syncResponse.join
+                .map { entries ->
+                    entries.value.timeline?.events?.map { it.copy(roomId = entries.key) }
+                }
+                .fold(emptyList<Event>(), { acc, next ->
+                    acc + (next ?: emptyList())
+                })
+        val inviteEvents = params.syncResponse.invite
+                .map { entries ->
+                    entries.value.inviteState?.events?.map { it.copy(roomId = entries.key) }
+                }
+                .fold(emptyList<Event>(), { acc, next ->
+                    acc + (next ?: emptyList())
+                })
+        val allEvents = (newJoinEvents + inviteEvents).filter { event ->
+            when (event.type) {
+                EventType.MESSAGE,
+                EventType.REDACTION,
+                EventType.ENCRYPTED,
+                EventType.STATE_ROOM_MEMBER -> true
+                else                        -> false
+            }
+        }.filter {
+            it.senderId != sessionParams.credentials.userId
+        }
+        Timber.v("[PushRules] Found ${allEvents.size} out of ${(newJoinEvents + inviteEvents).size}" +
+                " to check for push rules with ${params.rules.size} rules")
+        allEvents.forEach { event ->
+            fulfilledBingRule(event, params.rules)?.let {
+                Timber.v("[PushRules] Rule $it match for event ${event.eventId}")
+                defaultPushRuleService.dispatchBing(event, it)
+            }
+        }
+        defaultPushRuleService.dispatchFinish()
     }
 
     private fun fulfilledBingRule(event: Event, rules: List<PushRule>): PushRule? {

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/pushers/AddHttpPusherWorker.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/pushers/AddHttpPusherWorker.kt
@@ -18,6 +18,7 @@ package im.vector.matrix.android.internal.session.pushers
 import android.content.Context
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
+import arrow.core.Try
 import com.squareup.moshi.JsonClass
 import com.zhuinden.monarchy.Monarchy
 import im.vector.matrix.android.api.failure.Failure
@@ -56,8 +57,10 @@ internal class AddHttpPusherWorker(context: Context, params: WorkerParameters)
             return Result.failure()
         }
 
-        val result = executeRequest<Unit> {
-            apiCall = pushersAPI.setPusher(pusher)
+        val result = Try {
+            executeRequest<Unit> {
+                apiCall = pushersAPI.setPusher(pusher)
+            }
         }
         return result.fold({
             when (it) {

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/pushers/GetPushRulesTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/pushers/GetPushRulesTask.kt
@@ -15,7 +15,6 @@
  */
 package im.vector.matrix.android.internal.session.pushers
 
-import arrow.core.Try
 import com.zhuinden.monarchy.Monarchy
 import im.vector.matrix.android.api.auth.data.SessionParams
 import im.vector.matrix.android.api.pushrules.rest.GetPushRulesResponse
@@ -24,7 +23,6 @@ import im.vector.matrix.android.internal.database.model.PushRulesEntity
 import im.vector.matrix.android.internal.database.model.PusherEntityFields
 import im.vector.matrix.android.internal.network.executeRequest
 import im.vector.matrix.android.internal.task.Task
-import im.vector.matrix.android.internal.util.tryTransactionSync
 import javax.inject.Inject
 
 
@@ -39,58 +37,58 @@ internal class DefaultGetPushRulesTask @Inject constructor(private val pushRules
                                                            private val monarchy: Monarchy,
                                                            private val sessionParams: SessionParams) : GetPushRulesTask {
 
-    override suspend fun execute(params: GetPushRulesTask.Params): Try<Unit> {
-        return executeRequest<GetPushRulesResponse> {
+    override suspend fun execute(params: GetPushRulesTask.Params) {
+        val response = executeRequest<GetPushRulesResponse> {
             apiCall = pushRulesApi.getAllRules()
-        }.flatMap { response ->
-            val scope = params.scope
-            return monarchy.tryTransactionSync { realm ->
-                //clear existings?
-                //TODO
-                realm.where(PushRulesEntity::class.java)
-                        .equalTo(PusherEntityFields.USER_ID, sessionParams.credentials.userId)
-                        .findAll().deleteAllFromRealm()
+        }
 
-                val content = PushRulesEntity(sessionParams.credentials.userId, scope, "content")
-                response.global.content?.forEach { rule ->
-                    PushRulesMapper.map(rule).also {
-                        content.pushRules.add(it)
-                    }
-                }
-                realm.insertOrUpdate(content)
+        val scope = params.scope
+        monarchy.runTransactionSync { realm ->
+            //clear existings?
+            //TODO
+            realm.where(PushRulesEntity::class.java)
+                    .equalTo(PusherEntityFields.USER_ID, sessionParams.credentials.userId)
+                    .findAll().deleteAllFromRealm()
 
-                val override = PushRulesEntity(sessionParams.credentials.userId, scope, "override")
-                response.global.override?.forEach { rule ->
-                    PushRulesMapper.map(rule).also {
-                        override.pushRules.add(it)
-                    }
+            val content = PushRulesEntity(sessionParams.credentials.userId, scope, "content")
+            response.global.content?.forEach { rule ->
+                PushRulesMapper.map(rule).also {
+                    content.pushRules.add(it)
                 }
-                realm.insertOrUpdate(override)
-
-                val rooms = PushRulesEntity(sessionParams.credentials.userId, scope, "room")
-                response.global.room?.forEach { rule ->
-                    PushRulesMapper.map(rule).also {
-                        rooms.pushRules.add(it)
-                    }
-                }
-                realm.insertOrUpdate(rooms)
-
-                val senders = PushRulesEntity(sessionParams.credentials.userId, scope, "sender")
-                response.global.sender?.forEach { rule ->
-                    PushRulesMapper.map(rule).also {
-                        senders.pushRules.add(it)
-                    }
-                }
-                realm.insertOrUpdate(senders)
-
-                val underrides = PushRulesEntity(sessionParams.credentials.userId, scope, "underride")
-                response.global.underride?.forEach { rule ->
-                    PushRulesMapper.map(rule).also {
-                        underrides.pushRules.add(it)
-                    }
-                }
-                realm.insertOrUpdate(underrides)
             }
+            realm.insertOrUpdate(content)
+
+            val override = PushRulesEntity(sessionParams.credentials.userId, scope, "override")
+            response.global.override?.forEach { rule ->
+                PushRulesMapper.map(rule).also {
+                    override.pushRules.add(it)
+                }
+            }
+            realm.insertOrUpdate(override)
+
+            val rooms = PushRulesEntity(sessionParams.credentials.userId, scope, "room")
+            response.global.room?.forEach { rule ->
+                PushRulesMapper.map(rule).also {
+                    rooms.pushRules.add(it)
+                }
+            }
+            realm.insertOrUpdate(rooms)
+
+            val senders = PushRulesEntity(sessionParams.credentials.userId, scope, "sender")
+            response.global.sender?.forEach { rule ->
+                PushRulesMapper.map(rule).also {
+                    senders.pushRules.add(it)
+                }
+            }
+            realm.insertOrUpdate(senders)
+
+            val underrides = PushRulesEntity(sessionParams.credentials.userId, scope, "underride")
+            response.global.underride?.forEach { rule ->
+                PushRulesMapper.map(rule).also {
+                    underrides.pushRules.add(it)
+                }
+            }
+            realm.insertOrUpdate(underrides)
         }
     }
 }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/pushers/GetPushersTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/pushers/GetPushersTask.kt
@@ -15,7 +15,6 @@
  */
 package im.vector.matrix.android.internal.session.pushers
 
-import arrow.core.Try
 import com.zhuinden.monarchy.Monarchy
 import im.vector.matrix.android.api.auth.data.SessionParams
 import im.vector.matrix.android.api.session.pushers.PusherState
@@ -24,7 +23,6 @@ import im.vector.matrix.android.internal.database.model.PusherEntity
 import im.vector.matrix.android.internal.database.model.PusherEntityFields
 import im.vector.matrix.android.internal.network.executeRequest
 import im.vector.matrix.android.internal.task.Task
-import im.vector.matrix.android.internal.util.tryTransactionSync
 import javax.inject.Inject
 
 internal interface GetPushersTask : Task<Unit, Unit>
@@ -33,20 +31,20 @@ internal class DefaultGetPusherTask @Inject constructor(private val pushersAPI: 
                                                         private val monarchy: Monarchy,
                                                         private val sessionParams: SessionParams) : GetPushersTask {
 
-    override suspend fun execute(params: Unit): Try<Unit> {
-        return executeRequest<GetPushersResponse> {
+    override suspend fun execute(params: Unit) {
+        val response = executeRequest<GetPushersResponse> {
             apiCall = pushersAPI.getPushers()
-        }.flatMap { response ->
-            monarchy.tryTransactionSync { realm ->
-                //clear existings?
-                realm.where(PusherEntity::class.java)
-                        .equalTo(PusherEntityFields.USER_ID, sessionParams.credentials.userId)
-                        .findAll().deleteAllFromRealm()
-                response.pushers?.forEach { jsonPusher ->
-                    jsonPusher.toEntity(sessionParams.credentials.userId).also {
-                        it.state = PusherState.REGISTERED
-                        realm.insertOrUpdate(it)
-                    }
+        }
+
+        monarchy.runTransactionSync { realm ->
+            //clear existings?
+            realm.where(PusherEntity::class.java)
+                    .equalTo(PusherEntityFields.USER_ID, sessionParams.credentials.userId)
+                    .findAll().deleteAllFromRealm()
+            response.pushers?.forEach { jsonPusher ->
+                jsonPusher.toEntity(sessionParams.credentials.userId).also {
+                    it.state = PusherState.REGISTERED
+                    realm.insertOrUpdate(it)
                 }
             }
         }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/pushers/UpdatePushRuleEnableStatusTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/pushers/UpdatePushRuleEnableStatusTask.kt
@@ -15,7 +15,6 @@
  */
 package im.vector.matrix.android.internal.session.pushers
 
-import arrow.core.Try
 import im.vector.matrix.android.api.pushrules.rest.PushRule
 import im.vector.matrix.android.internal.network.executeRequest
 import im.vector.matrix.android.internal.task.Task
@@ -31,8 +30,8 @@ internal interface UpdatePushRuleEnableStatusTask : Task<UpdatePushRuleEnableSta
 internal class DefaultUpdatePushRuleEnableStatusTask @Inject constructor(private val pushRulesApi: PushRulesApi)
     : UpdatePushRuleEnableStatusTask {
 
-    override suspend fun execute(params: UpdatePushRuleEnableStatusTask.Params): Try<Unit> {
-        return executeRequest {
+    override suspend fun execute(params: UpdatePushRuleEnableStatusTask.Params) {
+        executeRequest<Unit> {
             apiCall = pushRulesApi.updateEnableRuleStatus(params.kind, params.pushRule.ruleId, params.enabled)
         }
     }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/EventRelationsAggregationTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/EventRelationsAggregationTask.kt
@@ -15,7 +15,6 @@
  */
 package im.vector.matrix.android.internal.session.room
 
-import arrow.core.Try
 import com.zhuinden.monarchy.Monarchy
 import im.vector.matrix.android.api.session.crypto.CryptoService
 import im.vector.matrix.android.api.session.crypto.MXCryptoError
@@ -31,7 +30,6 @@ import im.vector.matrix.android.internal.database.query.create
 import im.vector.matrix.android.internal.database.query.where
 import im.vector.matrix.android.internal.session.room.send.LocalEchoEventFactory
 import im.vector.matrix.android.internal.task.Task
-import im.vector.matrix.android.internal.util.tryTransactionSync
 import io.realm.Realm
 import timber.log.Timber
 import javax.inject.Inject
@@ -54,10 +52,10 @@ internal class DefaultEventRelationsAggregationTask @Inject constructor(
     //OPT OUT serer aggregation until API mature enough
     private val SHOULD_HANDLE_SERVER_AGREGGATION = false
 
-    override suspend fun execute(params: EventRelationsAggregationTask.Params): Try<Unit> {
+    override suspend fun execute(params: EventRelationsAggregationTask.Params) {
         val events = params.events
         val userId = params.userId
-        return monarchy.tryTransactionSync { realm ->
+        monarchy.runTransactionSync { realm ->
             Timber.v(">>> DefaultEventRelationsAggregationTask[${params.hashCode()}] called with ${events.size} events")
             update(realm, events, userId)
             Timber.v("<<< DefaultEventRelationsAggregationTask[${params.hashCode()}] finished")

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/directory/GetPublicRoomTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/directory/GetPublicRoomTask.kt
@@ -16,7 +16,6 @@
 
 package im.vector.matrix.android.internal.session.room.directory
 
-import arrow.core.Try
 import im.vector.matrix.android.api.session.room.model.roomdirectory.PublicRoomsParams
 import im.vector.matrix.android.api.session.room.model.roomdirectory.PublicRoomsResponse
 import im.vector.matrix.android.internal.network.executeRequest
@@ -34,7 +33,7 @@ internal interface GetPublicRoomTask : Task<GetPublicRoomTask.Params, PublicRoom
 
 internal class DefaultGetPublicRoomTask @Inject constructor(private val roomAPI: RoomAPI) : GetPublicRoomTask {
 
-    override suspend fun execute(params: GetPublicRoomTask.Params): Try<PublicRoomsResponse> {
+    override suspend fun execute(params: GetPublicRoomTask.Params): PublicRoomsResponse {
         return executeRequest {
             apiCall = roomAPI.publicRooms(params.server, params.publicRoomsParams)
         }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/directory/GetThirdPartyProtocolsTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/directory/GetThirdPartyProtocolsTask.kt
@@ -16,7 +16,6 @@
 
 package im.vector.matrix.android.internal.session.room.directory
 
-import arrow.core.Try
 import im.vector.matrix.android.api.session.room.model.thirdparty.ThirdPartyProtocol
 import im.vector.matrix.android.internal.network.executeRequest
 import im.vector.matrix.android.internal.session.SessionScope
@@ -28,7 +27,7 @@ internal interface GetThirdPartyProtocolsTask : Task<Unit, Map<String, ThirdPart
 
 internal class DefaultGetThirdPartyProtocolsTask @Inject constructor (private val roomAPI: RoomAPI) : GetThirdPartyProtocolsTask {
 
-    override suspend fun execute(params: Unit): Try<Map<String, ThirdPartyProtocol>> {
+    override suspend fun execute(params: Unit): Map<String, ThirdPartyProtocol> {
         return executeRequest {
             apiCall = roomAPI.thirdPartyProtocols()
         }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/membership/joining/InviteTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/membership/joining/InviteTask.kt
@@ -16,7 +16,6 @@
 
 package im.vector.matrix.android.internal.session.room.membership.joining
 
-import arrow.core.Try
 import im.vector.matrix.android.internal.network.executeRequest
 import im.vector.matrix.android.internal.session.SessionScope
 import im.vector.matrix.android.internal.session.room.RoomAPI
@@ -33,8 +32,8 @@ internal interface InviteTask : Task<InviteTask.Params, Unit> {
 
 internal class DefaultInviteTask @Inject constructor(private val roomAPI: RoomAPI) : InviteTask {
 
-    override suspend fun execute(params: InviteTask.Params): Try<Unit> {
-        return executeRequest {
+    override suspend fun execute(params: InviteTask.Params) {
+        executeRequest<Unit> {
             val body = InviteBody(params.userId)
             apiCall = roomAPI.invite(params.roomId, body)
         }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/membership/joining/JoinRoomTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/membership/joining/JoinRoomTask.kt
@@ -16,7 +16,6 @@
 
 package im.vector.matrix.android.internal.session.room.membership.joining
 
-import arrow.core.Try
 import im.vector.matrix.android.internal.network.executeRequest
 import im.vector.matrix.android.internal.session.SessionScope
 import im.vector.matrix.android.internal.session.room.RoomAPI
@@ -31,8 +30,8 @@ internal interface JoinRoomTask : Task<JoinRoomTask.Params, Unit> {
 
 internal class DefaultJoinRoomTask @Inject constructor(private val roomAPI: RoomAPI) : JoinRoomTask {
 
-    override suspend fun execute(params: JoinRoomTask.Params): Try<Unit> {
-        return executeRequest {
+    override suspend fun execute(params: JoinRoomTask.Params) {
+        executeRequest<Unit> {
             apiCall = roomAPI.join(params.roomId, HashMap())
         }
     }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/membership/leaving/LeaveRoomTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/membership/leaving/LeaveRoomTask.kt
@@ -16,7 +16,6 @@
 
 package im.vector.matrix.android.internal.session.room.membership.leaving
 
-import arrow.core.Try
 import im.vector.matrix.android.internal.network.executeRequest
 import im.vector.matrix.android.internal.session.SessionScope
 import im.vector.matrix.android.internal.session.room.RoomAPI
@@ -31,8 +30,8 @@ internal interface LeaveRoomTask : Task<LeaveRoomTask.Params, Unit> {
 
 internal class DefaultLeaveRoomTask @Inject constructor(private val roomAPI: RoomAPI) : LeaveRoomTask {
 
-    override suspend fun execute(params: LeaveRoomTask.Params): Try<Unit> {
-        return executeRequest {
+    override suspend fun execute(params: LeaveRoomTask.Params) {
+        executeRequest<Unit> {
             apiCall = roomAPI.leave(params.roomId, HashMap())
         }
     }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/prune/PruneEventTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/prune/PruneEventTask.kt
@@ -15,7 +15,6 @@
  */
 package im.vector.matrix.android.internal.session.room.prune
 
-import arrow.core.Try
 import com.zhuinden.monarchy.Monarchy
 import im.vector.matrix.android.api.session.events.model.Event
 import im.vector.matrix.android.api.session.events.model.EventType
@@ -30,7 +29,6 @@ import im.vector.matrix.android.internal.database.query.findWithSenderMembership
 import im.vector.matrix.android.internal.database.query.where
 import im.vector.matrix.android.internal.di.MoshiProvider
 import im.vector.matrix.android.internal.task.Task
-import im.vector.matrix.android.internal.util.tryTransactionSync
 import io.realm.Realm
 import timber.log.Timber
 import javax.inject.Inject
@@ -47,8 +45,8 @@ internal interface PruneEventTask : Task<PruneEventTask.Params, Unit> {
 
 internal class DefaultPruneEventTask @Inject constructor(private val monarchy: Monarchy) : PruneEventTask {
 
-    override suspend fun execute(params: PruneEventTask.Params): Try<Unit> {
-        return monarchy.tryTransactionSync { realm ->
+    override suspend fun execute(params: PruneEventTask.Params) {
+        return monarchy.runTransactionSync { realm ->
             params.redactionEvents.forEach { event ->
                 pruneEvent(realm, event, params.userId)
             }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/read/SetReadMarkersTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/read/SetReadMarkersTask.kt
@@ -16,7 +16,6 @@
 
 package im.vector.matrix.android.internal.session.room.read
 
-import arrow.core.Try
 import com.zhuinden.monarchy.Monarchy
 import im.vector.matrix.android.api.auth.data.Credentials
 import im.vector.matrix.android.internal.database.model.ChunkEntity
@@ -53,7 +52,7 @@ internal class DefaultSetReadMarkersTask @Inject constructor(private val roomAPI
                                                              private val monarchy: Monarchy
 ) : SetReadMarkersTask {
 
-    override suspend fun execute(params: SetReadMarkersTask.Params): Try<Unit> {
+    override suspend fun execute(params: SetReadMarkersTask.Params) {
         val markers = HashMap<String, String>()
         if (params.fullyReadEventId != null) {
             if (LocalEchoEventFactory.isLocalEchoId(params.fullyReadEventId)) {
@@ -72,10 +71,8 @@ internal class DefaultSetReadMarkersTask @Inject constructor(private val roomAPI
                 markers[READ_RECEIPT] = params.readReceiptEventId
             }
         }
-        return if (markers.isEmpty()) {
-            Try.just(Unit)
-        } else {
-            executeRequest {
+        if (markers.isNotEmpty()) {
+            executeRequest<Unit> {
                 apiCall = roomAPI.sendReadMarker(params.roomId, markers)
             }
         }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/relation/FetchEditHistoryTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/relation/FetchEditHistoryTask.kt
@@ -15,7 +15,6 @@
  */
 package im.vector.matrix.android.internal.session.room.relation
 
-import arrow.core.Try
 import im.vector.matrix.android.api.session.events.model.Event
 import im.vector.matrix.android.api.session.events.model.EventType
 import im.vector.matrix.android.api.session.events.model.RelationType
@@ -39,16 +38,15 @@ internal class DefaultFetchEditHistoryTask @Inject constructor(
         private val roomAPI: RoomAPI
 ) : FetchEditHistoryTask {
 
-    override suspend fun execute(params: FetchEditHistoryTask.Params): Try<List<Event>> {
-        return executeRequest<RelationsResponse> {
+    override suspend fun execute(params: FetchEditHistoryTask.Params): List<Event> {
+        val resp = executeRequest<RelationsResponse> {
             apiCall = roomAPI.getRelations(params.roomId,
                     params.eventId,
                     RelationType.REPLACE,
                     if (params.isRoomEncrypted) EventType.ENCRYPTED else EventType.MESSAGE)
-        }.map { resp ->
-            val events = resp.chunks.toMutableList()
-            resp.originalEvent?.let { events.add(it) }
-            events
         }
+        val events = resp.chunks.toMutableList()
+        resp.originalEvent?.let { events.add(it) }
+        return events
     }
 }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/relation/FindReactionEventForUndoTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/relation/FindReactionEventForUndoTask.kt
@@ -15,7 +15,6 @@
  */
 package im.vector.matrix.android.internal.session.room.relation
 
-import arrow.core.Try
 import com.zhuinden.monarchy.Monarchy
 import im.vector.matrix.android.internal.database.model.EventAnnotationsSummaryEntity
 import im.vector.matrix.android.internal.database.model.EventEntity
@@ -44,14 +43,12 @@ internal interface FindReactionEventForUndoTask : Task<FindReactionEventForUndoT
 
 internal class DefaultFindReactionEventForUndoTask @Inject constructor(private val monarchy: Monarchy) : FindReactionEventForUndoTask {
 
-    override suspend fun execute(params: FindReactionEventForUndoTask.Params): Try<FindReactionEventForUndoTask.Result> {
-        return Try {
-            var eventId: String? = null
-            monarchy.doWithRealm { realm ->
-                eventId = getReactionToRedact(realm, params.reaction, params.eventId, params.myUserId)?.eventId
-            }
-            FindReactionEventForUndoTask.Result(eventId)
+    override suspend fun execute(params: FindReactionEventForUndoTask.Params): FindReactionEventForUndoTask.Result {
+        var eventId: String? = null
+        monarchy.doWithRealm { realm ->
+            eventId = getReactionToRedact(realm, params.reaction, params.eventId, params.myUserId)?.eventId
         }
+        return FindReactionEventForUndoTask.Result(eventId)
     }
 
     private fun getReactionToRedact(realm: Realm, reaction: String, eventId: String, userId: String): EventEntity? {

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/relation/UpdateQuickReactionTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/relation/UpdateQuickReactionTask.kt
@@ -15,7 +15,6 @@
  */
 package im.vector.matrix.android.internal.session.room.relation
 
-import arrow.core.Try
 import com.zhuinden.monarchy.Monarchy
 import im.vector.matrix.android.internal.database.model.EventAnnotationsSummaryEntity
 import im.vector.matrix.android.internal.database.model.EventEntity
@@ -44,14 +43,12 @@ internal interface UpdateQuickReactionTask : Task<UpdateQuickReactionTask.Params
 }
 
 internal class DefaultUpdateQuickReactionTask @Inject constructor(private val monarchy: Monarchy) : UpdateQuickReactionTask {
-    override suspend fun execute(params: UpdateQuickReactionTask.Params): Try<UpdateQuickReactionTask.Result> {
-        return Try {
-            var res: Pair<String?, List<String>?>? = null
-            monarchy.doWithRealm { realm ->
-                res = updateQuickReaction(realm, params.reaction, params.oppositeReaction, params.eventId, params.myUserId)
-            }
-            UpdateQuickReactionTask.Result(res?.first, res?.second ?: emptyList())
+    override suspend fun execute(params: UpdateQuickReactionTask.Params): UpdateQuickReactionTask.Result {
+        var res: Pair<String?, List<String>?>? = null
+        monarchy.doWithRealm { realm ->
+            res = updateQuickReaction(realm, params.reaction, params.oppositeReaction, params.eventId, params.myUserId)
         }
+        return UpdateQuickReactionTask.Result(res?.first, res?.second ?: emptyList())
     }
 
 

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/send/RedactEventWorker.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/send/RedactEventWorker.kt
@@ -18,6 +18,7 @@ package im.vector.matrix.android.internal.session.room.send
 import android.content.Context
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
+import arrow.core.Try
 import com.squareup.moshi.JsonClass
 import im.vector.matrix.android.api.failure.Failure
 import im.vector.matrix.android.internal.network.executeRequest
@@ -54,13 +55,15 @@ internal class RedactEventWorker(context: Context, params: WorkerParameters) : C
         sessionComponent.inject(this)
 
         val eventId = params.eventId
-        val result = executeRequest<SendResponse> {
-            apiCall = roomAPI.redactEvent(
-                    params.txID,
-                    params.roomId,
-                    eventId,
-                    if (params.reason == null) emptyMap() else mapOf("reason" to params.reason)
-            )
+        val result = Try {
+            executeRequest<SendResponse> {
+                apiCall = roomAPI.redactEvent(
+                        params.txID,
+                        params.roomId,
+                        eventId,
+                        if (params.reason == null) emptyMap() else mapOf("reason" to params.reason)
+                )
+            }
         }
         return result.fold({
             when (it) {

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/state/SendStateTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/state/SendStateTask.kt
@@ -16,7 +16,6 @@
 
 package im.vector.matrix.android.internal.session.room.state
 
-import arrow.core.Try
 import im.vector.matrix.android.internal.network.executeRequest
 import im.vector.matrix.android.internal.session.SessionScope
 import im.vector.matrix.android.internal.session.room.RoomAPI
@@ -32,8 +31,8 @@ internal interface SendStateTask : Task<SendStateTask.Params, Unit> {
 }
 
 internal class DefaultSendStateTask @Inject constructor(private val roomAPI: RoomAPI) : SendStateTask {
-    override suspend fun execute(params: SendStateTask.Params): Try<Unit> {
-        return executeRequest {
+    override suspend fun execute(params: SendStateTask.Params) {
+        executeRequest<Unit> {
             apiCall = roomAPI.sendStateEvent(params.roomId, params.eventType, params.body)
         }
     }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/timeline/DefaultGetContextOfEventTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/timeline/DefaultGetContextOfEventTask.kt
@@ -16,7 +16,6 @@
 
 package im.vector.matrix.android.internal.session.room.timeline
 
-import arrow.core.Try
 import im.vector.matrix.android.internal.network.executeRequest
 import im.vector.matrix.android.internal.session.SessionScope
 import im.vector.matrix.android.internal.session.filter.FilterRepository
@@ -38,13 +37,13 @@ internal class DefaultGetContextOfEventTask @Inject constructor(private val room
                                             private val tokenChunkEventPersistor: TokenChunkEventPersistor
 ) : GetContextOfEventTask {
 
-    override suspend fun execute(params: GetContextOfEventTask.Params): Try<TokenChunkEventPersistor.Result> {
+    override suspend fun execute(params: GetContextOfEventTask.Params): TokenChunkEventPersistor.Result {
         val filter = filterRepository.getRoomFilter()
-        return executeRequest<EventContextResponse> {
+        val response = executeRequest<EventContextResponse> {
             apiCall = roomAPI.getContextOfEvent(params.roomId, params.eventId, 0, filter)
-        }.flatMap { response ->
-            tokenChunkEventPersistor.insertInDb(response, params.roomId, PaginationDirection.BACKWARDS)
         }
+        return tokenChunkEventPersistor.insertInDb(response, params.roomId, PaginationDirection.BACKWARDS)
+                .fold({ throw it }, { it })
     }
 
 }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/timeline/GetEventTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/timeline/GetEventTask.kt
@@ -16,7 +16,6 @@
 
 package im.vector.matrix.android.internal.session.room.timeline
 
-import arrow.core.Try
 import im.vector.matrix.android.api.session.events.model.Event
 import im.vector.matrix.android.internal.task.Task
 import im.vector.matrix.android.internal.network.executeRequest
@@ -32,7 +31,7 @@ internal class GetEventTask @Inject constructor(private val roomAPI: RoomAPI
             val eventId: String
     )
 
-    override suspend fun execute(params: Params): Try<Event> {
+    override suspend fun execute(params: Params): Event {
         return executeRequest {
             apiCall = roomAPI.getEvent(params.roomId, params.eventId)
         }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/signout/SignOutTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/signout/SignOutTask.kt
@@ -16,7 +16,6 @@
 
 package im.vector.matrix.android.internal.session.signout
 
-import arrow.core.Try
 import im.vector.matrix.android.api.auth.data.Credentials
 import im.vector.matrix.android.internal.SessionManager
 import im.vector.matrix.android.internal.auth.SessionParamsStore
@@ -31,15 +30,11 @@ internal class DefaultSignOutTask @Inject constructor(private val credentials: C
                                                       private val sessionManager: SessionManager,
                                                       private val sessionParamsStore: SessionParamsStore) : SignOutTask {
 
-    override suspend fun execute(params: Unit): Try<Unit> {
-        return executeRequest<Unit> {
+    override suspend fun execute(params: Unit) {
+        executeRequest<Unit> {
             apiCall = signOutAPI.signOut()
-        }.flatMap {
-            sessionParamsStore.delete(credentials.userId)
-        }.flatMap {
-            Try {
-                sessionManager.releaseSession(credentials.userId)
-            }
         }
+        sessionParamsStore.delete(credentials.userId)
+        sessionManager.releaseSession(credentials.userId)
     }
 }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/task/ConfigurableTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/task/ConfigurableTask.kt
@@ -16,7 +16,6 @@
 
 package im.vector.matrix.android.internal.task
 
-import arrow.core.Try
 import im.vector.matrix.android.api.MatrixCallback
 import im.vector.matrix.android.api.util.Cancelable
 
@@ -41,7 +40,7 @@ internal data class ConfigurableTask<PARAMS, RESULT>(
 ) : Task<PARAMS, RESULT> {
 
 
-    override suspend fun execute(params: PARAMS): Try<RESULT> {
+    override suspend fun execute(params: PARAMS): RESULT {
         return task.execute(params)
     }
 

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/task/Task.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/task/Task.kt
@@ -16,11 +16,10 @@
 
 package im.vector.matrix.android.internal.task
 
-import arrow.core.Try
 
 internal interface Task<PARAMS, RESULT> {
 
-    suspend fun execute(params: PARAMS): Try<RESULT>
+    suspend fun execute(params: PARAMS): RESULT
 
 }
 

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/task/TaskExecutor.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/task/TaskExecutor.kt
@@ -17,10 +17,7 @@
 package im.vector.matrix.android.internal.task
 
 
-import arrow.core.Try
 import im.vector.matrix.android.api.util.Cancelable
-import im.vector.matrix.android.internal.extensions.foldToCallback
-import im.vector.matrix.android.internal.extensions.onError
 import im.vector.matrix.android.internal.util.CancelableCoroutine
 import im.vector.matrix.android.internal.util.MatrixCoroutineDispatchers
 import kotlinx.coroutines.GlobalScope
@@ -28,6 +25,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import timber.log.Timber
+import java.lang.Exception
 import javax.inject.Inject
 import kotlin.coroutines.EmptyCoroutineContext
 
@@ -36,17 +34,19 @@ internal class TaskExecutor @Inject constructor(private val coroutineDispatchers
     fun <PARAMS, RESULT> execute(task: ConfigurableTask<PARAMS, RESULT>): Cancelable {
 
         val job = GlobalScope.launch(task.callbackThread.toDispatcher()) {
-            val resultOrFailure = withContext(task.executionThread.toDispatcher()) {
-                Timber.v("Executing $task on ${Thread.currentThread().name}")
-                retry(task.retryCount) {
-                    task.execute(task.params)
+            val resultOrFailure = runCatching {
+                withContext(task.executionThread.toDispatcher()) {
+                    Timber.v("Executing $task on ${Thread.currentThread().name}")
+                    retry(task.retryCount) {
+                        task.execute(task.params)
+                    }
                 }
             }
             resultOrFailure
-                    .onError {
+                    .onFailure {
                         Timber.d(it, "Task failed")
                     }
-                    .foldToCallback(task.callback)
+                    .fold(task.callback::onSuccess, task.callback::onFailure)
         }
         return CancelableCoroutine(job)
     }
@@ -56,14 +56,13 @@ internal class TaskExecutor @Inject constructor(private val coroutineDispatchers
             initialDelay: Long = 100, // 0.1 second
             maxDelay: Long = 10_000,    // 10 second
             factor: Double = 2.0,
-            block: suspend () -> Try<T>): Try<T> {
+            block: suspend () -> T): T {
 
         var currentDelay = initialDelay
         repeat(times - 1) {
-            val blockResult = block()
-            if (blockResult.isSuccess()) {
-                return blockResult
-            } else {
+            try {
+                return block()
+            } catch (e: Exception) {
                 delay(currentDelay)
                 currentDelay = (currentDelay * factor).toLong().coerceAtMost(maxDelay)
             }


### PR DESCRIPTION
Signed-off-by: Dominic Fischer <dominicfischer7@gmail.com>

### Pull Request Checklist

<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/riotX-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->

- [ ] Changes has been tested on an Android device or Android emulator with API 16
- [ ] UI change has been tested on both light and dark themes
- [x] Pull request is based on the develop branch
- [ ] Pull request updates [CHANGES.md](https://github.com/vector-im/riotX-android/blob/develop/CHANGES.md)
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#sign-off)

So I noticed `Try<...>`  is used as a return type from suspending functions. Unfortunately, when exceptions are handled this way, [coroutine cancellation](https://kotlinlang.org/docs/reference/coroutines/cancellation-and-timeouts.html#cancellation-is-cooperative) doesn't work. `CancellationException` needs to be thrown as normal and not swallowed by `Try`. As it is now, most of the `Cancellable`s don't actually cancel properly because of this.

So I've done a some of the work of removing them from suspend functions in particular.
So instead of having,
```
suspend fun execute(...): Try<...>

execute(...).fold(..., ...)
```

I've changed it to,
```
suspend fun execute(...): ...

Try { execute(...) }.fold(..., ...)
// or runCatching { execute(...) }.fold(..., ...)
```

This will also reduce the number of allocations. :smile: 
This still isn't perfect but it's better than before. I wanted to keep this PR small. I'll slowly move `Try` up to non-suspending code, where it works properly.