### PR TITLE
Slide-in reply icon is distorted

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,7 @@ Other changes:
  -
 
 Bugfix:
- -
+ - Slide-in reply icon is distorted (#423)
 
 Translations:
  -

--- a/vector/src/main/java/im/vector/riotx/features/home/room/detail/RoomMessageTouchHelperCallback.kt
+++ b/vector/src/main/java/im/vector/riotx/features/home/room/detail/RoomMessageTouchHelperCallback.kt
@@ -191,12 +191,13 @@ class RoomMessageTouchHelperCallback(private val context: Context,
         }
 
         val y = (itemView.top + itemView.measuredHeight / 2).toFloat()
-        //magic numbers?
+        val hw = imageDrawable.intrinsicWidth / 2f
+        val hh = imageDrawable.intrinsicHeight / 2f
         imageDrawable.setBounds(
-                (x - convertToPx(12) * scale).toInt(),
-                (y - convertToPx(11) * scale).toInt(),
-                (x + convertToPx(12) * scale).toInt(),
-                (y + convertToPx(10) * scale).toInt()
+                (x - hw * scale).toInt(),
+                (y - hh * scale).toInt(),
+                (x + hw * scale).toInt(),
+                (y + hh * scale).toInt()
         )
         imageDrawable.draw(canvas)
         imageDrawable.alpha = 255


### PR DESCRIPTION
Fixes #423 

<img width="241" alt="image" src="https://user-images.githubusercontent.com/9841565/63230828-3787ea00-c1e0-11e9-8769-320e4ea467ff.png">
