### PR TITLE
Some video won't play

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ Bugfix:
  - Fix text diff linebreak display (#441)
  - Date change message repeats for each redaction until a normal message (#358)
  - Slide-in reply icon is distorted (#423)
+ - Some video won't play
 
 Translations:
  -

--- a/vector/src/main/res/layout/activity_video_media_viewer.xml
+++ b/vector/src/main/res/layout/activity_video_media_viewer.xml
@@ -34,7 +34,9 @@
             android:id="@+id/videoMediaViewerThumbnailView"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
+            android:layout_gravity="center"
             android:visibility="gone"
+            android:scaleType="centerInside"
             tools:visibility="visible" />
 
         <ProgressBar
@@ -49,6 +51,7 @@
             android:id="@+id/videoMediaViewerVideoView"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
+            android:layout_gravity="center"
             android:visibility="gone" />
 
         <TextView


### PR DESCRIPTION
VideoView fails to play some remote uri video on some device. For now video is downloaded locally in internal cache then played. 
This offers basic support before full media preview implementation
