### PR TITLE
Fix reply fallback prefix

### DIFF
--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/send/LocalEchoEventFactory.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/send/LocalEchoEventFactory.kt
@@ -306,12 +306,12 @@ internal class LocalEchoEventFactory @Inject constructor(private val credentials
 
     private fun buildReplyFallback(body: TextContent, originalSenderId: String?, newBodyText: String): String {
         val lines = body.text.split("\n")
-        val replyFallback = StringBuffer("><$originalSenderId>")
+        val replyFallback = StringBuffer("> <$originalSenderId>")
         lines.forEachIndexed { index, s ->
             if (index == 0) {
                 replyFallback.append(" $s")
             } else {
-                replyFallback.append("\n>$s")
+                replyFallback.append("\n> $s")
             }
         }
         replyFallback.append("\n\n").append(newBodyText)


### PR DESCRIPTION
Plain text reply fallback should be prefixed with "> " not ">" (as per spec).

I am just doing this blind off github, I thought it was more useful to open a PR for a single character change than an issue!

### Pull Request Checklist

<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/riotX-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->

- [ ] Changes has been tested on an Android device or Android emulator with API 16
- [ ] UI change has been tested on both light and dark themes
- [x] Pull request is based on the develop branch
- [ ] Pull request updates [CHANGES.md](https://github.com/vector-im/riotX-android/blob/develop/CHANGES.md)
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#sign-off)

Signed Off By Stuart Mumford <stuart@cadair.com>