### PR TITLE
Clean up push rules management and fixes several issues

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ Bugfix:
  - Fix characters erased from the Search field when the result are coming (#545)
  - "No connection" banner was displayed by mistake
  - Leaving community (from another client) has no effect on RiotX (#497)
+ - Push rules was not retrieved after a clear cache
 
 Translations:
  -

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@ Bugfix:
  - "No connection" banner was displayed by mistake
  - Leaving community (from another client) has no effect on RiotX (#497)
  - Push rules was not retrieved after a clear cache
+ - m.notice messages trigger push notifications (#238)
 
 Translations:
  -

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/pushrules/PushRuleService.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/pushrules/PushRuleService.kt
@@ -25,14 +25,14 @@ interface PushRuleService {
     /**
      * Fetch the push rules from the server
      */
-    fun fetchPushRules(scope: String = "global")
+    fun fetchPushRules(scope: String = RuleScope.GLOBAL)
 
     //TODO get push rule set
-    fun getPushRules(scope: String = "global"): List<PushRule>
+    fun getPushRules(scope: String = RuleScope.GLOBAL): List<PushRule>
 
     //TODO update rule
 
-    fun updatePushRuleEnableStatus(kind: String, pushRule: PushRule, enabled: Boolean, callback: MatrixCallback<Unit>): Cancelable
+    fun updatePushRuleEnableStatus(kind: RuleKind, pushRule: PushRule, enabled: Boolean, callback: MatrixCallback<Unit>): Cancelable
 
     fun addPushRuleListener(listener: PushRuleListener)
 

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/pushrules/RuleIds.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/pushrules/RuleIds.kt
@@ -37,7 +37,7 @@ object RuleIds {
 
     // Default Underride Rules
     const val RULE_ID_CALL = ".m.rule.call"
-    const val RULE_ID_one_to_one_encrypted_room = ".m.rule.encrypted_room_one_to_one"
+    const val RULE_ID_ONE_TO_ONE_ENCRYPTED_ROOM = ".m.rule.encrypted_room_one_to_one"
     const val RULE_ID_ONE_TO_ONE_ROOM = ".m.rule.room_one_to_one"
     const val RULE_ID_ALL_OTHER_MESSAGES_ROOMS = ".m.rule.message"
     const val RULE_ID_ENCRYPTED = ".m.rule.encrypted"

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/pushrules/RuleScope.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/pushrules/RuleScope.kt
@@ -15,12 +15,6 @@
  */
 package im.vector.matrix.android.api.pushrules
 
-
-enum class RulesetKey(val value: String) {
-    CONTENT("content"),
-    OVERRIDE("override"),
-    ROOM("room"),
-    SENDER("sender"),
-    UNDERRIDE("underride"),
-    UNKNOWN("")
+object RuleScope {
+    const val GLOBAL = "global"
 }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/pushrules/RuleSetKey.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/pushrules/RuleSetKey.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.matrix.android.api.pushrules
+
+/**
+ * Ref: https://matrix.org/docs/spec/client_server/latest#get-matrix-client-r0-pushrules
+ */
+enum class RuleSetKey(val value: String) {
+    CONTENT("content"),
+    OVERRIDE("override"),
+    ROOM("room"),
+    SENDER("sender"),
+    UNDERRIDE("underride")
+}
+
+/**
+ * Ref: https://matrix.org/docs/spec/client_server/latest#get-matrix-client-r0-pushrules-scope-kind-ruleid
+ */
+typealias RuleKind = RuleSetKey

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/pushrules/rest/PushCondition.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/pushrules/rest/PushCondition.kt
@@ -71,7 +71,7 @@ data class PushCondition(
                 this.key?.let { SenderNotificationPermissionCondition(it) }
             }
             Condition.Kind.UNRECOGNIZE                    -> {
-                Timber.e("Unknwon kind $kind")
+                Timber.e("Unknown kind $kind")
                 null
             }
         }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/pushers/Pusher.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/pushers/Pusher.kt
@@ -16,9 +16,6 @@
 package im.vector.matrix.android.api.session.pushers
 
 data class Pusher(
-
-        val userId: String,
-
         val pushKey: String,
         val kind: String,
         val appId: String,

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/model/create/CreateRoomParams.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/model/create/CreateRoomParams.kt
@@ -20,7 +20,6 @@ import android.util.Patterns
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import im.vector.matrix.android.api.MatrixPatterns.isUserId
-import im.vector.matrix.android.api.auth.data.Credentials
 import im.vector.matrix.android.api.auth.data.HomeServerConnectionConfig
 import im.vector.matrix.android.api.session.events.model.Event
 import im.vector.matrix.android.api.session.events.model.EventType
@@ -219,7 +218,7 @@ class CreateRoomParams {
      * @param ids the participant ids to add.
      */
     fun addParticipantIds(hsConfig: HomeServerConnectionConfig,
-                          credentials: Credentials,
+                          userId: String,
                           ids: List<String>) {
         for (id in ids) {
             if (Patterns.EMAIL_ADDRESS.matcher(id).matches() && hsConfig.identityServerUri != null) {
@@ -233,7 +232,7 @@ class CreateRoomParams {
                 invite3pids!!.add(pid)
             } else if (isUserId(id)) {
                 // do not invite oneself
-                if (credentials.userId != id) {
+                if (userId != id) {
                     if (null == invitedUserIds) {
                         invitedUserIds = ArrayList()
                     }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/actions/SetDeviceVerificationAction.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/actions/SetDeviceVerificationAction.kt
@@ -23,8 +23,7 @@ import timber.log.Timber
 import javax.inject.Inject
 
 internal class SetDeviceVerificationAction @Inject constructor(private val cryptoStore: IMXCryptoStore,
-                                                               @UserId
-                                                               private val userId: String,
+                                                               @UserId private val userId: String,
                                                                private val keysBackup: KeysBackup) {
 
     fun handle(verificationStatus: Int, deviceId: String, userId: String) {

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/actions/SetDeviceVerificationAction.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/actions/SetDeviceVerificationAction.kt
@@ -16,14 +16,15 @@
 
 package im.vector.matrix.android.internal.crypto.actions
 
-import im.vector.matrix.android.api.auth.data.Credentials
 import im.vector.matrix.android.internal.crypto.keysbackup.KeysBackup
 import im.vector.matrix.android.internal.crypto.store.IMXCryptoStore
+import im.vector.matrix.android.internal.di.UserId
 import timber.log.Timber
 import javax.inject.Inject
 
 internal class SetDeviceVerificationAction @Inject constructor(private val cryptoStore: IMXCryptoStore,
-                                                               private val credentials: Credentials,
+                                                               @UserId
+                                                               private val userId: String,
                                                                private val keysBackup: KeysBackup) {
 
     fun handle(verificationStatus: Int, deviceId: String, userId: String) {
@@ -39,7 +40,7 @@ internal class SetDeviceVerificationAction @Inject constructor(private val crypt
             device.verified = verificationStatus
             cryptoStore.storeUserDevice(userId, device)
 
-            if (userId == credentials.userId) {
+            if (userId == this.userId) {
                 // If one of the user's own devices is being marked as verified / unverified,
                 // check the key backup status, since whether or not we use this depends on
                 // whether it has a signature from a verified device

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/algorithms/megolm/MXMegolmDecryption.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/algorithms/megolm/MXMegolmDecryption.kt
@@ -18,7 +18,6 @@
 package im.vector.matrix.android.internal.crypto.algorithms.megolm
 
 import android.text.TextUtils
-import im.vector.matrix.android.api.auth.data.Credentials
 import im.vector.matrix.android.api.session.crypto.MXCryptoError
 import im.vector.matrix.android.api.session.events.model.Event
 import im.vector.matrix.android.api.session.events.model.EventType
@@ -40,7 +39,7 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
-internal class MXMegolmDecryption(private val credentials: Credentials,
+internal class MXMegolmDecryption(private val userId: String,
                                   private val olmDevice: MXOlmDevice,
                                   private val deviceListManager: DeviceListManager,
                                   private val outgoingRoomKeyRequestManager: OutgoingRoomKeyRequestManager,
@@ -146,11 +145,11 @@ internal class MXMegolmDecryption(private val credentials: Credentials,
 
         val selfMap = HashMap<String, String>()
         // TODO Replace this hard coded keys (see OutgoingRoomKeyRequestManager)
-        selfMap["userId"] = credentials.userId
+        selfMap["userId"] = userId
         selfMap["deviceId"] = "*"
         recipients.add(selfMap)
 
-        if (!TextUtils.equals(sender, credentials.userId)) {
+        if (!TextUtils.equals(sender, userId)) {
             val senderMap = HashMap<String, String>()
             senderMap["userId"] = sender
             senderMap["deviceId"] = encryptedEventContent.deviceId!!

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/algorithms/megolm/MXMegolmDecryptionFactory.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/algorithms/megolm/MXMegolmDecryptionFactory.kt
@@ -16,7 +16,6 @@
 
 package im.vector.matrix.android.internal.crypto.algorithms.megolm
 
-import im.vector.matrix.android.api.auth.data.Credentials
 import im.vector.matrix.android.internal.crypto.DeviceListManager
 import im.vector.matrix.android.internal.crypto.MXOlmDevice
 import im.vector.matrix.android.internal.crypto.OutgoingRoomKeyRequestManager
@@ -24,10 +23,12 @@ import im.vector.matrix.android.internal.crypto.actions.EnsureOlmSessionsForDevi
 import im.vector.matrix.android.internal.crypto.actions.MessageEncrypter
 import im.vector.matrix.android.internal.crypto.store.IMXCryptoStore
 import im.vector.matrix.android.internal.crypto.tasks.SendToDeviceTask
+import im.vector.matrix.android.internal.di.UserId
 import im.vector.matrix.android.internal.util.MatrixCoroutineDispatchers
 import javax.inject.Inject
 
-internal class MXMegolmDecryptionFactory @Inject constructor(private val credentials: Credentials,
+internal class MXMegolmDecryptionFactory @Inject constructor(@UserId
+                                                             private val userId: String,
                                                              private val olmDevice: MXOlmDevice,
                                                              private val deviceListManager: DeviceListManager,
                                                              private val outgoingRoomKeyRequestManager: OutgoingRoomKeyRequestManager,
@@ -39,7 +40,7 @@ internal class MXMegolmDecryptionFactory @Inject constructor(private val credent
 
     fun create(): MXMegolmDecryption {
         return MXMegolmDecryption(
-                credentials,
+                userId,
                 olmDevice,
                 deviceListManager,
                 outgoingRoomKeyRequestManager,

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/algorithms/megolm/MXMegolmDecryptionFactory.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/algorithms/megolm/MXMegolmDecryptionFactory.kt
@@ -27,8 +27,7 @@ import im.vector.matrix.android.internal.di.UserId
 import im.vector.matrix.android.internal.util.MatrixCoroutineDispatchers
 import javax.inject.Inject
 
-internal class MXMegolmDecryptionFactory @Inject constructor(@UserId
-                                                             private val userId: String,
+internal class MXMegolmDecryptionFactory @Inject constructor(@UserId private val userId: String,
                                                              private val olmDevice: MXOlmDevice,
                                                              private val deviceListManager: DeviceListManager,
                                                              private val outgoingRoomKeyRequestManager: OutgoingRoomKeyRequestManager,

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/algorithms/olm/MXOlmDecryption.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/algorithms/olm/MXOlmDecryption.kt
@@ -17,7 +17,6 @@
 
 package im.vector.matrix.android.internal.crypto.algorithms.olm
 
-import im.vector.matrix.android.api.auth.data.Credentials
 import im.vector.matrix.android.api.session.crypto.MXCryptoError
 import im.vector.matrix.android.api.session.events.model.Event
 import im.vector.matrix.android.api.session.events.model.toModel
@@ -35,8 +34,8 @@ import timber.log.Timber
 internal class MXOlmDecryption(
         // The olm device interface
         private val olmDevice: MXOlmDevice,
-        // the matrix credentials
-        private val credentials: Credentials)
+        // the matrix userId
+        private val userId: String)
     : IMXDecrypting {
 
     override suspend fun decryptEvent(event: Event, timeline: String): MXEventDecryptionResult {
@@ -97,9 +96,9 @@ internal class MXOlmDecryption(
             throw MXCryptoError.Base(MXCryptoError.ErrorType.MISSING_PROPERTY, reason)
         }
 
-        if (olmPayloadContent.recipient != credentials.userId) {
+        if (olmPayloadContent.recipient != userId) {
             Timber.e("## decryptEvent() : Event ${event.eventId}:" +
-                    " Intended recipient ${olmPayloadContent.recipient} does not match our id ${credentials.userId}")
+                    " Intended recipient ${olmPayloadContent.recipient} does not match our id $userId")
             throw MXCryptoError.Base(MXCryptoError.ErrorType.BAD_RECIPIENT,
                     String.format(MXCryptoError.BAD_RECIPIENT_REASON, olmPayloadContent.recipient))
         }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/algorithms/olm/MXOlmDecryptionFactory.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/algorithms/olm/MXOlmDecryptionFactory.kt
@@ -16,16 +16,17 @@
 
 package im.vector.matrix.android.internal.crypto.algorithms.olm
 
-import im.vector.matrix.android.api.auth.data.Credentials
 import im.vector.matrix.android.internal.crypto.MXOlmDevice
+import im.vector.matrix.android.internal.di.UserId
 import javax.inject.Inject
 
 internal class MXOlmDecryptionFactory @Inject constructor(private val olmDevice: MXOlmDevice,
-                                                          private val credentials: Credentials) {
+                                                          @UserId
+                                                          private val userId: String) {
 
     fun create(): MXOlmDecryption {
         return MXOlmDecryption(
                 olmDevice,
-                credentials)
+                userId)
     }
 }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/algorithms/olm/MXOlmDecryptionFactory.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/algorithms/olm/MXOlmDecryptionFactory.kt
@@ -21,8 +21,7 @@ import im.vector.matrix.android.internal.di.UserId
 import javax.inject.Inject
 
 internal class MXOlmDecryptionFactory @Inject constructor(private val olmDevice: MXOlmDevice,
-                                                          @UserId
-                                                          private val userId: String) {
+                                                          @UserId private val userId: String) {
 
     fun create(): MXOlmDecryption {
         return MXOlmDecryption(

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/tasks/DeleteDeviceWithUserPasswordTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/tasks/DeleteDeviceWithUserPasswordTask.kt
@@ -16,11 +16,11 @@
 
 package im.vector.matrix.android.internal.crypto.tasks
 
-import im.vector.matrix.android.api.auth.data.Credentials
 import im.vector.matrix.android.internal.auth.data.LoginFlowTypes
 import im.vector.matrix.android.internal.crypto.api.CryptoApi
 import im.vector.matrix.android.internal.crypto.model.rest.DeleteDeviceAuth
 import im.vector.matrix.android.internal.crypto.model.rest.DeleteDeviceParams
+import im.vector.matrix.android.internal.di.UserId
 import im.vector.matrix.android.internal.network.executeRequest
 import im.vector.matrix.android.internal.task.Task
 import javax.inject.Inject
@@ -34,7 +34,8 @@ internal interface DeleteDeviceWithUserPasswordTask : Task<DeleteDeviceWithUserP
 }
 
 internal class DefaultDeleteDeviceWithUserPasswordTask @Inject constructor(private val cryptoApi: CryptoApi,
-                                                                           private val credentials: Credentials)
+                                                                           @UserId
+                                                                           private val userId: String)
     : DeleteDeviceWithUserPasswordTask {
 
     override suspend fun execute(params: DeleteDeviceWithUserPasswordTask.Params) {
@@ -45,7 +46,7 @@ internal class DefaultDeleteDeviceWithUserPasswordTask @Inject constructor(priva
                                 .apply {
                                     type = LoginFlowTypes.PASSWORD
                                     session = params.authSession
-                                    user = credentials.userId
+                                    user = userId
                                     password = params.password
                                 }
                     })

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/tasks/DeleteDeviceWithUserPasswordTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/tasks/DeleteDeviceWithUserPasswordTask.kt
@@ -34,8 +34,7 @@ internal interface DeleteDeviceWithUserPasswordTask : Task<DeleteDeviceWithUserP
 }
 
 internal class DefaultDeleteDeviceWithUserPasswordTask @Inject constructor(private val cryptoApi: CryptoApi,
-                                                                           @UserId
-                                                                           private val userId: String)
+                                                                           @UserId private val userId: String)
     : DeleteDeviceWithUserPasswordTask {
 
     override suspend fun execute(params: DeleteDeviceWithUserPasswordTask.Params) {

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/database/mapper/PushersMapper.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/database/mapper/PushersMapper.kt
@@ -26,7 +26,6 @@ internal object PushersMapper {
     fun map(pushEntity: PusherEntity): Pusher {
 
         return Pusher(
-                userId = pushEntity.userId,
                 pushKey = pushEntity.pushKey,
                 kind = pushEntity.kind ?: "",
                 appId = pushEntity.appId,
@@ -39,9 +38,8 @@ internal object PushersMapper {
         )
     }
 
-    fun map(pusher: JsonPusher, userId: String): PusherEntity {
+    fun map(pusher: JsonPusher): PusherEntity {
         return PusherEntity(
-                userId = userId,
                 pushKey = pusher.pushKey,
                 kind = pusher.kind,
                 appId = pusher.appId,
@@ -58,6 +56,6 @@ internal fun PusherEntity.asDomain(): Pusher {
     return PushersMapper.map(this)
 }
 
-internal fun JsonPusher.toEntity(userId: String): PusherEntity {
-    return PushersMapper.map(this, userId)
+internal fun JsonPusher.toEntity(): PusherEntity {
+    return PushersMapper.map(this)
 }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/database/model/PushRulesEntity.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/database/model/PushRulesEntity.kt
@@ -18,12 +18,9 @@ package im.vector.matrix.android.internal.database.model
 import im.vector.matrix.android.api.pushrules.RuleKind
 import io.realm.RealmList
 import io.realm.RealmObject
-import io.realm.annotations.Index
 
 
 internal open class PushRulesEntity(
-        // TODO Remove userId
-        @Index var userId: String = "",
         var scope: String = "",
         var pushRules: RealmList<PushRuleEntity> = RealmList()
 ) : RealmObject() {

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/database/model/PushRulesEntity.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/database/model/PushRulesEntity.kt
@@ -15,17 +15,27 @@
  */
 package im.vector.matrix.android.internal.database.model
 
+import im.vector.matrix.android.api.pushrules.RuleKind
 import io.realm.RealmList
 import io.realm.RealmObject
 import io.realm.annotations.Index
 
 
 internal open class PushRulesEntity(
+        // TODO Remove userId
         @Index var userId: String = "",
         var scope: String = "",
-        // "content", etc.
-        var rulesetKey: String = "",
         var pushRules: RealmList<PushRuleEntity> = RealmList()
 ) : RealmObject() {
+
+    private var kindStr: String = RuleKind.CONTENT.name
+    var kind: RuleKind
+        get() {
+            return RuleKind.valueOf(kindStr)
+        }
+        set(value) {
+            kindStr = value.name
+        }
+
     companion object
 }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/database/model/PusherEntity.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/database/model/PusherEntity.kt
@@ -17,7 +17,6 @@ package im.vector.matrix.android.internal.database.model
 
 import im.vector.matrix.android.api.session.pushers.PusherState
 import io.realm.RealmObject
-import io.realm.annotations.Index
 
 //TODO
 //        at java.lang.Thread.run(Thread.java:764)
@@ -29,8 +28,6 @@ import io.realm.annotations.Index
 //        at im.vector.matrix.android.internal.session.pushers.AddHttpPusherWorker$doWork$$inlined$fold$lambda$2.execute(AddHttpPusherWorker.kt:70)
 //        at io.realm.Realm.executeTransaction(Realm.java:1493)
 internal open class PusherEntity(
-        // TODO Remove userId
-        @Index var userId: String = "",
         var pushKey: String = "",
         var kind: String? = null,
         var appId: String = "",

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/database/model/PusherEntity.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/database/model/PusherEntity.kt
@@ -29,6 +29,7 @@ import io.realm.annotations.Index
 //        at im.vector.matrix.android.internal.session.pushers.AddHttpPusherWorker$doWork$$inlined$fold$lambda$2.execute(AddHttpPusherWorker.kt:70)
 //        at io.realm.Realm.executeTransaction(Realm.java:1493)
 internal open class PusherEntity(
+        // TODO Remove userId
         @Index var userId: String = "",
         var pushKey: String = "",
         var kind: String? = null,

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/database/query/PushersQueries.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/database/query/PushersQueries.kt
@@ -15,6 +15,7 @@
  */
 package im.vector.matrix.android.internal.database.query
 
+import im.vector.matrix.android.api.pushrules.RuleKind
 import im.vector.matrix.android.internal.database.model.PushRulesEntity
 import im.vector.matrix.android.internal.database.model.PushRulesEntityFields
 import im.vector.matrix.android.internal.database.model.PusherEntity
@@ -38,9 +39,9 @@ internal fun PusherEntity.Companion.where(realm: Realm,
 internal fun PushRulesEntity.Companion.where(realm: Realm,
                                              userId: String,
                                              scope: String,
-                                             ruleSetKey: String): RealmQuery<PushRulesEntity> {
+                                             kind: RuleKind): RealmQuery<PushRulesEntity> {
     return realm.where<PushRulesEntity>()
             .equalTo(PushRulesEntityFields.USER_ID, userId)
             .equalTo(PushRulesEntityFields.SCOPE, scope)
-            .equalTo(PushRulesEntityFields.RULESET_KEY, ruleSetKey)
+            .equalTo(PushRulesEntityFields.KIND_STR, kind.name)
 }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/database/query/PushersQueries.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/database/query/PushersQueries.kt
@@ -25,10 +25,8 @@ import io.realm.RealmQuery
 import io.realm.kotlin.where
 
 internal fun PusherEntity.Companion.where(realm: Realm,
-                                          userId: String,
                                           pushKey: String? = null): RealmQuery<PusherEntity> {
     return realm.where<PusherEntity>()
-            .equalTo(PusherEntityFields.USER_ID, userId)
             .apply {
                 if (pushKey != null) {
                     equalTo(PusherEntityFields.PUSH_KEY, pushKey)
@@ -37,11 +35,9 @@ internal fun PusherEntity.Companion.where(realm: Realm,
 }
 
 internal fun PushRulesEntity.Companion.where(realm: Realm,
-                                             userId: String,
                                              scope: String,
                                              kind: RuleKind): RealmQuery<PushRulesEntity> {
     return realm.where<PushRulesEntity>()
-            .equalTo(PushRulesEntityFields.USER_ID, userId)
             .equalTo(PushRulesEntityFields.SCOPE, scope)
             .equalTo(PushRulesEntityFields.KIND_STR, kind.name)
 }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/di/MoshiProvider.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/di/MoshiProvider.kt
@@ -23,6 +23,7 @@ import im.vector.matrix.android.internal.network.parsing.UriMoshiAdapter
 import im.vector.matrix.android.internal.session.sync.model.UserAccountData
 import im.vector.matrix.android.internal.session.sync.model.UserAccountDataDirectMessages
 import im.vector.matrix.android.internal.session.sync.model.UserAccountDataFallback
+import im.vector.matrix.android.internal.session.sync.model.UserAccountDataPushRules
 
 
 object MoshiProvider {
@@ -31,6 +32,7 @@ object MoshiProvider {
             .add(UriMoshiAdapter())
             .add(RuntimeJsonAdapterFactory.of(UserAccountData::class.java, "type", UserAccountDataFallback::class.java)
                     .registerSubtype(UserAccountDataDirectMessages::class.java, UserAccountData.TYPE_DIRECT_MESSAGES)
+                    .registerSubtype(UserAccountDataPushRules::class.java, UserAccountData.TYPE_PUSH_RULES)
             )
             .add(RuntimeJsonAdapterFactory.of(MessageContent::class.java, "msgtype", MessageDefaultContent::class.java)
                     .registerSubtype(MessageTextContent::class.java, MessageType.MSGTYPE_TEXT)

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/di/StringQualifiers.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/di/StringQualifiers.kt
@@ -18,6 +18,16 @@ package im.vector.matrix.android.internal.di
 
 import javax.inject.Qualifier
 
+/**
+ * Used to inject the userId
+ */
 @Qualifier
 @Retention(AnnotationRetention.RUNTIME)
-annotation class UserMd5
+internal annotation class UserId
+
+/**
+ * Used to inject the md5 of the userId
+ */
+@Qualifier
+@Retention(AnnotationRetention.RUNTIME)
+internal annotation class UserMd5

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/DefaultFileService.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/DefaultFileService.kt
@@ -40,8 +40,7 @@ import java.io.IOException
 import javax.inject.Inject
 
 internal class DefaultFileService @Inject constructor(private val context: Context,
-                                                      @UserMd5
-                                                      private val userMd5: String,
+                                                      @UserMd5 private val userMd5: String,
                                                       private val contentUrlResolver: ContentUrlResolver,
                                                       private val coroutineDispatchers: MatrixCoroutineDispatchers) : FileService {
 

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/DefaultFileService.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/DefaultFileService.kt
@@ -20,11 +20,11 @@ import android.content.Context
 import android.os.Environment
 import arrow.core.Try
 import im.vector.matrix.android.api.MatrixCallback
-import im.vector.matrix.android.api.auth.data.SessionParams
 import im.vector.matrix.android.api.session.content.ContentUrlResolver
 import im.vector.matrix.android.api.session.file.FileService
 import im.vector.matrix.android.internal.crypto.attachments.ElementToDecrypt
 import im.vector.matrix.android.internal.crypto.attachments.MXEncryptedAttachments
+import im.vector.matrix.android.internal.di.UserMd5
 import im.vector.matrix.android.internal.extensions.foldToCallback
 import im.vector.matrix.android.internal.util.MatrixCoroutineDispatchers
 import im.vector.matrix.android.internal.util.md5
@@ -40,7 +40,8 @@ import java.io.IOException
 import javax.inject.Inject
 
 internal class DefaultFileService @Inject constructor(private val context: Context,
-                                                      private val sessionParams: SessionParams,
+                                                      @UserMd5
+                                                      private val userMd5: String,
                                                       private val contentUrlResolver: ContentUrlResolver,
                                                       private val coroutineDispatchers: MatrixCoroutineDispatchers) : FileService {
 
@@ -105,7 +106,7 @@ internal class DefaultFileService @Inject constructor(private val context: Conte
                 // Create dir tree (MF stands for Matrix File):
                 // <cache>/MF/<md5(userId)>/<md5(id)>/
                 val tmpFolderRoot = File(context.cacheDir, "MF")
-                val tmpFolderUser = File(tmpFolderRoot, sessionParams.credentials.userId.md5())
+                val tmpFolderUser = File(tmpFolderRoot, userMd5)
                 File(tmpFolderUser, id.md5())
             }
             FileService.DownloadMode.TO_EXPORT        -> {

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/SessionModule.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/SessionModule.kt
@@ -68,10 +68,17 @@ internal abstract class SessionModule {
         }
 
         @JvmStatic
+        @UserId
+        @Provides
+        fun providesUserId(credentials: Credentials): String {
+            return credentials.userId
+        }
+
+        @JvmStatic
         @UserMd5
         @Provides
-        fun providesUserMd5(sessionParams: SessionParams): String {
-            return sessionParams.credentials.userId.md5()
+        fun providesUserMd5(@UserId userId: String): String {
+            return userId.md5()
         }
 
         @JvmStatic

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/filter/DefaultSaveFilterTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/filter/DefaultSaveFilterTask.kt
@@ -33,8 +33,7 @@ internal interface SaveFilterTask : Task<SaveFilterTask.Params, Unit> {
 
 }
 
-internal class DefaultSaveFilterTask @Inject constructor(@UserId
-                                                         private val userId: String,
+internal class DefaultSaveFilterTask @Inject constructor(@UserId private val userId: String,
                                                          private val filterAPI: FilterApi,
                                                          private val filterRepository: FilterRepository
 ) : SaveFilterTask {

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/filter/DefaultSaveFilterTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/filter/DefaultSaveFilterTask.kt
@@ -16,7 +16,7 @@
 
 package im.vector.matrix.android.internal.session.filter
 
-import im.vector.matrix.android.api.auth.data.SessionParams
+import im.vector.matrix.android.internal.di.UserId
 import im.vector.matrix.android.internal.network.executeRequest
 import im.vector.matrix.android.internal.task.Task
 import javax.inject.Inject
@@ -33,7 +33,8 @@ internal interface SaveFilterTask : Task<SaveFilterTask.Params, Unit> {
 
 }
 
-internal class DefaultSaveFilterTask @Inject constructor(private val sessionParams: SessionParams,
+internal class DefaultSaveFilterTask @Inject constructor(@UserId
+                                                         private val userId: String,
                                                          private val filterAPI: FilterApi,
                                                          private val filterRepository: FilterRepository
 ) : SaveFilterTask {
@@ -41,7 +42,7 @@ internal class DefaultSaveFilterTask @Inject constructor(private val sessionPara
     override suspend fun execute(params: SaveFilterTask.Params) {
         val filterResponse = executeRequest<FilterResponse> {
             // TODO auto retry
-            apiCall = filterAPI.uploadFilter(sessionParams.credentials.userId, params.filter)
+            apiCall = filterAPI.uploadFilter(userId, params.filter)
         }
         filterRepository.storeFilterId(params.filter, filterResponse.filterId)
     }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/group/GroupSummaryUpdater.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/group/GroupSummaryUpdater.kt
@@ -20,12 +20,12 @@ import android.content.Context
 import androidx.work.ExistingWorkPolicy
 import androidx.work.WorkManager
 import com.zhuinden.monarchy.Monarchy
-import im.vector.matrix.android.api.auth.data.Credentials
 import im.vector.matrix.android.api.session.room.model.Membership
 import im.vector.matrix.android.internal.database.RealmLiveEntityObserver
 import im.vector.matrix.android.internal.database.model.GroupEntity
 import im.vector.matrix.android.internal.database.model.GroupSummaryEntity
 import im.vector.matrix.android.internal.database.query.where
+import im.vector.matrix.android.internal.di.UserId
 import im.vector.matrix.android.internal.worker.WorkManagerUtil
 import im.vector.matrix.android.internal.worker.WorkManagerUtil.matrixOneTimeWorkRequestBuilder
 import im.vector.matrix.android.internal.worker.WorkerParamsFactory
@@ -36,7 +36,8 @@ import javax.inject.Inject
 private const val GET_GROUP_DATA_WORKER = "GET_GROUP_DATA_WORKER"
 
 internal class GroupSummaryUpdater @Inject constructor(private val context: Context,
-                                                       private val credentials: Credentials,
+                                                       @UserId
+                                                       private val userId: String,
                                                        private val monarchy: Monarchy)
     : RealmLiveEntityObserver<GroupEntity>(monarchy.realmConfiguration) {
 
@@ -60,7 +61,8 @@ internal class GroupSummaryUpdater @Inject constructor(private val context: Cont
     }
 
     private fun fetchGroupsData(groupIds: List<String>) {
-        val getGroupDataWorkerParams = GetGroupDataWorker.Params(credentials.userId, groupIds)
+        val getGroupDataWorkerParams = GetGroupDataWorker.Params(userId, groupIds)
+
         val workData = WorkerParamsFactory.toData(getGroupDataWorkerParams)
 
         val sendWork = matrixOneTimeWorkRequestBuilder<GetGroupDataWorker>()

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/group/GroupSummaryUpdater.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/group/GroupSummaryUpdater.kt
@@ -36,8 +36,7 @@ import javax.inject.Inject
 private const val GET_GROUP_DATA_WORKER = "GET_GROUP_DATA_WORKER"
 
 internal class GroupSummaryUpdater @Inject constructor(private val context: Context,
-                                                       @UserId
-                                                       private val userId: String,
+                                                       @UserId private val userId: String,
                                                        private val monarchy: Monarchy)
     : RealmLiveEntityObserver<GroupEntity>(monarchy.realmConfiguration) {
 

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/notification/DefaultPushRuleService.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/notification/DefaultPushRuleService.kt
@@ -87,7 +87,8 @@ internal class DefaultPushRuleService @Inject constructor(private val getPushRul
                     }
         }
 
-        return contentRules + overrideRules + roomRules + senderRules + underrideRules
+        // Ref. for the order: https://matrix.org/docs/spec/client_server/latest#push-rules
+        return overrideRules + contentRules + roomRules + senderRules + underrideRules
     }
 
     override fun updatePushRuleEnableStatus(kind: RuleKind, pushRule: PushRule, enabled: Boolean, callback: MatrixCallback<Unit>): Cancelable {

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/notification/DefaultPushRuleService.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/notification/DefaultPushRuleService.kt
@@ -58,8 +58,6 @@ internal class DefaultPushRuleService @Inject constructor(private val getPushRul
         var underrideRules: List<PushRule> = emptyList()
 
         monarchy.doWithRealm { realm ->
-            // FIXME PushRulesEntity are not always created here...
-            // FIWME Get the push rules from the sync
             PushRulesEntity.where(realm, scope, RuleSetKey.CONTENT)
                     .findFirst()
                     ?.let { pushRulesEntity ->

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/notification/DefaultPushRuleService.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/notification/DefaultPushRuleService.kt
@@ -27,7 +27,6 @@ import im.vector.matrix.android.api.util.Cancelable
 import im.vector.matrix.android.internal.database.mapper.PushRulesMapper
 import im.vector.matrix.android.internal.database.model.PushRulesEntity
 import im.vector.matrix.android.internal.database.query.where
-import im.vector.matrix.android.internal.di.UserId
 import im.vector.matrix.android.internal.session.SessionScope
 import im.vector.matrix.android.internal.session.pushers.GetPushRulesTask
 import im.vector.matrix.android.internal.session.pushers.UpdatePushRuleEnableStatusTask
@@ -37,13 +36,10 @@ import timber.log.Timber
 import javax.inject.Inject
 
 @SessionScope
-internal class DefaultPushRuleService @Inject constructor(
-        @UserId
-        private val userId: String,
-        private val getPushRulesTask: GetPushRulesTask,
-        private val updatePushRuleEnableStatusTask: UpdatePushRuleEnableStatusTask,
-        private val taskExecutor: TaskExecutor,
-        private val monarchy: Monarchy
+internal class DefaultPushRuleService @Inject constructor(private val getPushRulesTask: GetPushRulesTask,
+                                                          private val updatePushRuleEnableStatusTask: UpdatePushRuleEnableStatusTask,
+                                                          private val taskExecutor: TaskExecutor,
+                                                          private val monarchy: Monarchy
 ) : PushRuleService {
 
     private var listeners = ArrayList<PushRuleService.PushRuleListener>()
@@ -64,27 +60,27 @@ internal class DefaultPushRuleService @Inject constructor(
         monarchy.doWithRealm { realm ->
             // FIXME PushRulesEntity are not always created here...
             // FIWME Get the push rules from the sync
-            PushRulesEntity.where(realm, userId, scope, RuleSetKey.CONTENT)
+            PushRulesEntity.where(realm, scope, RuleSetKey.CONTENT)
                     .findFirst()
                     ?.let { pushRulesEntity ->
                         contentRules = pushRulesEntity.pushRules.map { PushRulesMapper.mapContentRule(it) }
                     }
-            PushRulesEntity.where(realm, userId, scope, RuleSetKey.OVERRIDE)
+            PushRulesEntity.where(realm, scope, RuleSetKey.OVERRIDE)
                     .findFirst()
                     ?.let { pushRulesEntity ->
                         overrideRules = pushRulesEntity.pushRules.map { PushRulesMapper.map(it) }
                     }
-            PushRulesEntity.where(realm, userId, scope, RuleSetKey.ROOM)
+            PushRulesEntity.where(realm, scope, RuleSetKey.ROOM)
                     .findFirst()
                     ?.let { pushRulesEntity ->
                         roomRules = pushRulesEntity.pushRules.map { PushRulesMapper.mapRoomRule(it) }
                     }
-            PushRulesEntity.where(realm, userId, scope, RuleSetKey.SENDER)
+            PushRulesEntity.where(realm, scope, RuleSetKey.SENDER)
                     .findFirst()
                     ?.let { pushRulesEntity ->
                         senderRules = pushRulesEntity.pushRules.map { PushRulesMapper.mapSenderRule(it) }
                     }
-            PushRulesEntity.where(realm, userId, scope, RuleSetKey.UNDERRIDE)
+            PushRulesEntity.where(realm, scope, RuleSetKey.UNDERRIDE)
                     .findFirst()
                     ?.let { pushRulesEntity ->
                         underrideRules = pushRulesEntity.pushRules.map { PushRulesMapper.map(it) }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/notification/DefaultPushRuleService.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/notification/DefaultPushRuleService.kt
@@ -17,10 +17,10 @@ package im.vector.matrix.android.internal.session.notification
 
 import com.zhuinden.monarchy.Monarchy
 import im.vector.matrix.android.api.MatrixCallback
-import im.vector.matrix.android.api.pushrules.Action
 import im.vector.matrix.android.api.pushrules.PushRuleService
 import im.vector.matrix.android.api.pushrules.RuleKind
 import im.vector.matrix.android.api.pushrules.RuleSetKey
+import im.vector.matrix.android.api.pushrules.getActions
 import im.vector.matrix.android.api.pushrules.rest.PushRule
 import im.vector.matrix.android.api.session.events.model.Event
 import im.vector.matrix.android.api.util.Cancelable
@@ -123,8 +123,9 @@ internal class DefaultPushRuleService @Inject constructor(private val getPushRul
 
     fun dispatchBing(event: Event, rule: PushRule) {
         try {
+            val actionsList = rule.getActions()
             listeners.forEach {
-                it.onMatchRule(event, Action.mapFrom(rule) ?: emptyList())
+                it.onMatchRule(event, actionsList)
             }
         } catch (e: Throwable) {
             Timber.e(e, "Error while dispatching bing")

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/notification/ProcessEventForPushTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/notification/ProcessEventForPushTask.kt
@@ -37,8 +37,7 @@ internal interface ProcessEventForPushTask : Task<ProcessEventForPushTask.Params
 internal class DefaultProcessEventForPushTask @Inject constructor(
         private val defaultPushRuleService: DefaultPushRuleService,
         private val roomService: RoomService,
-        @UserId
-        private val userId: String
+        @UserId private val userId: String
 ) : ProcessEventForPushTask {
 
     override suspend fun execute(params: ProcessEventForPushTask.Params) {

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/notification/ProcessEventForPushTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/notification/ProcessEventForPushTask.kt
@@ -102,6 +102,7 @@ internal class DefaultProcessEventForPushTask @Inject constructor(
     }
 
     private fun fulfilledBingRule(event: Event, rules: List<PushRule>): PushRule? {
+        // TODO This should be injected
         val conditionResolver = DefaultConditionResolver(event, roomService, userId)
         rules.filter { it.enabled }.forEach { rule ->
             val isFullfilled = rule.conditions?.map {

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/pushers/DefaultConditionResolver.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/pushers/DefaultConditionResolver.kt
@@ -24,8 +24,7 @@ import timber.log.Timber
 // TODO Inject constructor
 internal class DefaultConditionResolver(private val event: Event,
                                         private val roomService: RoomService,
-                                        @UserId
-                                        private val userId: String) : ConditionResolver {
+                                        @UserId private val userId: String) : ConditionResolver {
 
 
     override fun resolveEventMatchCondition(eventMatchCondition: EventMatchCondition): Boolean {

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/pushers/DefaultConditionResolver.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/pushers/DefaultConditionResolver.kt
@@ -15,15 +15,16 @@
  */
 package im.vector.matrix.android.internal.session.pushers
 
-import im.vector.matrix.android.api.auth.data.SessionParams
 import im.vector.matrix.android.api.pushrules.*
 import im.vector.matrix.android.api.session.events.model.Event
 import im.vector.matrix.android.api.session.room.RoomService
+import im.vector.matrix.android.internal.di.UserId
 import timber.log.Timber
 
 internal class DefaultConditionResolver(private val event: Event,
                                         private val roomService: RoomService,
-                                        private val sessionParams: SessionParams) : ConditionResolver {
+                                        @UserId
+                                        private val userId: String) : ConditionResolver {
 
 
     override fun resolveEventMatchCondition(eventMatchCondition: EventMatchCondition): Boolean {
@@ -45,8 +46,7 @@ internal class DefaultConditionResolver(private val event: Event,
     override fun resolveContainsDisplayNameCondition(containsDisplayNameCondition: ContainsDisplayNameCondition): Boolean {
         val roomId = event.roomId ?: return false
         val room = roomService.getRoom(roomId) ?: return false
-        val myDisplayName = room.getRoomMember(sessionParams.credentials.userId)?.displayName
-                ?: return false
+        val myDisplayName = room.getRoomMember(userId)?.displayName ?: return false
         return containsDisplayNameCondition.isSatisfied(event, myDisplayName)
     }
 }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/pushers/DefaultConditionResolver.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/pushers/DefaultConditionResolver.kt
@@ -21,6 +21,7 @@ import im.vector.matrix.android.api.session.room.RoomService
 import im.vector.matrix.android.internal.di.UserId
 import timber.log.Timber
 
+// TODO Inject constructor
 internal class DefaultConditionResolver(private val event: Event,
                                         private val roomService: RoomService,
                                         @UserId

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/pushers/DefaultPusherService.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/pushers/DefaultPusherService.kt
@@ -39,8 +39,7 @@ import javax.inject.Inject
 
 internal class DefaultPusherService @Inject constructor(private val context: Context,
                                                         private val monarchy: Monarchy,
-                                                        @UserId
-                                                        private val userId: String,
+                                                        @UserId private val userId: String,
                                                         private val getPusherTask: GetPushersTask,
                                                         private val removePusherTask: RemovePusherTask,
                                                         private val taskExecutor: TaskExecutor

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/pushers/DefaultPusherService.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/pushers/DefaultPusherService.kt
@@ -82,7 +82,7 @@ internal class DefaultPusherService @Inject constructor(private val context: Con
     }
 
     override fun removeHttpPusher(pushkey: String, appId: String, callback: MatrixCallback<Unit>) {
-        val params = RemovePusherTask.Params(userId, pushkey, appId)
+        val params = RemovePusherTask.Params(pushkey, appId)
         removePusherTask
                 .configureWith(params) {
                     this.callback = callback
@@ -93,12 +93,12 @@ internal class DefaultPusherService @Inject constructor(private val context: Con
 
     override fun livePushers(): LiveData<List<Pusher>> {
         return monarchy.findAllMappedWithChanges(
-                { realm -> PusherEntity.where(realm, userId) },
+                { realm -> PusherEntity.where(realm) },
                 { it.asDomain() }
         )
     }
 
     override fun pushers(): List<Pusher> {
-        return monarchy.fetchAllCopiedSync { PusherEntity.where(it, userId) }.map { it.asDomain() }
+        return monarchy.fetchAllCopiedSync { PusherEntity.where(it) }.map { it.asDomain() }
     }
 }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/pushers/DefaultPusherService.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/pushers/DefaultPusherService.kt
@@ -21,29 +21,29 @@ import androidx.work.BackoffPolicy
 import androidx.work.WorkManager
 import com.zhuinden.monarchy.Monarchy
 import im.vector.matrix.android.api.MatrixCallback
-import im.vector.matrix.android.api.auth.data.SessionParams
 import im.vector.matrix.android.api.session.pushers.Pusher
 import im.vector.matrix.android.api.session.pushers.PushersService
 import im.vector.matrix.android.internal.database.mapper.asDomain
 import im.vector.matrix.android.internal.database.model.PusherEntity
 import im.vector.matrix.android.internal.database.query.where
+import im.vector.matrix.android.internal.di.UserId
 import im.vector.matrix.android.internal.task.TaskExecutor
 import im.vector.matrix.android.internal.task.configureWith
 import im.vector.matrix.android.internal.worker.WorkManagerUtil
 import im.vector.matrix.android.internal.worker.WorkManagerUtil.matrixOneTimeWorkRequestBuilder
 import im.vector.matrix.android.internal.worker.WorkerParamsFactory
-import java.util.UUID
+import java.util.*
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
 
-internal class DefaultPusherService @Inject constructor(
-        private val context: Context,
-        private val monarchy: Monarchy,
-        private val sessionParam: SessionParams,
-        private val getPusherTask: GetPushersTask,
-        private val removePusherTask: RemovePusherTask,
-        private val taskExecutor: TaskExecutor
+internal class DefaultPusherService @Inject constructor(private val context: Context,
+                                                        private val monarchy: Monarchy,
+                                                        @UserId
+                                                        private val userId: String,
+                                                        private val getPusherTask: GetPushersTask,
+                                                        private val removePusherTask: RemovePusherTask,
+                                                        private val taskExecutor: TaskExecutor
 ) : PushersService {
 
 
@@ -70,7 +70,7 @@ internal class DefaultPusherService @Inject constructor(
                 append = append)
 
 
-        val params = AddHttpPusherWorker.Params(pusher, sessionParam.credentials.userId)
+        val params = AddHttpPusherWorker.Params(pusher, userId)
 
         val request = matrixOneTimeWorkRequestBuilder<AddHttpPusherWorker>()
                 .setConstraints(WorkManagerUtil.workConstraints)
@@ -82,7 +82,7 @@ internal class DefaultPusherService @Inject constructor(
     }
 
     override fun removeHttpPusher(pushkey: String, appId: String, callback: MatrixCallback<Unit>) {
-        val params = RemovePusherTask.Params(sessionParam.credentials.userId, pushkey, appId)
+        val params = RemovePusherTask.Params(userId, pushkey, appId)
         removePusherTask
                 .configureWith(params) {
                     this.callback = callback
@@ -93,12 +93,12 @@ internal class DefaultPusherService @Inject constructor(
 
     override fun livePushers(): LiveData<List<Pusher>> {
         return monarchy.findAllMappedWithChanges(
-                { realm -> PusherEntity.where(realm, sessionParam.credentials.userId) },
+                { realm -> PusherEntity.where(realm, userId) },
                 { it.asDomain() }
         )
     }
 
     override fun pushers(): List<Pusher> {
-        return monarchy.fetchAllCopiedSync { PusherEntity.where(it, sessionParam.credentials.userId) }.map { it.asDomain() }
+        return monarchy.fetchAllCopiedSync { PusherEntity.where(it, userId) }.map { it.asDomain() }
     }
 }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/pushers/GetPushRulesTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/pushers/GetPushRulesTask.kt
@@ -15,14 +15,9 @@
  */
 package im.vector.matrix.android.internal.session.pushers
 
-import com.zhuinden.monarchy.Monarchy
-import im.vector.matrix.android.api.pushrules.RuleSetKey
 import im.vector.matrix.android.api.pushrules.rest.GetPushRulesResponse
-import im.vector.matrix.android.internal.database.mapper.PushRulesMapper
-import im.vector.matrix.android.internal.database.model.PushRulesEntity
 import im.vector.matrix.android.internal.network.executeRequest
 import im.vector.matrix.android.internal.task.Task
-import im.vector.matrix.android.internal.util.awaitTransaction
 import javax.inject.Inject
 
 
@@ -30,52 +25,17 @@ internal interface GetPushRulesTask : Task<GetPushRulesTask.Params, Unit> {
     data class Params(val scope: String)
 }
 
+/**
+ * We keep this task, but it should not be used anymore, the push rules comes from the sync response
+ */
 internal class DefaultGetPushRulesTask @Inject constructor(private val pushRulesApi: PushRulesApi,
-                                                           private val monarchy: Monarchy) : GetPushRulesTask {
+                                                           private val savePushRulesTask: SavePushRulesTask) : GetPushRulesTask {
 
     override suspend fun execute(params: GetPushRulesTask.Params) {
         val response = executeRequest<GetPushRulesResponse> {
             apiCall = pushRulesApi.getAllRules()
         }
-        val scope = params.scope
-        monarchy.awaitTransaction { realm ->
-            //clear existings?
-            //TODO
-            realm.where(PushRulesEntity::class.java)
-                    .findAll()
-                    .deleteAllFromRealm()
 
-            val content = PushRulesEntity(scope).apply { kind = RuleSetKey.CONTENT }
-            response.global.content?.forEach { rule ->
-                content.pushRules.add(PushRulesMapper.map(rule))
-            }
-            realm.insertOrUpdate(content)
-
-            val override = PushRulesEntity(scope).apply { kind = RuleSetKey.OVERRIDE }
-            response.global.override?.forEach { rule ->
-                PushRulesMapper.map(rule).also {
-                    override.pushRules.add(it)
-                }
-            }
-            realm.insertOrUpdate(override)
-
-            val rooms = PushRulesEntity(scope).apply { kind = RuleSetKey.ROOM }
-            response.global.room?.forEach { rule ->
-                rooms.pushRules.add(PushRulesMapper.map(rule))
-            }
-            realm.insertOrUpdate(rooms)
-
-            val senders = PushRulesEntity(scope).apply { kind = RuleSetKey.SENDER }
-            response.global.sender?.forEach { rule ->
-                senders.pushRules.add(PushRulesMapper.map(rule))
-            }
-            realm.insertOrUpdate(senders)
-
-            val underrides = PushRulesEntity(scope).apply { kind = RuleSetKey.UNDERRIDE }
-            response.global.underride?.forEach { rule ->
-                underrides.pushRules.add(PushRulesMapper.map(rule))
-            }
-            realm.insertOrUpdate(underrides)
-        }
+        savePushRulesTask.execute(SavePushRulesTask.Params(response))
     }
 }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/pushers/GetPushersTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/pushers/GetPushersTask.kt
@@ -16,11 +16,11 @@
 package im.vector.matrix.android.internal.session.pushers
 
 import com.zhuinden.monarchy.Monarchy
-import im.vector.matrix.android.api.auth.data.SessionParams
 import im.vector.matrix.android.api.session.pushers.PusherState
 import im.vector.matrix.android.internal.database.mapper.toEntity
 import im.vector.matrix.android.internal.database.model.PusherEntity
 import im.vector.matrix.android.internal.database.model.PusherEntityFields
+import im.vector.matrix.android.internal.di.UserId
 import im.vector.matrix.android.internal.network.executeRequest
 import im.vector.matrix.android.internal.task.Task
 import im.vector.matrix.android.internal.util.awaitTransaction
@@ -30,7 +30,8 @@ internal interface GetPushersTask : Task<Unit, Unit>
 
 internal class DefaultGetPusherTask @Inject constructor(private val pushersAPI: PushersAPI,
                                                         private val monarchy: Monarchy,
-                                                        private val sessionParams: SessionParams) : GetPushersTask {
+                                                        @UserId
+                                                        private val userId: String) : GetPushersTask {
 
     override suspend fun execute(params: Unit) {
         val response = executeRequest<GetPushersResponse> {
@@ -39,10 +40,10 @@ internal class DefaultGetPusherTask @Inject constructor(private val pushersAPI: 
         monarchy.awaitTransaction { realm ->
             //clear existings?
             realm.where(PusherEntity::class.java)
-                    .equalTo(PusherEntityFields.USER_ID, sessionParams.credentials.userId)
+                    .equalTo(PusherEntityFields.USER_ID, userId)
                     .findAll().deleteAllFromRealm()
             response.pushers?.forEach { jsonPusher ->
-                jsonPusher.toEntity(sessionParams.credentials.userId).also {
+                jsonPusher.toEntity(userId).also {
                     it.state = PusherState.REGISTERED
                     realm.insertOrUpdate(it)
                 }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/pushers/PushRulesApi.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/pushers/PushRulesApi.kt
@@ -15,6 +15,7 @@
  */
 package im.vector.matrix.android.internal.session.pushers
 
+import im.vector.matrix.android.api.pushrules.RuleKind
 import im.vector.matrix.android.api.pushrules.rest.GetPushRulesResponse
 import im.vector.matrix.android.api.pushrules.rest.PushRule
 import im.vector.matrix.android.internal.network.NetworkConstants
@@ -37,7 +38,7 @@ internal interface PushRulesApi {
      * @param enable the new enable status
      */
     @PUT(NetworkConstants.URI_API_PREFIX_PATH_R0 + "pushrules/global/{kind}/{ruleId}/enabled")
-    fun updateEnableRuleStatus(@Path("kind") kind: String,
+    fun updateEnableRuleStatus(@Path("kind") kind: RuleKind,
                                @Path("ruleId") ruleId: String,
                                @Body enable: Boolean?)
             : Call<Unit>
@@ -51,7 +52,7 @@ internal interface PushRulesApi {
      * @param actions the actions
      */
     @PUT(NetworkConstants.URI_API_PREFIX_PATH_R0 + "pushrules/global/{kind}/{ruleId}/actions")
-    fun updateRuleActions(@Path("kind") kind: String,
+    fun updateRuleActions(@Path("kind") kind: RuleKind,
                           @Path("ruleId") ruleId: String,
                           @Body actions: Any)
             : Call<Unit>
@@ -64,7 +65,7 @@ internal interface PushRulesApi {
      * @param ruleId the ruleId
      */
     @DELETE(NetworkConstants.URI_API_PREFIX_PATH_R0 + "pushrules/global/{kind}/{ruleId}")
-    fun deleteRule(@Path("kind") kind: String,
+    fun deleteRule(@Path("kind") kind: RuleKind,
                    @Path("ruleId") ruleId: String)
             : Call<Unit>
 
@@ -76,7 +77,7 @@ internal interface PushRulesApi {
      * @param rule   the rule to add.
      */
     @PUT(NetworkConstants.URI_API_PREFIX_PATH_R0 + "pushrules/global/{kind}/{ruleId}")
-    fun addRule(@Path("kind") kind: String,
+    fun addRule(@Path("kind") kind: RuleKind,
                 @Path("ruleId") ruleId: String,
                 @Body rule: PushRule)
             : Call<Unit>

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/pushers/PushRulesApi.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/pushers/PushRulesApi.kt
@@ -15,7 +15,6 @@
  */
 package im.vector.matrix.android.internal.session.pushers
 
-import im.vector.matrix.android.api.pushrules.RuleKind
 import im.vector.matrix.android.api.pushrules.rest.GetPushRulesResponse
 import im.vector.matrix.android.api.pushrules.rest.PushRule
 import im.vector.matrix.android.internal.network.NetworkConstants
@@ -38,7 +37,7 @@ internal interface PushRulesApi {
      * @param enable the new enable status
      */
     @PUT(NetworkConstants.URI_API_PREFIX_PATH_R0 + "pushrules/global/{kind}/{ruleId}/enabled")
-    fun updateEnableRuleStatus(@Path("kind") kind: RuleKind,
+    fun updateEnableRuleStatus(@Path("kind") kind: String,
                                @Path("ruleId") ruleId: String,
                                @Body enable: Boolean?)
             : Call<Unit>
@@ -52,7 +51,7 @@ internal interface PushRulesApi {
      * @param actions the actions
      */
     @PUT(NetworkConstants.URI_API_PREFIX_PATH_R0 + "pushrules/global/{kind}/{ruleId}/actions")
-    fun updateRuleActions(@Path("kind") kind: RuleKind,
+    fun updateRuleActions(@Path("kind") kind: String,
                           @Path("ruleId") ruleId: String,
                           @Body actions: Any)
             : Call<Unit>
@@ -65,7 +64,7 @@ internal interface PushRulesApi {
      * @param ruleId the ruleId
      */
     @DELETE(NetworkConstants.URI_API_PREFIX_PATH_R0 + "pushrules/global/{kind}/{ruleId}")
-    fun deleteRule(@Path("kind") kind: RuleKind,
+    fun deleteRule(@Path("kind") kind: String,
                    @Path("ruleId") ruleId: String)
             : Call<Unit>
 
@@ -77,7 +76,7 @@ internal interface PushRulesApi {
      * @param rule   the rule to add.
      */
     @PUT(NetworkConstants.URI_API_PREFIX_PATH_R0 + "pushrules/global/{kind}/{ruleId}")
-    fun addRule(@Path("kind") kind: RuleKind,
+    fun addRule(@Path("kind") kind: String,
                 @Path("ruleId") ruleId: String,
                 @Body rule: PushRule)
             : Call<Unit>

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/pushers/PushersModule.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/pushers/PushersModule.kt
@@ -60,6 +60,9 @@ internal abstract class PushersModule {
     abstract fun bindGetPushRulesTask(getPushRulesTask: DefaultGetPushRulesTask): GetPushRulesTask
 
     @Binds
+    abstract fun bindSavePushRulesTask(savePushRulesTask: DefaultSavePushRulesTask): SavePushRulesTask
+
+    @Binds
     abstract fun bindRemovePusherTask(removePusherTask: DefaultRemovePusherTask): RemovePusherTask
 
     @Binds

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/pushers/SavePushRulesTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/pushers/SavePushRulesTask.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2019 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package im.vector.matrix.android.internal.session.pushers
+
+import com.zhuinden.monarchy.Monarchy
+import im.vector.matrix.android.api.pushrules.RuleScope
+import im.vector.matrix.android.api.pushrules.RuleSetKey
+import im.vector.matrix.android.api.pushrules.rest.GetPushRulesResponse
+import im.vector.matrix.android.internal.database.mapper.PushRulesMapper
+import im.vector.matrix.android.internal.database.model.PushRulesEntity
+import im.vector.matrix.android.internal.task.Task
+import im.vector.matrix.android.internal.util.awaitTransaction
+import javax.inject.Inject
+
+
+/**
+ * Save the push rules in DB
+ */
+internal interface SavePushRulesTask : Task<SavePushRulesTask.Params, Unit> {
+    data class Params(val pushRules: GetPushRulesResponse)
+}
+
+internal class DefaultSavePushRulesTask @Inject constructor(private val monarchy: Monarchy) : SavePushRulesTask {
+
+    override suspend fun execute(params: SavePushRulesTask.Params) {
+        monarchy.awaitTransaction { realm ->
+            //clear existings?
+            //TODO
+            realm.where(PushRulesEntity::class.java)
+                    .findAll()
+                    .deleteAllFromRealm()
+
+            // Save only global rules for the moment
+            val globalRules = params.pushRules.global
+
+            val content = PushRulesEntity(RuleScope.GLOBAL).apply { kind = RuleSetKey.CONTENT }
+            globalRules.content?.forEach { rule ->
+                content.pushRules.add(PushRulesMapper.map(rule))
+            }
+            realm.insertOrUpdate(content)
+
+            val override = PushRulesEntity(RuleScope.GLOBAL).apply { kind = RuleSetKey.OVERRIDE }
+            globalRules.override?.forEach { rule ->
+                PushRulesMapper.map(rule).also {
+                    override.pushRules.add(it)
+                }
+            }
+            realm.insertOrUpdate(override)
+
+            val rooms = PushRulesEntity(RuleScope.GLOBAL).apply { kind = RuleSetKey.ROOM }
+            globalRules.room?.forEach { rule ->
+                rooms.pushRules.add(PushRulesMapper.map(rule))
+            }
+            realm.insertOrUpdate(rooms)
+
+            val senders = PushRulesEntity(RuleScope.GLOBAL).apply { kind = RuleSetKey.SENDER }
+            globalRules.sender?.forEach { rule ->
+                senders.pushRules.add(PushRulesMapper.map(rule))
+            }
+            realm.insertOrUpdate(senders)
+
+            val underrides = PushRulesEntity(RuleScope.GLOBAL).apply { kind = RuleSetKey.UNDERRIDE }
+            globalRules.underride?.forEach { rule ->
+                underrides.pushRules.add(PushRulesMapper.map(rule))
+            }
+            realm.insertOrUpdate(underrides)
+        }
+    }
+}

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/pushers/SavePushRulesTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/pushers/SavePushRulesTask.kt
@@ -37,8 +37,7 @@ internal class DefaultSavePushRulesTask @Inject constructor(private val monarchy
 
     override suspend fun execute(params: SavePushRulesTask.Params) {
         monarchy.awaitTransaction { realm ->
-            //clear existings?
-            //TODO
+            // clear current push rules
             realm.where(PushRulesEntity::class.java)
                     .findAll()
                     .deleteAllFromRealm()

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/pushers/UpdatePushRuleEnableStatusTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/pushers/UpdatePushRuleEnableStatusTask.kt
@@ -33,7 +33,7 @@ internal class DefaultUpdatePushRuleEnableStatusTask @Inject constructor(private
 
     override suspend fun execute(params: UpdatePushRuleEnableStatusTask.Params) {
         return executeRequest {
-            apiCall = pushRulesApi.updateEnableRuleStatus(params.kind, params.pushRule.ruleId, params.enabled)
+            apiCall = pushRulesApi.updateEnableRuleStatus(params.kind.value, params.pushRule.ruleId, params.enabled)
         }
     }
 }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/pushers/UpdatePushRuleEnableStatusTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/pushers/UpdatePushRuleEnableStatusTask.kt
@@ -15,6 +15,7 @@
  */
 package im.vector.matrix.android.internal.session.pushers
 
+import im.vector.matrix.android.api.pushrules.RuleKind
 import im.vector.matrix.android.api.pushrules.rest.PushRule
 import im.vector.matrix.android.internal.network.executeRequest
 import im.vector.matrix.android.internal.task.Task
@@ -22,7 +23,7 @@ import javax.inject.Inject
 
 
 internal interface UpdatePushRuleEnableStatusTask : Task<UpdatePushRuleEnableStatusTask.Params, Unit> {
-    data class Params(val kind: String,
+    data class Params(val kind: RuleKind,
                       val pushRule: PushRule,
                       val enabled: Boolean)
 }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/EventRelationsAggregationUpdater.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/EventRelationsAggregationUpdater.kt
@@ -38,8 +38,7 @@ import javax.inject.Inject
  */
 
 internal class EventRelationsAggregationUpdater @Inject constructor(@SessionDatabase realmConfiguration: RealmConfiguration,
-                                                                    @UserId
-                                                                    private val userId: String,
+                                                                    @UserId private val userId: String,
                                                                     private val task: EventRelationsAggregationTask,
                                                                     private val taskExecutor: TaskExecutor) :
         RealmLiveEntityObserver<EventEntity>(realmConfiguration) {

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/EventRelationsAggregationUpdater.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/EventRelationsAggregationUpdater.kt
@@ -16,13 +16,13 @@
 package im.vector.matrix.android.internal.session.room
 
 import com.zhuinden.monarchy.Monarchy
-import im.vector.matrix.android.api.auth.data.Credentials
 import im.vector.matrix.android.api.session.events.model.EventType
 import im.vector.matrix.android.internal.database.RealmLiveEntityObserver
 import im.vector.matrix.android.internal.database.mapper.asDomain
 import im.vector.matrix.android.internal.database.model.EventEntity
 import im.vector.matrix.android.internal.database.query.types
 import im.vector.matrix.android.internal.di.SessionDatabase
+import im.vector.matrix.android.internal.di.UserId
 import im.vector.matrix.android.internal.task.TaskExecutor
 import im.vector.matrix.android.internal.task.configureWith
 import io.realm.OrderedCollectionChangeSet
@@ -38,7 +38,8 @@ import javax.inject.Inject
  */
 
 internal class EventRelationsAggregationUpdater @Inject constructor(@SessionDatabase realmConfiguration: RealmConfiguration,
-                                                                    private val credentials: Credentials,
+                                                                    @UserId
+                                                                    private val userId: String,
                                                                     private val task: EventRelationsAggregationTask,
                                                                     private val taskExecutor: TaskExecutor) :
         RealmLiveEntityObserver<EventEntity>(realmConfiguration) {
@@ -61,7 +62,7 @@ internal class EventRelationsAggregationUpdater @Inject constructor(@SessionData
                 .toList()
         val params = EventRelationsAggregationTask.Params(
                 insertedDomains,
-                credentials.userId
+                userId
         )
         task.configureWith(params).executeBy(taskExecutor)
     }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/RoomAvatarResolver.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/RoomAvatarResolver.kt
@@ -31,8 +31,7 @@ import im.vector.matrix.android.internal.session.room.membership.RoomMembers
 import javax.inject.Inject
 
 internal class RoomAvatarResolver @Inject constructor(private val monarchy: Monarchy,
-                                                      @UserId
-                                                      private val userId: String) {
+                                                      @UserId private val userId: String) {
 
     /**
      * Compute the room avatar url

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/RoomAvatarResolver.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/RoomAvatarResolver.kt
@@ -17,7 +17,6 @@
 package im.vector.matrix.android.internal.session.room
 
 import com.zhuinden.monarchy.Monarchy
-import im.vector.matrix.android.api.auth.data.Credentials
 import im.vector.matrix.android.api.session.events.model.EventType
 import im.vector.matrix.android.api.session.events.model.toModel
 import im.vector.matrix.android.api.session.room.model.RoomAvatarContent
@@ -27,11 +26,13 @@ import im.vector.matrix.android.internal.database.model.EventEntity
 import im.vector.matrix.android.internal.database.model.EventEntityFields
 import im.vector.matrix.android.internal.database.query.prev
 import im.vector.matrix.android.internal.database.query.where
+import im.vector.matrix.android.internal.di.UserId
 import im.vector.matrix.android.internal.session.room.membership.RoomMembers
 import javax.inject.Inject
 
 internal class RoomAvatarResolver @Inject constructor(private val monarchy: Monarchy,
-                                                      private val credentials: Credentials) {
+                                                      @UserId
+                                                      private val userId: String) {
 
     /**
      * Compute the room avatar url
@@ -52,7 +53,7 @@ internal class RoomAvatarResolver @Inject constructor(private val monarchy: Mona
             if (members.size == 1) {
                 res = members.firstOrNull()?.toRoomMember()?.avatarUrl
             } else if (members.size == 2) {
-                val firstOtherMember = members.where().notEqualTo(EventEntityFields.STATE_KEY, credentials.userId).findFirst()
+                val firstOtherMember = members.where().notEqualTo(EventEntityFields.STATE_KEY, userId).findFirst()
                 res = firstOtherMember?.toRoomMember()?.avatarUrl
             }
         }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/RoomSummaryUpdater.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/RoomSummaryUpdater.kt
@@ -39,8 +39,7 @@ import io.realm.Realm
 import io.realm.kotlin.createObject
 import javax.inject.Inject
 
-internal class RoomSummaryUpdater @Inject constructor(@UserId
-                                                      private val userId: String,
+internal class RoomSummaryUpdater @Inject constructor(@UserId private val userId: String,
                                                       private val roomDisplayNameResolver: RoomDisplayNameResolver,
                                                       private val roomAvatarResolver: RoomAvatarResolver,
                                                       private val monarchy: Monarchy) {

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/RoomSummaryUpdater.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/RoomSummaryUpdater.kt
@@ -17,7 +17,6 @@
 package im.vector.matrix.android.internal.session.room
 
 import com.zhuinden.monarchy.Monarchy
-import im.vector.matrix.android.api.auth.data.Credentials
 import im.vector.matrix.android.api.session.events.model.EventType
 import im.vector.matrix.android.api.session.events.model.toModel
 import im.vector.matrix.android.api.session.room.model.Membership
@@ -31,6 +30,7 @@ import im.vector.matrix.android.internal.database.query.isEventRead
 import im.vector.matrix.android.internal.database.query.latestEvent
 import im.vector.matrix.android.internal.database.query.prev
 import im.vector.matrix.android.internal.database.query.where
+import im.vector.matrix.android.internal.di.UserId
 import im.vector.matrix.android.internal.session.room.membership.RoomDisplayNameResolver
 import im.vector.matrix.android.internal.session.room.membership.RoomMembers
 import im.vector.matrix.android.internal.session.sync.model.RoomSyncSummary
@@ -39,7 +39,8 @@ import io.realm.Realm
 import io.realm.kotlin.createObject
 import javax.inject.Inject
 
-internal class RoomSummaryUpdater @Inject constructor(private val credentials: Credentials,
+internal class RoomSummaryUpdater @Inject constructor(@UserId
+                                                      private val userId: String,
                                                       private val roomDisplayNameResolver: RoomDisplayNameResolver,
                                                       private val roomAvatarResolver: RoomAvatarResolver,
                                                       private val monarchy: Monarchy) {
@@ -92,11 +93,11 @@ internal class RoomSummaryUpdater @Inject constructor(private val credentials: C
 
         roomSummaryEntity.hasUnreadMessages = roomSummaryEntity.notificationCount > 0
                 //avoid this call if we are sure there are unread events
-                || !isEventRead(monarchy, credentials.userId, roomId, latestPreviewableEvent?.eventId)
+                || !isEventRead(monarchy, userId, roomId, latestPreviewableEvent?.eventId)
 
         val otherRoomMembers = RoomMembers(realm, roomId)
                 .queryRoomMembersEvent()
-                .notEqualTo(EventEntityFields.STATE_KEY, credentials.userId)
+                .notEqualTo(EventEntityFields.STATE_KEY, userId)
                 .findAll()
                 .asSequence()
                 .map { it.stateKey }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/membership/RoomDisplayNameResolver.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/membership/RoomDisplayNameResolver.kt
@@ -19,7 +19,6 @@ package im.vector.matrix.android.internal.session.room.membership
 import android.content.Context
 import com.zhuinden.monarchy.Monarchy
 import im.vector.matrix.android.R
-import im.vector.matrix.android.api.auth.data.Credentials
 import im.vector.matrix.android.api.session.events.model.EventType
 import im.vector.matrix.android.api.session.events.model.toModel
 import im.vector.matrix.android.api.session.room.model.*
@@ -30,6 +29,7 @@ import im.vector.matrix.android.internal.database.model.RoomEntity
 import im.vector.matrix.android.internal.database.model.RoomSummaryEntity
 import im.vector.matrix.android.internal.database.query.prev
 import im.vector.matrix.android.internal.database.query.where
+import im.vector.matrix.android.internal.di.UserId
 import javax.inject.Inject
 
 /**
@@ -37,7 +37,8 @@ import javax.inject.Inject
  */
 internal class RoomDisplayNameResolver @Inject constructor(private val context: Context,
                                                            private val monarchy: Monarchy,
-                                                           private val credentials: Credentials
+                                                           @UserId
+                                                           private val userId: String
 ) {
 
     /**
@@ -79,7 +80,7 @@ internal class RoomDisplayNameResolver @Inject constructor(private val context: 
 
 
             if (roomEntity?.membership == Membership.INVITE) {
-                val inviteMeEvent = roomMembers.queryRoomMemberEvent(credentials.userId).findFirst()
+                val inviteMeEvent = roomMembers.queryRoomMemberEvent(userId).findFirst()
                 val inviterId = inviteMeEvent?.sender
                 name = if (inviterId != null) {
                     val inviterMemberEvent = loadedMembers.where()
@@ -97,7 +98,7 @@ internal class RoomDisplayNameResolver @Inject constructor(private val context: 
                     }
                 } else {
                     loadedMembers.where()
-                            .notEqualTo(EventEntityFields.STATE_KEY, credentials.userId)
+                            .notEqualTo(EventEntityFields.STATE_KEY, userId)
                             .limit(3)
                             .findAll()
                 }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/membership/RoomDisplayNameResolver.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/membership/RoomDisplayNameResolver.kt
@@ -37,8 +37,7 @@ import javax.inject.Inject
  */
 internal class RoomDisplayNameResolver @Inject constructor(private val context: Context,
                                                            private val monarchy: Monarchy,
-                                                           @UserId
-                                                           private val userId: String
+                                                           @UserId private val userId: String
 ) {
 
     /**

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/prune/EventsPruner.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/prune/EventsPruner.kt
@@ -17,13 +17,13 @@
 package im.vector.matrix.android.internal.session.room.prune
 
 import com.zhuinden.monarchy.Monarchy
-import im.vector.matrix.android.api.auth.data.Credentials
 import im.vector.matrix.android.api.session.events.model.EventType
 import im.vector.matrix.android.internal.database.RealmLiveEntityObserver
 import im.vector.matrix.android.internal.database.mapper.asDomain
 import im.vector.matrix.android.internal.database.model.EventEntity
 import im.vector.matrix.android.internal.database.query.types
 import im.vector.matrix.android.internal.di.SessionDatabase
+import im.vector.matrix.android.internal.di.UserId
 import im.vector.matrix.android.internal.task.TaskExecutor
 import im.vector.matrix.android.internal.task.configureWith
 import io.realm.OrderedCollectionChangeSet
@@ -37,7 +37,8 @@ import javax.inject.Inject
  * As it will actually delete the content, it should be called last in the list of listener.
  */
 internal class EventsPruner @Inject constructor(@SessionDatabase realmConfiguration: RealmConfiguration,
-                                                private val credentials: Credentials,
+                                                @UserId
+                                                private val userId: String,
                                                 private val pruneEventTask: PruneEventTask,
                                                 private val taskExecutor: TaskExecutor) :
         RealmLiveEntityObserver<EventEntity>(realmConfiguration) {
@@ -54,7 +55,7 @@ internal class EventsPruner @Inject constructor(@SessionDatabase realmConfigurat
 
         val params = PruneEventTask.Params(
                 insertedDomains,
-                credentials.userId
+                userId
         )
         pruneEventTask.configureWith(params).executeBy(taskExecutor)
     }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/prune/EventsPruner.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/prune/EventsPruner.kt
@@ -37,8 +37,7 @@ import javax.inject.Inject
  * As it will actually delete the content, it should be called last in the list of listener.
  */
 internal class EventsPruner @Inject constructor(@SessionDatabase realmConfiguration: RealmConfiguration,
-                                                @UserId
-                                                private val userId: String,
+                                                @UserId private val userId: String,
                                                 private val pruneEventTask: PruneEventTask,
                                                 private val taskExecutor: TaskExecutor) :
         RealmLiveEntityObserver<EventEntity>(realmConfiguration) {

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/read/DefaultReadService.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/read/DefaultReadService.kt
@@ -38,8 +38,7 @@ internal class DefaultReadService @AssistedInject constructor(@Assisted private 
                                                               private val taskExecutor: TaskExecutor,
                                                               private val setReadMarkersTask: SetReadMarkersTask,
                                                               private val readReceiptsSummaryMapper: ReadReceiptsSummaryMapper,
-                                                              @UserId
-                                                              private val userId: String
+                                                              @UserId private val userId: String
 ) : ReadService {
 
     @AssistedInject.Factory

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/read/DefaultReadService.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/read/DefaultReadService.kt
@@ -22,7 +22,6 @@ import com.squareup.inject.assisted.Assisted
 import com.squareup.inject.assisted.AssistedInject
 import com.zhuinden.monarchy.Monarchy
 import im.vector.matrix.android.api.MatrixCallback
-import im.vector.matrix.android.api.auth.data.Credentials
 import im.vector.matrix.android.api.session.room.model.ReadReceipt
 import im.vector.matrix.android.api.session.room.read.ReadService
 import im.vector.matrix.android.internal.database.RealmLiveData
@@ -30,6 +29,7 @@ import im.vector.matrix.android.internal.database.mapper.ReadReceiptsSummaryMapp
 import im.vector.matrix.android.internal.database.model.ReadReceiptsSummaryEntity
 import im.vector.matrix.android.internal.database.query.isEventRead
 import im.vector.matrix.android.internal.database.query.where
+import im.vector.matrix.android.internal.di.UserId
 import im.vector.matrix.android.internal.task.TaskExecutor
 import im.vector.matrix.android.internal.task.configureWith
 
@@ -38,7 +38,8 @@ internal class DefaultReadService @AssistedInject constructor(@Assisted private 
                                                               private val taskExecutor: TaskExecutor,
                                                               private val setReadMarkersTask: SetReadMarkersTask,
                                                               private val readReceiptsSummaryMapper: ReadReceiptsSummaryMapper,
-                                                              private val credentials: Credentials
+                                                              @UserId
+                                                              private val userId: String
 ) : ReadService {
 
     @AssistedInject.Factory
@@ -75,7 +76,7 @@ internal class DefaultReadService @AssistedInject constructor(@Assisted private 
 
 
     override fun isEventRead(eventId: String): Boolean {
-        return isEventRead(monarchy, credentials.userId, roomId, eventId)
+        return isEventRead(monarchy, userId, roomId, eventId)
     }
 
     override fun getEventReadReceiptsLive(eventId: String): LiveData<List<ReadReceipt>> {

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/read/SetReadMarkersTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/read/SetReadMarkersTask.kt
@@ -48,8 +48,7 @@ private const val READ_MARKER = "m.fully_read"
 private const val READ_RECEIPT = "m.read"
 
 internal class DefaultSetReadMarkersTask @Inject constructor(private val roomAPI: RoomAPI,
-                                                             @UserId
-                                                             private val userId: String,
+                                                             @UserId private val userId: String,
                                                              private val monarchy: Monarchy
 ) : SetReadMarkersTask {
 

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/read/SetReadMarkersTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/read/SetReadMarkersTask.kt
@@ -17,7 +17,6 @@
 package im.vector.matrix.android.internal.session.room.read
 
 import com.zhuinden.monarchy.Monarchy
-import im.vector.matrix.android.api.auth.data.Credentials
 import im.vector.matrix.android.internal.database.model.ChunkEntity
 import im.vector.matrix.android.internal.database.model.ReadReceiptEntity
 import im.vector.matrix.android.internal.database.model.RoomSummaryEntity
@@ -26,6 +25,7 @@ import im.vector.matrix.android.internal.database.query.find
 import im.vector.matrix.android.internal.database.query.findLastLiveChunkFromRoom
 import im.vector.matrix.android.internal.database.query.latestEvent
 import im.vector.matrix.android.internal.database.query.where
+import im.vector.matrix.android.internal.di.UserId
 import im.vector.matrix.android.internal.network.executeRequest
 import im.vector.matrix.android.internal.session.room.RoomAPI
 import im.vector.matrix.android.internal.session.room.send.LocalEchoEventFactory
@@ -48,7 +48,8 @@ private const val READ_MARKER = "m.fully_read"
 private const val READ_RECEIPT = "m.read"
 
 internal class DefaultSetReadMarkersTask @Inject constructor(private val roomAPI: RoomAPI,
-                                                             private val credentials: Credentials,
+                                                             @UserId
+                                                             private val userId: String,
                                                              private val monarchy: Monarchy
 ) : SetReadMarkersTask {
 
@@ -109,7 +110,7 @@ internal class DefaultSetReadMarkersTask @Inject constructor(private val roomAPI
     private fun isEventRead(roomId: String, eventId: String): Boolean {
         var isEventRead = false
         monarchy.doWithRealm {
-            val readReceipt = ReadReceiptEntity.where(it, roomId, credentials.userId).findFirst()
+            val readReceipt = ReadReceiptEntity.where(it, roomId, userId).findFirst()
                     ?: return@doWithRealm
             val liveChunk = ChunkEntity.findLastLiveChunkFromRoom(it, roomId)
                     ?: return@doWithRealm

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/relation/DefaultRelationService.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/relation/DefaultRelationService.kt
@@ -50,8 +50,7 @@ import timber.log.Timber
 
 internal class DefaultRelationService @AssistedInject constructor(@Assisted private val roomId: String,
                                                                   private val context: Context,
-                                                                  @UserId
-                                                                  private val userId: String,
+                                                                  @UserId private val userId: String,
                                                                   private val eventFactory: LocalEchoEventFactory,
                                                                   private val cryptoService: CryptoService,
                                                                   private val findReactionEventForUndoTask: FindReactionEventForUndoTask,

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/send/DefaultSendService.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/send/DefaultSendService.kt
@@ -17,14 +17,10 @@
 package im.vector.matrix.android.internal.session.room.send
 
 import android.content.Context
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.Transformations
 import androidx.work.*
 import com.squareup.inject.assisted.Assisted
 import com.squareup.inject.assisted.AssistedInject
 import com.zhuinden.monarchy.Monarchy
-import im.vector.matrix.android.BuildConfig
-import im.vector.matrix.android.api.auth.data.Credentials
 import im.vector.matrix.android.api.session.content.ContentAttachmentData
 import im.vector.matrix.android.api.session.crypto.CryptoService
 import im.vector.matrix.android.api.session.events.model.*
@@ -32,16 +28,16 @@ import im.vector.matrix.android.api.session.room.model.message.MessageContent
 import im.vector.matrix.android.api.session.room.model.message.MessageType
 import im.vector.matrix.android.api.session.room.send.SendService
 import im.vector.matrix.android.api.session.room.send.SendState
-import im.vector.matrix.android.api.session.room.send.UserDraft
 import im.vector.matrix.android.api.session.room.timeline.TimelineEvent
 import im.vector.matrix.android.api.util.Cancelable
 import im.vector.matrix.android.api.util.CancelableBag
-import im.vector.matrix.android.internal.database.RealmLiveData
-import im.vector.matrix.android.internal.database.mapper.DraftMapper
 import im.vector.matrix.android.internal.database.mapper.asDomain
-import im.vector.matrix.android.internal.database.model.*
+import im.vector.matrix.android.internal.database.model.EventEntity
+import im.vector.matrix.android.internal.database.model.RoomEntity
+import im.vector.matrix.android.internal.database.model.TimelineEventEntity
 import im.vector.matrix.android.internal.database.query.findAllInRoomWithSendStates
 import im.vector.matrix.android.internal.database.query.where
+import im.vector.matrix.android.internal.di.UserId
 import im.vector.matrix.android.internal.session.content.UploadContentWorker
 import im.vector.matrix.android.internal.session.room.timeline.TimelineSendEventWorkCommon
 import im.vector.matrix.android.internal.util.CancelableWork
@@ -59,7 +55,8 @@ private const val BACKOFF_DELAY = 10_000L
 
 internal class DefaultSendService @AssistedInject constructor(@Assisted private val roomId: String,
                                                               private val context: Context,
-                                                              private val credentials: Credentials,
+                                                              @UserId
+                                                              private val userId: String,
                                                               private val localEchoEventFactory: LocalEchoEventFactory,
                                                               private val cryptoService: CryptoService,
                                                               private val monarchy: Monarchy
@@ -292,7 +289,7 @@ internal class DefaultSendService @AssistedInject constructor(@Assisted private 
 
     private fun createEncryptEventWork(event: Event, startChain: Boolean): OneTimeWorkRequest {
         // Same parameter
-        val params = EncryptEventWorker.Params(credentials.userId, roomId, event)
+        val params = EncryptEventWorker.Params(userId, roomId, event)
         val sendWorkData = WorkerParamsFactory.toData(params)
 
         return matrixOneTimeWorkRequestBuilder<EncryptEventWorker>()
@@ -304,7 +301,7 @@ internal class DefaultSendService @AssistedInject constructor(@Assisted private 
     }
 
     private fun createSendEventWork(event: Event, startChain: Boolean): OneTimeWorkRequest {
-        val sendContentWorkerParams = SendEventWorker.Params(credentials.userId, roomId, event)
+        val sendContentWorkerParams = SendEventWorker.Params(userId, roomId, event)
         val sendWorkData = WorkerParamsFactory.toData(sendContentWorkerParams)
 
         return TimelineSendEventWorkCommon.createWork<SendEventWorker>(sendWorkData, startChain)
@@ -314,7 +311,7 @@ internal class DefaultSendService @AssistedInject constructor(@Assisted private 
         val redactEvent = localEchoEventFactory.createRedactEvent(roomId, event.eventId!!, reason).also {
             saveLocalEcho(it)
         }
-        val sendContentWorkerParams = RedactEventWorker.Params(credentials.userId, redactEvent.eventId!!, roomId, event.eventId, reason)
+        val sendContentWorkerParams = RedactEventWorker.Params(userId, redactEvent.eventId!!, roomId, event.eventId, reason)
         val redactWorkData = WorkerParamsFactory.toData(sendContentWorkerParams)
         return TimelineSendEventWorkCommon.createWork<RedactEventWorker>(redactWorkData, true)
     }
@@ -323,7 +320,7 @@ internal class DefaultSendService @AssistedInject constructor(@Assisted private 
                                       attachment: ContentAttachmentData,
                                       isRoomEncrypted: Boolean,
                                       startChain: Boolean): OneTimeWorkRequest {
-        val uploadMediaWorkerParams = UploadContentWorker.Params(credentials.userId, roomId, event, attachment, isRoomEncrypted)
+        val uploadMediaWorkerParams = UploadContentWorker.Params(userId, roomId, event, attachment, isRoomEncrypted)
         val uploadWorkData = WorkerParamsFactory.toData(uploadMediaWorkerParams)
 
         return matrixOneTimeWorkRequestBuilder<UploadContentWorker>()

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/send/DefaultSendService.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/send/DefaultSendService.kt
@@ -55,8 +55,7 @@ private const val BACKOFF_DELAY = 10_000L
 
 internal class DefaultSendService @AssistedInject constructor(@Assisted private val roomId: String,
                                                               private val context: Context,
-                                                              @UserId
-                                                              private val userId: String,
+                                                              @UserId private val userId: String,
                                                               private val localEchoEventFactory: LocalEchoEventFactory,
                                                               private val cryptoService: CryptoService,
                                                               private val monarchy: Monarchy

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/send/LocalEchoEventFactory.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/send/LocalEchoEventFactory.kt
@@ -50,8 +50,7 @@ import javax.inject.Inject
  *
  * The transactionID is used as loc
  */
-internal class LocalEchoEventFactory @Inject constructor(@UserId
-                                                         private val userId: String,
+internal class LocalEchoEventFactory @Inject constructor(@UserId private val userId: String,
                                                          private val stringProvider: StringProvider,
                                                          private val roomSummaryUpdater: RoomSummaryUpdater) {
     // TODO Inject

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/send/LocalEchoEventFactory.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/send/LocalEchoEventFactory.kt
@@ -19,7 +19,6 @@ package im.vector.matrix.android.internal.session.room.send
 import android.media.MediaMetadataRetriever
 import com.zhuinden.monarchy.Monarchy
 import im.vector.matrix.android.R
-import im.vector.matrix.android.api.auth.data.Credentials
 import im.vector.matrix.android.api.permalinks.PermalinkFactory
 import im.vector.matrix.android.api.session.content.ContentAttachmentData
 import im.vector.matrix.android.api.session.events.model.*
@@ -33,12 +32,13 @@ import im.vector.matrix.android.api.session.room.timeline.getLastMessageContent
 import im.vector.matrix.android.internal.database.helper.addSendingEvent
 import im.vector.matrix.android.internal.database.model.RoomEntity
 import im.vector.matrix.android.internal.database.query.where
+import im.vector.matrix.android.internal.di.UserId
 import im.vector.matrix.android.internal.session.content.ThumbnailExtractor
 import im.vector.matrix.android.internal.session.room.RoomSummaryUpdater
 import im.vector.matrix.android.internal.util.StringProvider
 import org.commonmark.parser.Parser
 import org.commonmark.renderer.html.HtmlRenderer
-import java.util.UUID
+import java.util.*
 import javax.inject.Inject
 
 /**
@@ -50,7 +50,8 @@ import javax.inject.Inject
  *
  * The transactionID is used as loc
  */
-internal class LocalEchoEventFactory @Inject constructor(private val credentials: Credentials,
+internal class LocalEchoEventFactory @Inject constructor(@UserId
+                                                         private val userId: String,
                                                          private val stringProvider: StringProvider,
                                                          private val roomSummaryUpdater: RoomSummaryUpdater) {
     // TODO Inject
@@ -163,7 +164,7 @@ internal class LocalEchoEventFactory @Inject constructor(private val credentials
         return Event(
                 roomId = roomId,
                 originServerTs = dummyOriginServerTs(),
-                senderId = credentials.userId,
+                senderId = userId,
                 eventId = localId,
                 type = EventType.REACTION,
                 content = content.toContent(),
@@ -255,7 +256,7 @@ internal class LocalEchoEventFactory @Inject constructor(private val credentials
         return Event(
                 roomId = roomId,
                 originServerTs = dummyOriginServerTs(),
-                senderId = credentials.userId,
+                senderId = userId,
                 eventId = localID,
                 type = EventType.MESSAGE,
                 content = content.toContent(),
@@ -373,7 +374,7 @@ internal class LocalEchoEventFactory @Inject constructor(private val credentials
         return Event(
                 roomId = roomId,
                 originServerTs = dummyOriginServerTs(),
-                senderId = credentials.userId,
+                senderId = userId,
                 eventId = localID,
                 type = EventType.REDACTION,
                 redacts = eventId,

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/timeline/TimelineEventDecryptor.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/timeline/TimelineEventDecryptor.kt
@@ -106,7 +106,7 @@ internal class TimelineEventDecryptor(
             Timber.v("Successfully decrypted event ${eventId}")
             eventEntity.setDecryptionResult(result)
         } catch (e: MXCryptoError) {
-            Timber.v("Failed to decrypte event ${eventId} ${e}")
+            Timber.v("Failed to decrypt event ${eventId} ${e}")
             if (e is MXCryptoError.Base && e.errorType == MXCryptoError.ErrorType.UNKNOWN_INBOUND_SESSION_ID) {
                 //Keep track of unknown sessions to automatically try to decrypt on new session
                 eventEntity.decryptionErrorCode = e.errorType.name

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/signout/SignOutTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/signout/SignOutTask.kt
@@ -17,15 +17,11 @@
 package im.vector.matrix.android.internal.session.signout
 
 import android.content.Context
-import im.vector.matrix.android.api.auth.data.Credentials
 import im.vector.matrix.android.internal.SessionManager
 import im.vector.matrix.android.internal.auth.SessionParamsStore
 import im.vector.matrix.android.internal.crypto.CryptoModule
 import im.vector.matrix.android.internal.database.RealmKeysUtils
-import im.vector.matrix.android.internal.di.CryptoDatabase
-import im.vector.matrix.android.internal.di.SessionDatabase
-import im.vector.matrix.android.internal.di.UserCacheDirectory
-import im.vector.matrix.android.internal.di.UserMd5
+import im.vector.matrix.android.internal.di.*
 import im.vector.matrix.android.internal.network.executeRequest
 import im.vector.matrix.android.internal.session.SessionModule
 import im.vector.matrix.android.internal.session.cache.ClearCacheTask
@@ -38,7 +34,8 @@ import javax.inject.Inject
 internal interface SignOutTask : Task<Unit, Unit>
 
 internal class DefaultSignOutTask @Inject constructor(private val context: Context,
-                                                      private val credentials: Credentials,
+                                                      @UserId
+                                                      private val userId: String,
                                                       private val signOutAPI: SignOutAPI,
                                                       private val sessionManager: SessionManager,
                                                       private val sessionParamsStore: SessionParamsStore,
@@ -55,13 +52,13 @@ internal class DefaultSignOutTask @Inject constructor(private val context: Conte
         }
 
         Timber.d("SignOut: release session...")
-        sessionManager.releaseSession(credentials.userId)
+        sessionManager.releaseSession(userId)
 
         Timber.d("SignOut: cancel pending works...")
         WorkManagerUtil.cancelAllWorks(context)
 
         Timber.d("SignOut: delete session params...")
-        sessionParamsStore.delete(credentials.userId)
+        sessionParamsStore.delete(userId)
 
         Timber.d("SignOut: clear session data...")
         clearSessionDataTask.execute(Unit)

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/signout/SignOutTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/signout/SignOutTask.kt
@@ -34,8 +34,7 @@ import javax.inject.Inject
 internal interface SignOutTask : Task<Unit, Unit>
 
 internal class DefaultSignOutTask @Inject constructor(private val context: Context,
-                                                      @UserId
-                                                      private val userId: String,
+                                                      @UserId private val userId: String,
                                                       private val signOutAPI: SignOutAPI,
                                                       private val sessionManager: SessionManager,
                                                       private val sessionParamsStore: SessionParamsStore,

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/sync/RoomSyncHandler.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/sync/RoomSyncHandler.kt
@@ -18,6 +18,7 @@ package im.vector.matrix.android.internal.session.sync
 
 import com.zhuinden.monarchy.Monarchy
 import im.vector.matrix.android.R
+import im.vector.matrix.android.api.pushrules.RuleScope
 import im.vector.matrix.android.api.session.events.model.Event
 import im.vector.matrix.android.api.session.events.model.EventType
 import im.vector.matrix.android.api.session.events.model.toModel
@@ -77,11 +78,11 @@ internal class RoomSyncHandler @Inject constructor(private val monarchy: Monarch
     private fun checkPushRules(roomsSyncResponse: RoomsSyncResponse) {
         Timber.v("[PushRules] --> checkPushRules")
         if (tokenStore.getLastToken() == null) {
-            Timber.v("[PushRules] <-- No push tule check on initial sync")
+            Timber.v("[PushRules] <-- No push rule check on initial sync")
             return
         } //nothing on initial sync
 
-        val rules = pushRuleService.getPushRules("global")
+        val rules = pushRuleService.getPushRules(RuleScope.GLOBAL)
         processForPushTask.configureWith(ProcessEventForPushTask.Params(roomsSyncResponse, rules))
                 .executeBy(taskExecutor)
         Timber.v("[PushRules] <-- Push task scheduled")

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/sync/SyncResponseHandler.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/sync/SyncResponseHandler.kt
@@ -33,7 +33,7 @@ internal class SyncResponseHandler @Inject constructor(private val roomSyncHandl
                                                        private val cryptoService: DefaultCryptoService,
                                                        private val initialSyncProgressService: DefaultInitialSyncProgressService) {
 
-    fun handleResponse(syncResponse: SyncResponse, fromToken: String?, isCatchingUp: Boolean): Try<SyncResponse> {
+    suspend fun handleResponse(syncResponse: SyncResponse, fromToken: String?, isCatchingUp: Boolean): Try<SyncResponse> {
         return Try {
             val isInitialSync = fromToken == null
             Timber.v("Start handling sync, is InitialSync: $isInitialSync")

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/sync/SyncResponseHandler.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/sync/SyncResponseHandler.kt
@@ -16,7 +16,6 @@
 
 package im.vector.matrix.android.internal.session.sync
 
-import arrow.core.Try
 import im.vector.matrix.android.R
 import im.vector.matrix.android.internal.crypto.DefaultCryptoService
 import im.vector.matrix.android.internal.session.DefaultInitialSyncProgressService
@@ -33,73 +32,70 @@ internal class SyncResponseHandler @Inject constructor(private val roomSyncHandl
                                                        private val cryptoService: DefaultCryptoService,
                                                        private val initialSyncProgressService: DefaultInitialSyncProgressService) {
 
-    suspend fun handleResponse(syncResponse: SyncResponse, fromToken: String?, isCatchingUp: Boolean): Try<SyncResponse> {
-        return Try {
-            val isInitialSync = fromToken == null
-            Timber.v("Start handling sync, is InitialSync: $isInitialSync")
-            val reporter = initialSyncProgressService.takeIf { isInitialSync }
+    suspend fun handleResponse(syncResponse: SyncResponse, fromToken: String?, isCatchingUp: Boolean) {
+        val isInitialSync = fromToken == null
+        Timber.v("Start handling sync, is InitialSync: $isInitialSync")
+        val reporter = initialSyncProgressService.takeIf { isInitialSync }
 
+        measureTimeMillis {
+            if (!cryptoService.isStarted()) {
+                Timber.v("Should start cryptoService")
+                cryptoService.start(isInitialSync)
+            }
+        }.also {
+            Timber.v("Finish handling start cryptoService in $it ms")
+        }
+        val measure = measureTimeMillis {
+            // Handle the to device events before the room ones
+            // to ensure to decrypt them properly
             measureTimeMillis {
-                if (!cryptoService.isStarted()) {
-                    Timber.v("Should start cryptoService")
-                    cryptoService.start(isInitialSync)
+                Timber.v("Handle toDevice")
+                reportSubtask(reporter, R.string.initial_sync_start_importing_account_crypto, 100, 0.1f) {
+                    if (syncResponse.toDevice != null) {
+                        cryptoSyncHandler.handleToDevice(syncResponse.toDevice, reporter)
+                    }
                 }
             }.also {
-                Timber.v("Finish handling start cryptoService in $it ms")
+                Timber.v("Finish handling toDevice in $it ms")
             }
-            val measure = measureTimeMillis {
-                // Handle the to device events before the room ones
-                // to ensure to decrypt them properly
-                measureTimeMillis {
-                    Timber.v("Handle toDevice")
-                    reportSubtask(reporter, R.string.initial_sync_start_importing_account_crypto, 100, 0.1f) {
-                        if (syncResponse.toDevice != null) {
-                            cryptoSyncHandler.handleToDevice(syncResponse.toDevice, reporter)
-                        }
+
+            measureTimeMillis {
+                Timber.v("Handle rooms")
+
+                reportSubtask(reporter, R.string.initial_sync_start_importing_account_rooms, 100, 0.7f) {
+                    if (syncResponse.rooms != null) {
+                        roomSyncHandler.handle(syncResponse.rooms, isInitialSync, reporter)
                     }
-                }.also {
-                    Timber.v("Finish handling toDevice in $it ms")
                 }
-
-                measureTimeMillis {
-                    Timber.v("Handle rooms")
-
-                    reportSubtask(reporter, R.string.initial_sync_start_importing_account_rooms, 100, 0.7f) {
-                        if (syncResponse.rooms != null) {
-                            roomSyncHandler.handle(syncResponse.rooms, isInitialSync, reporter)
-                        }
-                    }
-                }.also {
-                    Timber.v("Finish handling rooms in $it ms")
-                }
-
-
-                measureTimeMillis {
-                    reportSubtask(reporter, R.string.initial_sync_start_importing_account_groups, 100, 0.1f) {
-                        Timber.v("Handle groups")
-                        if (syncResponse.groups != null) {
-                            groupSyncHandler.handle(syncResponse.groups, reporter)
-                        }
-                    }
-                }.also {
-                    Timber.v("Finish handling groups in $it ms")
-                }
-
-                measureTimeMillis {
-                    reportSubtask(reporter, R.string.initial_sync_start_importing_account_data, 100, 0.1f) {
-                        Timber.v("Handle accountData")
-                        userAccountDataSyncHandler.handle(syncResponse.accountData, syncResponse.rooms?.invite)
-                    }
-                }.also {
-                    Timber.v("Finish handling accountData in $it ms")
-                }
-
-                Timber.v("On sync completed")
-                cryptoSyncHandler.onSyncCompleted(syncResponse)
+            }.also {
+                Timber.v("Finish handling rooms in $it ms")
             }
-            Timber.v("Finish handling sync in $measure ms")
-            syncResponse
+
+
+            measureTimeMillis {
+                reportSubtask(reporter, R.string.initial_sync_start_importing_account_groups, 100, 0.1f) {
+                    Timber.v("Handle groups")
+                    if (syncResponse.groups != null) {
+                        groupSyncHandler.handle(syncResponse.groups, reporter)
+                    }
+                }
+            }.also {
+                Timber.v("Finish handling groups in $it ms")
+            }
+
+            measureTimeMillis {
+                reportSubtask(reporter, R.string.initial_sync_start_importing_account_data, 100, 0.1f) {
+                    Timber.v("Handle accountData")
+                    userAccountDataSyncHandler.handle(syncResponse.accountData, syncResponse.rooms?.invite)
+                }
+            }.also {
+                Timber.v("Finish handling accountData in $it ms")
+            }
+
+            Timber.v("On sync completed")
+            cryptoSyncHandler.onSyncCompleted(syncResponse)
         }
+        Timber.v("Finish handling sync in $measure ms")
     }
 
 }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/sync/SyncTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/sync/SyncTask.kt
@@ -18,10 +18,10 @@ package im.vector.matrix.android.internal.session.sync
 
 import com.zhuinden.monarchy.Monarchy
 import im.vector.matrix.android.R
-import im.vector.matrix.android.api.auth.data.Credentials
 import im.vector.matrix.android.api.failure.Failure
 import im.vector.matrix.android.api.failure.MatrixError
 import im.vector.matrix.android.internal.auth.SessionParamsStore
+import im.vector.matrix.android.internal.di.UserId
 import im.vector.matrix.android.internal.network.executeRequest
 import im.vector.matrix.android.internal.session.DefaultInitialSyncProgressService
 import im.vector.matrix.android.internal.session.filter.FilterRepository
@@ -36,7 +36,8 @@ internal interface SyncTask : Task<SyncTask.Params, Unit> {
 }
 
 internal class DefaultSyncTask @Inject constructor(private val syncAPI: SyncAPI,
-                                                   private val credentials: Credentials,
+                                                   @UserId
+                                                   private val userId: String,
                                                    private val filterRepository: FilterRepository,
                                                    private val syncResponseHandler: SyncResponseHandler,
                                                    private val sessionParamsStore: SessionParamsStore,
@@ -70,7 +71,7 @@ internal class DefaultSyncTask @Inject constructor(private val syncAPI: SyncAPI,
             // Intercept 401
             if (throwable is Failure.ServerError
                     && throwable.error.code == MatrixError.UNKNOWN_TOKEN) {
-                sessionParamsStore.delete(credentials.userId)
+                sessionParamsStore.delete(userId)
             }
             throw throwable
         }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/sync/SyncTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/sync/SyncTask.kt
@@ -36,8 +36,7 @@ internal interface SyncTask : Task<SyncTask.Params, Unit> {
 }
 
 internal class DefaultSyncTask @Inject constructor(private val syncAPI: SyncAPI,
-                                                   @UserId
-                                                   private val userId: String,
+                                                   @UserId private val userId: String,
                                                    private val filterRepository: FilterRepository,
                                                    private val syncResponseHandler: SyncResponseHandler,
                                                    private val sessionParamsStore: SessionParamsStore,

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/sync/UserAccountDataSyncHandler.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/sync/UserAccountDataSyncHandler.kt
@@ -39,8 +39,7 @@ import timber.log.Timber
 import javax.inject.Inject
 
 internal class UserAccountDataSyncHandler @Inject constructor(private val monarchy: Monarchy,
-                                                              @UserId
-                                                              private val userId: String,
+                                                              @UserId private val userId: String,
                                                               private val directChatsHelper: DirectChatsHelper,
                                                               private val updateUserAccountDataTask: UpdateUserAccountDataTask,
                                                               private val savePushRulesTask: SavePushRulesTask,

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/sync/UserAccountDataSyncHandler.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/sync/UserAccountDataSyncHandler.kt
@@ -17,13 +17,13 @@
 package im.vector.matrix.android.internal.session.sync
 
 import com.zhuinden.monarchy.Monarchy
-import im.vector.matrix.android.api.auth.data.Credentials
 import im.vector.matrix.android.api.session.events.model.toModel
 import im.vector.matrix.android.api.session.room.model.RoomMember
 import im.vector.matrix.android.internal.database.mapper.asDomain
 import im.vector.matrix.android.internal.database.model.RoomSummaryEntity
 import im.vector.matrix.android.internal.database.query.getDirectRooms
 import im.vector.matrix.android.internal.database.query.where
+import im.vector.matrix.android.internal.di.UserId
 import im.vector.matrix.android.internal.session.room.membership.RoomMembers
 import im.vector.matrix.android.internal.session.sync.model.InvitedRoomSync
 import im.vector.matrix.android.internal.session.sync.model.UserAccountDataDirectMessages
@@ -37,7 +37,8 @@ import timber.log.Timber
 import javax.inject.Inject
 
 internal class UserAccountDataSyncHandler @Inject constructor(private val monarchy: Monarchy,
-                                                              private val credentials: Credentials,
+                                                              @UserId
+                                                              private val userId: String,
                                                               private val directChatsHelper: DirectChatsHelper,
                                                               private val updateUserAccountDataTask: UpdateUserAccountDataTask,
                                                               private val taskExecutor: TaskExecutor) {
@@ -81,11 +82,11 @@ internal class UserAccountDataSyncHandler @Inject constructor(private val monarc
         val directChats = directChatsHelper.getLocalUserAccount()
         var hasUpdate = false
         invites.forEach { (roomId, _) ->
-            val myUserStateEvent = RoomMembers(realm, roomId).getStateEvent(credentials.userId)
+            val myUserStateEvent = RoomMembers(realm, roomId).getStateEvent(userId)
             val inviterId = myUserStateEvent?.sender
             val myUserRoomMember: RoomMember? = myUserStateEvent?.let { it.asDomain().content?.toModel() }
             val isDirect = myUserRoomMember?.isDirect
-            if (inviterId != null && inviterId != credentials.userId && isDirect == true) {
+            if (inviterId != null && inviterId != userId && isDirect == true) {
                 directChats
                         .getOrPut(inviterId, { arrayListOf() })
                         .apply {

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/sync/model/UserAccountDataPushRules.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/sync/model/UserAccountDataPushRules.kt
@@ -16,13 +16,12 @@
 
 package im.vector.matrix.android.internal.session.sync.model
 
-internal interface UserAccountData {
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+import im.vector.matrix.android.api.pushrules.rest.GetPushRulesResponse
 
-    companion object {
-        const val TYPE_IGNORED_USER_LIST = "m.ignored_user_list"
-        const val TYPE_DIRECT_MESSAGES = "m.direct"
-        const val TYPE_PREVIEW_URLS = "org.matrix.preview_urls"
-        const val TYPE_WIDGETS = "m.widgets"
-        const val TYPE_PUSH_RULES = "m.push_rules"
-    }
-}
+@JsonClass(generateAdapter = true)
+internal data class UserAccountDataPushRules(
+        @Json(name = "content") val content: GetPushRulesResponse
+) : UserAccountData
+

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/user/accountdata/UpdateUserAccountDataTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/user/accountdata/UpdateUserAccountDataTask.kt
@@ -16,7 +16,7 @@
 
 package im.vector.matrix.android.internal.session.user.accountdata
 
-import im.vector.matrix.android.api.auth.data.Credentials
+import im.vector.matrix.android.internal.di.UserId
 import im.vector.matrix.android.internal.network.executeRequest
 import im.vector.matrix.android.internal.session.sync.model.UserAccountData
 import im.vector.matrix.android.internal.task.Task
@@ -42,11 +42,12 @@ internal interface UpdateUserAccountDataTask : Task<UpdateUserAccountDataTask.Pa
 }
 
 internal class DefaultUpdateUserAccountDataTask @Inject constructor(private val accountDataApi: AccountDataAPI,
-                                                                    private val credentials: Credentials) : UpdateUserAccountDataTask {
+                                                                    @UserId
+                                                                    private val userId: String) : UpdateUserAccountDataTask {
 
     override suspend fun execute(params: UpdateUserAccountDataTask.Params) {
         return executeRequest {
-            apiCall = accountDataApi.setAccountData(credentials.userId, params.type, params.getData())
+            apiCall = accountDataApi.setAccountData(userId, params.type, params.getData())
         }
     }
 

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/user/accountdata/UpdateUserAccountDataTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/user/accountdata/UpdateUserAccountDataTask.kt
@@ -42,8 +42,7 @@ internal interface UpdateUserAccountDataTask : Task<UpdateUserAccountDataTask.Pa
 }
 
 internal class DefaultUpdateUserAccountDataTask @Inject constructor(private val accountDataApi: AccountDataAPI,
-                                                                    @UserId
-                                                                    private val userId: String) : UpdateUserAccountDataTask {
+                                                                    @UserId private val userId: String) : UpdateUserAccountDataTask {
 
     override suspend fun execute(params: UpdateUserAccountDataTask.Params) {
         return executeRequest {

--- a/matrix-sdk-android/src/test/java/im/vector/matrix/android/api/pushrules/PushrulesConditionTest.kt
+++ b/matrix-sdk-android/src/test/java/im/vector/matrix/android/api/pushrules/PushrulesConditionTest.kt
@@ -24,14 +24,13 @@ import im.vector.matrix.android.api.session.events.model.Event
 import im.vector.matrix.android.api.session.events.model.toContent
 import im.vector.matrix.android.api.session.room.Room
 import im.vector.matrix.android.api.session.room.RoomService
-import im.vector.matrix.android.api.session.room.model.EventAnnotationsSummary
-import im.vector.matrix.android.api.session.room.model.Membership
-import im.vector.matrix.android.api.session.room.model.RoomMember
-import im.vector.matrix.android.api.session.room.model.RoomSummary
+import im.vector.matrix.android.api.session.room.model.*
 import im.vector.matrix.android.api.session.room.model.create.CreateRoomParams
 import im.vector.matrix.android.api.session.room.model.message.MessageTextContent
+import im.vector.matrix.android.api.session.room.send.UserDraft
 import im.vector.matrix.android.api.session.room.timeline.Timeline
 import im.vector.matrix.android.api.session.room.timeline.TimelineEvent
+import im.vector.matrix.android.api.session.room.timeline.TimelineSettings
 import im.vector.matrix.android.api.util.Cancelable
 import org.junit.Assert
 import org.junit.Test
@@ -164,10 +163,29 @@ class PushrulesConditionTest {
     }
 
 
+    @Test
+    fun test_notice_condition() {
+        val conditionEqual = EventMatchCondition("content.msgtype", "m.notice")
+
+        Event(
+                type = "m.room.message",
+                eventId = "mx0",
+                content = MessageTextContent("m.notice", "A").toContent(),
+                originServerTs = 0,
+                roomId = "2joined").also {
+            Assert.assertTrue("Notice", conditionEqual.isSatisfied(it))
+        }
+    }
+
+
     class MockRoomService() : RoomService {
 
-        override fun createRoom(createRoomParams: CreateRoomParams, callback: MatrixCallback<String>) {
+        override fun createRoom(createRoomParams: CreateRoomParams, callback: MatrixCallback<String>): Cancelable {
+            TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        }
 
+        override fun joinRoom(roomId: String, viaServers: List<String>, callback: MatrixCallback<Unit>): Cancelable {
+            TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
         }
 
         override fun getRoom(roomId: String): Room? {
@@ -184,6 +202,53 @@ class PushrulesConditionTest {
     }
 
     class MockRoom(override val roomId: String, val _numberOfJoinedMembers: Int) : Room {
+        override fun resendTextMessage(localEcho: TimelineEvent): Cancelable? {
+            TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        }
+
+        override fun resendMediaMessage(localEcho: TimelineEvent): Cancelable? {
+            TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        }
+
+        override fun deleteFailedEcho(localEcho: TimelineEvent) {
+            TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        }
+
+        override fun clearSendingQueue() {
+            TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        }
+
+        override fun resendAllFailedMessages() {
+            TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        }
+
+        override fun saveDraft(draft: UserDraft) {
+            TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        }
+
+        override fun deleteDraft() {
+            TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        }
+
+        override fun getDraftsLive(): LiveData<List<UserDraft>> {
+            TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        }
+
+        override fun getEventReadReceiptsLive(eventId: String): LiveData<List<ReadReceipt>> {
+            TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        }
+
+        override fun getStateEvent(eventType: String): Event? {
+            TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        }
+
+        override fun editReply(replyToEdit: TimelineEvent, originalTimelineEvent: TimelineEvent, newBodyText: String, compatibilityBodyText: String): Cancelable {
+            TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        }
+
+        override fun fetchEditHistory(eventId: String, callback: MatrixCallback<List<Event>>) {
+        }
+
         override fun liveTimeLineEvent(eventId: String): LiveData<TimelineEvent> {
             TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
         }
@@ -201,7 +266,7 @@ class PushrulesConditionTest {
             TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
         }
 
-        override fun createTimeline(eventId: String?, allowedTypes: List<String>?): Timeline {
+        override fun createTimeline(eventId: String?, settings: TimelineSettings): Timeline {
             TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
         }
 
@@ -245,7 +310,7 @@ class PushrulesConditionTest {
             TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
         }
 
-        override fun loadRoomMembersIfNeeded(): Cancelable {
+        override fun loadRoomMembersIfNeeded(matrixCallback: MatrixCallback<Unit>): Cancelable {
             TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
         }
 
@@ -257,15 +322,15 @@ class PushrulesConditionTest {
             TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
         }
 
-        override fun invite(userId: String, callback: MatrixCallback<Unit>) {
+        override fun invite(userId: String, callback: MatrixCallback<Unit>): Cancelable {
             TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
         }
 
-        override fun join(callback: MatrixCallback<Unit>) {
+        override fun join(viaServers: List<String>, callback: MatrixCallback<Unit>): Cancelable {
             TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
         }
 
-        override fun leave(callback: MatrixCallback<Unit>) {
+        override fun leave(callback: MatrixCallback<Unit>): Cancelable {
             TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
         }
 

--- a/vector/src/main/java/im/vector/riotx/core/extensions/Session.kt
+++ b/vector/src/main/java/im/vector/riotx/core/extensions/Session.kt
@@ -32,6 +32,9 @@ fun Session.configureAndStart(pushRuleTriggerListener: PushRuleTriggerListener) 
     startSync(isAtLeastStarted)
     refreshPushers()
     pushRuleTriggerListener.startWithSession(this)
+
+    // TODO After a clear cache, this is not done.
+    // TODO Push rule should be parsed from the sync
     fetchPushRules()
 
     // TODO P1 From HomeActivity

--- a/vector/src/main/java/im/vector/riotx/core/extensions/Session.kt
+++ b/vector/src/main/java/im/vector/riotx/core/extensions/Session.kt
@@ -33,10 +33,6 @@ fun Session.configureAndStart(pushRuleTriggerListener: PushRuleTriggerListener) 
     refreshPushers()
     pushRuleTriggerListener.startWithSession(this)
 
-    // TODO After a clear cache, this is not done.
-    // TODO Push rule should be parsed from the sync
-    fetchPushRules()
-
     // TODO P1 From HomeActivity
     // @Inject lateinit var incomingVerificationRequestHandler: IncomingVerificationRequestHandler
     // @Inject lateinit var keyRequestHandler: KeyRequestHandler

--- a/vector/src/main/java/im/vector/riotx/features/crypto/keysrequest/KeyRequestHandler.kt
+++ b/vector/src/main/java/im/vector/riotx/features/crypto/keysrequest/KeyRequestHandler.kt
@@ -204,7 +204,7 @@ class KeyRequestHandler @Inject constructor(private val context: Context)
                 Runnable {
                     alert.weakCurrentActivity?.get()?.let {
                         val intent = SASVerificationActivity.outgoingIntent(it,
-                                session?.sessionParams?.credentials?.userId ?: "",
+                                session?.myUserId ?: "",
                                 userId, deviceId)
                         it.startActivity(intent)
                     }

--- a/vector/src/main/java/im/vector/riotx/features/crypto/verification/IncomingVerificationRequestHandler.kt
+++ b/vector/src/main/java/im/vector/riotx/features/crypto/verification/IncomingVerificationRequestHandler.kt
@@ -60,7 +60,7 @@ class IncomingVerificationRequestHandler @Inject constructor(private val context
                         .apply {
                             contentAction = Runnable {
                                 val intent = SASVerificationActivity.incomingIntent(context,
-                                        session?.sessionParams?.credentials?.userId ?: "",
+                                        session?.myUserId  ?: "",
                                         tx.otherUserId,
                                         tx.transactionId)
                                 weakCurrentActivity?.get()?.startActivity(intent)
@@ -78,7 +78,7 @@ class IncomingVerificationRequestHandler @Inject constructor(private val context
                                     context.getString(R.string.action_open),
                                     Runnable {
                                         val intent = SASVerificationActivity.incomingIntent(context,
-                                                session?.sessionParams?.credentials?.userId ?: "",
+                                                session?.myUserId ?: "",
                                                 tx.otherUserId,
                                                 tx.transactionId)
                                         weakCurrentActivity?.get()?.startActivity(intent)

--- a/vector/src/main/java/im/vector/riotx/features/notifications/NotificationAction.kt
+++ b/vector/src/main/java/im/vector/riotx/features/notifications/NotificationAction.kt
@@ -19,24 +19,21 @@ import im.vector.matrix.android.api.pushrules.Action
 
 data class NotificationAction(
         val shouldNotify: Boolean,
-        val highlight: Boolean = false,
-        val soundName: String? = null
-) {
-    companion object {
-        fun extractFrom(ruleActions: List<Action>): NotificationAction {
-            var shouldNotify = false
-            var highlight = false
-            var sound: String? = null
-            ruleActions.forEach {
-                // TODO When
-                if (it.type == Action.Type.NOTIFY) shouldNotify = true
-                if (it.type == Action.Type.DONT_NOTIFY) shouldNotify = false
-                if (it.type == Action.Type.SET_TWEAK) {
-                    if (it.tweak_action == "highlight") highlight = it.boolValue ?: false
-                    if (it.tweak_action == "sound") sound = it.stringValue
-                }
-            }
-            return NotificationAction(shouldNotify, highlight, sound)
+        val highlight: Boolean,
+        val soundName: String?
+)
+
+fun List<Action>.toNotificationAction(): NotificationAction {
+    var shouldNotify = false
+    var highlight = false
+    var sound: String? = null
+    forEach { action ->
+        when (action) {
+            is Action.Notify      -> shouldNotify = true
+            is Action.DoNotNotify -> shouldNotify = false
+            is Action.Highlight   -> highlight = action.highlight
+            is Action.Sound       -> sound = action.sound
         }
     }
+    return NotificationAction(shouldNotify, highlight, sound)
 }

--- a/vector/src/main/java/im/vector/riotx/features/notifications/NotificationAction.kt
+++ b/vector/src/main/java/im/vector/riotx/features/notifications/NotificationAction.kt
@@ -28,6 +28,7 @@ data class NotificationAction(
             var highlight = false
             var sound: String? = null
             ruleActions.forEach {
+                // TODO When
                 if (it.type == Action.Type.NOTIFY) shouldNotify = true
                 if (it.type == Action.Type.DONT_NOTIFY) shouldNotify = false
                 if (it.type == Action.Type.SET_TWEAK) {

--- a/vector/src/main/java/im/vector/riotx/features/notifications/PushRuleTriggerListener.kt
+++ b/vector/src/main/java/im/vector/riotx/features/notifications/PushRuleTriggerListener.kt
@@ -40,7 +40,7 @@ class PushRuleTriggerListener @Inject constructor(
             Timber.e("Called without active session")
             return
         }
-        val notificationAction = NotificationAction.extractFrom(actions)
+        val notificationAction = actions.toNotificationAction()
         if (notificationAction.shouldNotify) {
             val notifiableEvent = resolver.resolveEvent(event, session!!)
             if (notifiableEvent == null) {

--- a/vector/src/main/java/im/vector/riotx/features/settings/VectorSettingsNotificationFragment.kt
+++ b/vector/src/main/java/im/vector/riotx/features/settings/VectorSettingsNotificationFragment.kt
@@ -21,6 +21,7 @@ import androidx.preference.Preference
 import androidx.preference.SwitchPreference
 import im.vector.matrix.android.api.MatrixCallback
 import im.vector.matrix.android.api.pushrules.RuleIds
+import im.vector.matrix.android.api.pushrules.RuleKind
 import im.vector.riotx.R
 import im.vector.riotx.core.di.ActiveSessionHolder
 import im.vector.riotx.core.di.ScreenComponent
@@ -45,12 +46,13 @@ class VectorSettingsNotificationPreferenceFragment : VectorSettingsBaseFragment(
                     .find { it.ruleId == RuleIds.RULE_ID_DISABLE_ALL }
 
             if (mRuleMaster == null) {
+                // The home server does not support RULE_ID_DISABLE_ALL, so hide the preference
                 pref.isVisible = false
                 return
             }
 
-            val areNotifEnabledAtAccountLevelt = !mRuleMaster.enabled
-            (pref as SwitchPreference).isChecked = areNotifEnabledAtAccountLevelt
+            val areNotifEnabledAtAccountLevel = !mRuleMaster.enabled
+            (pref as SwitchPreference).isChecked = areNotifEnabledAtAccountLevel
         }
     }
 
@@ -114,19 +116,21 @@ class VectorSettingsNotificationPreferenceFragment : VectorSettingsBaseFragment(
                 .find { it.ruleId == RuleIds.RULE_ID_DISABLE_ALL }
                 ?.let {
                     //Trick, we must enable this room to disable notifications
-                    pushRuleService.updatePushRuleEnableStatus("override", it, !switchPref.isChecked,
-                                                               object : MatrixCallback<Unit> {
+                    pushRuleService.updatePushRuleEnableStatus(RuleKind.OVERRIDE,
+                            it,
+                            !switchPref.isChecked,
+                            object : MatrixCallback<Unit> {
 
-                                                                   override fun onSuccess(data: Unit) {
-                                                                       pushRuleService.fetchPushRules()
-                                                                   }
+                                override fun onSuccess(data: Unit) {
+                                    pushRuleService.fetchPushRules()
+                                }
 
-                                                                   override fun onFailure(failure: Throwable) {
-                                                                       //revert the check box
-                                                                       switchPref.isChecked = !switchPref.isChecked
-                                                                       Toast.makeText(activity, R.string.unknown_error, Toast.LENGTH_SHORT).show()
-                                                                   }
-                                                               })
+                                override fun onFailure(failure: Throwable) {
+                                    //revert the check box
+                                    switchPref.isChecked = !switchPref.isChecked
+                                    Toast.makeText(activity, R.string.unknown_error, Toast.LENGTH_SHORT).show()
+                                }
+                            })
                 }
 
     }

--- a/vector/src/main/java/im/vector/riotx/features/settings/VectorSettingsNotificationFragment.kt
+++ b/vector/src/main/java/im/vector/riotx/features/settings/VectorSettingsNotificationFragment.kt
@@ -122,7 +122,7 @@ class VectorSettingsNotificationPreferenceFragment : VectorSettingsBaseFragment(
                             object : MatrixCallback<Unit> {
 
                                 override fun onSuccess(data: Unit) {
-                                    pushRuleService.fetchPushRules()
+                                    // Push rules will be updated form the sync
                                 }
 
                                 override fun onFailure(failure: Throwable) {

--- a/vector/src/main/java/im/vector/riotx/features/settings/push/PushRuleItem.kt
+++ b/vector/src/main/java/im/vector/riotx/features/settings/push/PushRuleItem.kt
@@ -26,11 +26,11 @@ import androidx.core.view.isVisible
 import com.airbnb.epoxy.EpoxyAttribute
 import com.airbnb.epoxy.EpoxyModelClass
 import com.airbnb.epoxy.EpoxyModelWithHolder
-import im.vector.matrix.android.api.pushrules.Action
+import im.vector.matrix.android.api.pushrules.getActions
 import im.vector.matrix.android.api.pushrules.rest.PushRule
 import im.vector.riotx.R
 import im.vector.riotx.core.epoxy.VectorEpoxyHolder
-import im.vector.riotx.features.notifications.NotificationAction
+import im.vector.riotx.features.notifications.toNotificationAction
 
 
 @EpoxyModelClass(layout = R.layout.item_pushrule_raw)
@@ -50,12 +50,12 @@ abstract class PushRuleItem : EpoxyModelWithHolder<PushRuleItem.Holder>() {
             holder.view.setBackgroundColor(ContextCompat.getColor(context, R.color.vector_silver_color))
             holder.ruleId.text = "[Disabled] ${pushRule.ruleId}"
         }
-        val actions = Action.mapFrom(pushRule)
-        if (actions.isNullOrEmpty()) {
+        val actions = pushRule.getActions()
+        if (actions.isEmpty()) {
             holder.actionIcon.isInvisible = true
         } else {
             holder.actionIcon.isVisible = true
-            val notifAction = NotificationAction.extractFrom(actions)
+            val notifAction = actions.toNotificationAction()
 
             if (notifAction.shouldNotify && !notifAction.soundName.isNullOrBlank()) {
                 holder.actionIcon.setImageDrawable(ContextCompat.getDrawable(context, R.drawable.ic_action_notify_noisy))

--- a/vector/src/main/java/im/vector/riotx/features/settings/troubleshoot/TestAccountSettings.kt
+++ b/vector/src/main/java/im/vector/riotx/features/settings/troubleshoot/TestAccountSettings.kt
@@ -17,6 +17,7 @@ package im.vector.riotx.features.settings.troubleshoot
 
 import im.vector.matrix.android.api.MatrixCallback
 import im.vector.matrix.android.api.pushrules.RuleIds
+import im.vector.matrix.android.api.pushrules.RuleKind
 import im.vector.riotx.R
 import im.vector.riotx.core.di.ActiveSessionHolder
 import im.vector.riotx.core.resources.StringProvider
@@ -45,8 +46,7 @@ class TestAccountSettings @Inject constructor(private val stringProvider: String
                     override fun doFix() {
                         if (manager?.diagStatus == TestStatus.RUNNING) return //wait before all is finished
 
-                        // TODO Use constant for kind
-                        session.updatePushRuleEnableStatus("override", defaultRule, !defaultRule.enabled,
+                        session.updatePushRuleEnableStatus(RuleKind.OVERRIDE, defaultRule, !defaultRule.enabled,
                                                            object : MatrixCallback<Unit> {
 
                                                                override fun onSuccess(data: Unit) {

--- a/vector/src/main/java/im/vector/riotx/features/settings/troubleshoot/TestBingRulesSettings.kt
+++ b/vector/src/main/java/im/vector/riotx/features/settings/troubleshoot/TestBingRulesSettings.kt
@@ -15,12 +15,12 @@
  */
 package im.vector.riotx.features.settings.troubleshoot
 
-import im.vector.matrix.android.api.pushrules.Action
 import im.vector.matrix.android.api.pushrules.RuleIds
+import im.vector.matrix.android.api.pushrules.getActions
 import im.vector.riotx.R
 import im.vector.riotx.core.di.ActiveSessionHolder
 import im.vector.riotx.core.resources.StringProvider
-import im.vector.riotx.features.notifications.NotificationAction
+import im.vector.riotx.features.notifications.toNotificationAction
 import javax.inject.Inject
 
 class TestBingRulesSettings @Inject constructor(private val activeSessionHolder: ActiveSessionHolder,
@@ -29,15 +29,15 @@ class TestBingRulesSettings @Inject constructor(private val activeSessionHolder:
 
     private val testedRules =
             listOf(RuleIds.RULE_ID_CONTAIN_DISPLAY_NAME,
-                   RuleIds.RULE_ID_CONTAIN_USER_NAME,
-                   RuleIds.RULE_ID_ONE_TO_ONE_ROOM,
-                   RuleIds.RULE_ID_ALL_OTHER_MESSAGES_ROOMS)
+                    RuleIds.RULE_ID_CONTAIN_USER_NAME,
+                    RuleIds.RULE_ID_ONE_TO_ONE_ROOM,
+                    RuleIds.RULE_ID_ALL_OTHER_MESSAGES_ROOMS)
 
 
     val ruleSettingsName = arrayOf(R.string.settings_containing_my_display_name,
-                                   R.string.settings_containing_my_user_name,
-                                   R.string.settings_messages_in_one_to_one,
-                                   R.string.settings_messages_in_group_chat)
+            R.string.settings_containing_my_user_name,
+            R.string.settings_messages_in_one_to_one,
+            R.string.settings_messages_in_group_chat)
 
     override fun perform() {
         val session = activeSessionHolder.getSafeActiveSession() ?: return
@@ -50,8 +50,8 @@ class TestBingRulesSettings @Inject constructor(private val activeSessionHolder:
             var oneOrMoreRuleAreSilent = false
             for ((index, ruleId) in testedRules.withIndex()) {
                 pushRules.find { it.ruleId == ruleId }?.let { rule ->
-                    val actions = Action.mapFrom(rule) ?: return@let
-                    val notifAction = NotificationAction.extractFrom(actions)
+                    val actions = rule.getActions()
+                    val notifAction = actions.toNotificationAction()
                     if (!rule.enabled || !notifAction.shouldNotify) {
                         //off
                         oneOrMoreRuleIsOff = true


### PR DESCRIPTION
This PR fixes several issues:
- Clear cache was losing the push rules. Push rules are now retrieved from the sync, so are always up to date
- (Should fix) m.notice trigger notification (#238)
- simplify db entity by removing useless userId field
- Fix TU compilation error

It also introduce @UserId, to inject the userId as a String

