### PR TITLE
Split apk

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,7 +25,7 @@ Translations:
  -
 
 Build:
- -
+ - Split APK: generate one APK per arch, to reduce APK size of about 30%
 
 
 Changes in RiotX 0.2.0 (2019-07-18)

--- a/matrix-sdk-android-rx/build.gradle
+++ b/matrix-sdk-android-rx/build.gradle
@@ -33,7 +33,6 @@ android {
 }
 
 dependencies {
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(":matrix-sdk-android")
     implementation 'androidx.appcompat:appcompat:1.1.0-beta01'
     implementation 'io.reactivex.rxjava2:rxkotlin:2.3.0'

--- a/matrix-sdk-android/build.gradle
+++ b/matrix-sdk-android/build.gradle
@@ -94,7 +94,6 @@ dependencies {
     def markwon_version = '3.0.0'
     def daggerVersion = '2.23.1'
 
-    implementation fileTree(dir: 'libs', include: ['*.aar'])
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version"

--- a/vector/build.gradle
+++ b/vector/build.gradle
@@ -1,3 +1,5 @@
+import com.android.build.OutputFile
+
 apply plugin: 'com.android.application'
 apply plugin: 'com.google.android.gms.oss-licenses-plugin'
 apply plugin: 'kotlin-android'
@@ -52,6 +54,11 @@ project.android.buildTypes.all { buildType ->
             ]
 }
 
+// map for the version codes
+// x86 must have greater values than arm, see https://software.intel.com/en-us/android/articles/google-play-supports-cpu-architecture-filtering-for-multiple-apk
+// 64 bits have greater value than 32 bits
+ext.abiVersionCodes = ["armeabi-v7a": 1, "arm64-v8a": 2, "x86": 3, "x86_64": 4].withDefault { 0 }
+
 def buildNumber = System.getenv("BUILDKITE_BUILD_NUMBER") as Integer ?: 0
 
 android {
@@ -83,6 +90,39 @@ android {
         resValue "string", "build_number", "\"${buildNumber}\""
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+
+        // Keep abiFilter for the universalApk
+        ndk {
+            abiFilters "armeabi-v7a", "x86", 'arm64-v8a', 'x86_64'
+        }
+
+        // Ref: https://developer.android.com/studio/build/configure-apk-splits.html
+        splits {
+            // Configures multiple APKs based on ABI.
+            abi {
+                // Enables building multiple APKs per ABI.
+                enable true
+
+                // By default all ABIs are included, so use reset() and include to specify that we only
+                // want APKs for armeabi-v7a, x86, arm64-v8a and x86_64.
+
+                // Resets the list of ABIs that Gradle should create APKs for to none.
+                reset()
+
+                // Specifies a list of ABIs that Gradle should create APKs for.
+                include "armeabi-v7a", "x86", "arm64-v8a", "x86_64"
+
+                // Generate a universal APK that includes all ABIs, so user who install from CI tool can use this one by default.
+                universalApk true
+            }
+        }
+
+        android.applicationVariants.all { variant ->
+            variant.outputs.each { output ->
+                def baseAbiVersionCode = project.ext.abiVersionCodes.get(output.getFilter(OutputFile.ABI))
+                output.versionCodeOverride = baseAbiVersionCode * 10_000_000 + variant.versionCode
+            }
+        }
     }
 
     signingConfigs {

--- a/vector/src/main/java/im/vector/riotx/features/version/Version.kt
+++ b/vector/src/main/java/im/vector/riotx/features/version/Version.kt
@@ -19,7 +19,7 @@ package im.vector.riotx.features.version
 import im.vector.riotx.BuildConfig
 
 fun getVersion(longFormat: Boolean, useBuildNumber: Boolean): String {
-    var result = BuildConfig.VERSION_NAME
+    var result = "${BuildConfig.VERSION_NAME} [${BuildConfig.VERSION_CODE}]"
 
     var flavor = BuildConfig.SHORT_FLAVOR_DESCRIPTION
 


### PR DESCRIPTION
Split APK per arch.
Also cleanup unwanted library

APK size is reduced from about 31Mo to about 18Mo each
