### PR TITLE
Fix / event mapper persist the clear type in type

### DIFF
--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/database/helper/ChunkEntityHelper.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/database/helper/ChunkEntityHelper.kt
@@ -124,7 +124,7 @@ internal fun ChunkEntity.add(roomId: String,
         backwardsDisplayIndex = currentDisplayIndex
     }
     var currentStateIndex = lastStateIndex(direction, defaultValue = stateIndexOffset)
-    if (direction == PaginationDirection.FORWARDS && EventType.isStateEvent(event.getClearType())) {
+    if (direction == PaginationDirection.FORWARDS && EventType.isStateEvent(event.type)) {
         currentStateIndex += 1
         forwardsStateIndex = currentStateIndex
     } else if (direction == PaginationDirection.BACKWARDS && timelineEvents.isNotEmpty()) {

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/database/mapper/EventMapper.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/database/mapper/EventMapper.kt
@@ -37,7 +37,7 @@ internal object EventMapper {
         val resolvedPrevContent = event.prevContent ?: event.unsignedData?.prevContent
         eventEntity.prevContent = ContentMapper.map(resolvedPrevContent)
         eventEntity.stateKey = event.stateKey
-        eventEntity.type = event.getClearType()
+        eventEntity.type = event.type
         eventEntity.sender = event.senderId
         eventEntity.originServerTs = event.originServerTs
         eventEntity.redacts = event.redacts


### PR DESCRIPTION
Fix bug when some messages in encrypted rooms appears as malformed events
(rageshake 6356)

The issue is that the event mapper persists the clear type as the type in DB, leading to an event with a clear type m.room.message but with an encrypted content.
Not sure what lead to this case as the sync handler does not decrypt before persisting, but it might be possible that the in memory event is modified by another 'task' before the persisting occurs?(Event is not immutable)
