### PR TITLE
Make tasks responsible for dispatching.

### DIFF
--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/OutgoingRoomKeyRequestManager.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/OutgoingRoomKeyRequestManager.kt
@@ -300,7 +300,6 @@ internal class OutgoingRoomKeyRequestManager @Inject constructor(
                 .configureWith(SendToDeviceTask.Params(EventType.ROOM_KEY_REQUEST, contentMap, transactionId)) {
                     this.callback = callback
                     this.callbackThread = TaskThread.CALLER
-                    this.executionThread = TaskThread.CALLER
                 }
                 .executeBy(taskExecutor)
     }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/keysbackup/KeysBackup.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/keysbackup/KeysBackup.kt
@@ -356,12 +356,13 @@ internal class KeysBackup @Inject constructor(
         // TODO Validate with François that this is correct
         object : Task<KeysVersionResult, KeysBackupVersionTrust> {
             override suspend fun execute(params: KeysVersionResult): KeysBackupVersionTrust {
-                return getKeysBackupTrustBg(params)
+                return withContext(coroutineDispatchers.computation) {
+                    getKeysBackupTrustBg(params)
+                }
             }
         }
                 .configureWith(keysBackupVersion) {
                     this.callback = callback
-                    this.executionThread = TaskThread.COMPUTATION
                 }
                 .executeBy(taskExecutor)
     }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/di/MatrixModule.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/di/MatrixModule.kt
@@ -36,7 +36,7 @@ internal object MatrixModule {
     @MatrixScope
     fun providesMatrixCoroutineDispatchers(): MatrixCoroutineDispatchers {
         return MatrixCoroutineDispatchers(io = Dispatchers.IO,
-                                          computation = Dispatchers.IO,
+                                          computation = Dispatchers.Default,
                                           main = Dispatchers.Main,
                                           crypto = createBackgroundHandler("Crypto_Thread").asCoroutineDispatcher(),
                                           sync = Executors.newSingleThreadExecutor().asCoroutineDispatcher()

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/filter/DefaultSaveFilterTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/filter/DefaultSaveFilterTask.kt
@@ -19,6 +19,8 @@ package im.vector.matrix.android.internal.session.filter
 import im.vector.matrix.android.internal.di.UserId
 import im.vector.matrix.android.internal.network.executeRequest
 import im.vector.matrix.android.internal.task.Task
+import im.vector.matrix.android.internal.util.MatrixCoroutineDispatchers
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 /**
@@ -33,7 +35,8 @@ internal interface SaveFilterTask : Task<SaveFilterTask.Params, Unit> {
 
 internal class DefaultSaveFilterTask @Inject constructor(@UserId private val userId: String,
                                                          private val filterAPI: FilterApi,
-                                                         private val filterRepository: FilterRepository
+                                                         private val filterRepository: FilterRepository,
+                                                         private val dispatchers: MatrixCoroutineDispatchers
 ) : SaveFilterTask {
 
     override suspend fun execute(params: SaveFilterTask.Params) {
@@ -41,6 +44,8 @@ internal class DefaultSaveFilterTask @Inject constructor(@UserId private val use
             // TODO auto retry
             apiCall = filterAPI.uploadFilter(userId, params.filter)
         }
-        filterRepository.storeFilterId(params.filter, filterResponse.filterId)
+        withContext(dispatchers.io) {
+            filterRepository.storeFilterId(params.filter, filterResponse.filterId)
+        }
     }
 }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/sync/job/SyncService.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/sync/job/SyncService.kt
@@ -106,7 +106,6 @@ open class SyncService : Service() {
             cancelableTask = syncTask
                     .configureWith(params) {
                         callbackThread = TaskThread.SYNC
-                        executionThread = TaskThread.SYNC
                         callback = object : MatrixCallback<Unit> {
                             override fun onSuccess(data: Unit) {
                                 cancelableTask = null

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/sync/job/SyncThread.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/sync/job/SyncThread.kt
@@ -127,7 +127,6 @@ internal class SyncThread @Inject constructor(private val syncTask: SyncTask,
 
                 cancelableTask = syncTask.configureWith(params) {
                     this.callbackThread = TaskThread.SYNC
-                    this.executionThread = TaskThread.SYNC
                     this.callback = object : MatrixCallback<Unit> {
                         override fun onSuccess(data: Unit) {
                             Timber.v("onSuccess")

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/task/ConfigurableTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/task/ConfigurableTask.kt
@@ -35,7 +35,6 @@ internal data class ConfigurableTask<PARAMS, RESULT>(
         val params: PARAMS,
         val id: UUID,
         val callbackThread: TaskThread,
-        val executionThread: TaskThread,
         val constraints: TaskConstraints,
         val retryCount: Int,
         val callback: MatrixCallback<RESULT>
@@ -47,7 +46,6 @@ internal data class ConfigurableTask<PARAMS, RESULT>(
             private val params: PARAMS,
             var id: UUID = UUID.randomUUID(),
             var callbackThread: TaskThread = TaskThread.MAIN,
-            var executionThread: TaskThread = TaskThread.IO,
             var constraints: TaskConstraints = TaskConstraints(),
             var retryCount: Int = 0,
             var callback: MatrixCallback<RESULT> = object : MatrixCallback<RESULT> {}
@@ -58,7 +56,6 @@ internal data class ConfigurableTask<PARAMS, RESULT>(
                 params = params,
                 id = id,
                 callbackThread = callbackThread,
-                executionThread = executionThread,
                 constraints = constraints,
                 retryCount = retryCount,
                 callback = callback

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/task/TaskExecutor.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/task/TaskExecutor.kt
@@ -36,7 +36,7 @@ internal class TaskExecutor @Inject constructor(private val coroutineDispatchers
     fun <PARAMS, RESULT> execute(task: ConfigurableTask<PARAMS, RESULT>): Cancelable {
         val job = executorScope.launch(task.callbackThread.toDispatcher()) {
             val resultOrFailure = runCatching {
-                withContext(task.executionThread.toDispatcher()) {
+                withContext(coroutineDispatchers.computation) {
                     Timber.v("Enqueue task $task")
                     retry(task.retryCount) {
                         if (task.constraints.connectedToNetwork) {


### PR DESCRIPTION
Signed-off-by: Dominic Fischer <dominicfischer7@gmail.com>

### Pull Request Checklist

<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/riotX-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->

- [ ] Changes has been tested on an Android device or Android emulator with API 16
- [ ] UI change has been tested on both light and dark themes
- [x] Pull request is based on the develop branch
- [ ] Pull request updates [CHANGES.md](https://github.com/vector-im/riotX-android/blob/develop/CHANGES.md)
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#sign-off)

In this PR I have made `Task`s responsible for which dispatcher they run in.
In terms of coroutines, it doesn't make sense for caller to dictate where a task should execute, the task should know it needs to place blocking IO in the IO dispatcher, crypto in the crypto dispatcher, etc.
In some cases, tasks might need to use mutliple dispatchers depending on what it is doing, in which case, `executionThread` stops making sense.


Somewhat related:
I also noticed that `Dispatchers.IO` (dynamic 64 threads) is used for everything instead of `Dispatchers.Default` (fixed n threads, n == number of cores). Doing this might be less efficient, since threads won't be recycled, app becomes more resource heavy.