### PR TITLE
Fix rendering issue of accepted third party invitation event

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@ Translations:
 
 Build:
  - Fix issue with version name (#533)
+ - Fix rendering issue of accepted third party invitation event
 
 Changes in RiotX 0.4.0 (2019-XX-XX)
 ===================================================

--- a/vector/src/main/java/im/vector/riotx/features/home/room/detail/timeline/format/NoticeEventFormatter.kt
+++ b/vector/src/main/java/im/vector/riotx/features/home/room/detail/timeline/format/NoticeEventFormatter.kt
@@ -95,8 +95,7 @@ class NoticeEventFormatter @Inject constructor(private val stringProvider: Strin
     }
 
     private fun formatRoomHistoryVisibilityEvent(event: Event, senderName: String?): CharSequence? {
-        val historyVisibility = event.getClearContent().toModel<RoomHistoryVisibilityContent>()?.historyVisibility
-                                ?: return null
+        val historyVisibility = event.getClearContent().toModel<RoomHistoryVisibilityContent>()?.historyVisibility ?: return null
 
         val formattedVisibility = when (historyVisibility) {
             RoomHistoryVisibility.SHARED         -> stringProvider.getString(R.string.notice_room_visibility_shared)
@@ -146,7 +145,7 @@ class NoticeEventFormatter @Inject constructor(private val stringProvider: Strin
                     stringProvider.getString(R.string.notice_display_name_removed, event.senderId, prevEventContent?.displayName)
                 else                                          ->
                     stringProvider.getString(R.string.notice_display_name_changed_from,
-                                             event.senderId, prevEventContent?.displayName, eventContent?.displayName)
+                            event.senderId, prevEventContent?.displayName, eventContent?.displayName)
             }
             displayText.append(displayNameText)
         }
@@ -171,9 +170,11 @@ class NoticeEventFormatter @Inject constructor(private val stringProvider: Strin
                 // TODO get userId
                 val selfUserId = ""
                 when {
-                    eventContent.thirdPartyInvite != null        ->
+                    eventContent.thirdPartyInvite != null        -> {
+                        val userWhoHasAccepted = eventContent.thirdPartyInvite?.signed?.mxid ?: event.stateKey
                         stringProvider.getString(R.string.notice_room_third_party_registered_invite,
-                                                 targetDisplayName, eventContent.thirdPartyInvite?.displayName)
+                                userWhoHasAccepted, eventContent.thirdPartyInvite?.displayName)
+                    }
                     TextUtils.equals(event.stateKey, selfUserId) ->
                         stringProvider.getString(R.string.notice_room_invite_you, senderDisplayName)
                     event.stateKey.isNullOrEmpty()               ->

--- a/vector/src/main/java/im/vector/riotx/features/home/room/detail/timeline/format/NoticeEventFormatter.kt
+++ b/vector/src/main/java/im/vector/riotx/features/home/room/detail/timeline/format/NoticeEventFormatter.kt
@@ -24,12 +24,14 @@ import im.vector.matrix.android.api.session.room.model.*
 import im.vector.matrix.android.api.session.room.model.call.CallInviteContent
 import im.vector.matrix.android.api.session.room.timeline.TimelineEvent
 import im.vector.riotx.R
+import im.vector.riotx.core.di.ActiveSessionHolder
 import im.vector.riotx.core.resources.StringProvider
 import im.vector.riotx.features.home.room.detail.timeline.helper.senderName
 import timber.log.Timber
 import javax.inject.Inject
 
-class NoticeEventFormatter @Inject constructor(private val stringProvider: StringProvider) {
+class NoticeEventFormatter @Inject constructor(private val sessionHolder: ActiveSessionHolder,
+                                               private val stringProvider: StringProvider) {
 
     fun format(timelineEvent: TimelineEvent): CharSequence? {
         return when (val type = timelineEvent.root.getClearType()) {
@@ -167,8 +169,7 @@ class NoticeEventFormatter @Inject constructor(private val stringProvider: Strin
         val targetDisplayName = eventContent?.displayName ?: prevEventContent?.displayName ?: ""
         return when {
             Membership.INVITE == eventContent?.membership -> {
-                // TODO get userId
-                val selfUserId = ""
+                val selfUserId = sessionHolder.getSafeActiveSession()?.myUserId
                 when {
                     eventContent.thirdPartyInvite != null        -> {
                         val userWhoHasAccepted = eventContent.thirdPartyInvite?.signed?.mxid ?: event.stateKey


### PR DESCRIPTION
Before:

![Screenshot 2019-09-06 at 14 30 59](https://user-images.githubusercontent.com/3940906/64428258-96d86c00-d0b3-11e9-8725-3fa10e4014dd.png)

After:

![image](https://user-images.githubusercontent.com/3940906/64428247-93dd7b80-d0b3-11e9-8314-b0d935e415ca.png)

Riot-Android uses the stateKey first, but I think it's better to use the mxid.