### PR TITLE
Feature/timeline message code

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@ Features ✨:
  -
 
 Improvements 🙌:
- -
+ - Handle code tags (#567)
 
 Other changes:
  -

--- a/vector/build.gradle
+++ b/vector/build.gradle
@@ -219,7 +219,7 @@ dependencies {
     def epoxy_version = '3.8.0'
     def arrow_version = "0.8.2"
     def coroutines_version = "1.3.2"
-    def markwon_version = '3.1.0'
+    def markwon_version = '4.1.2'
     def big_image_viewer_version = '1.5.6'
     def glide_version = '4.10.0'
     def moshi_version = '1.8.0'
@@ -283,8 +283,8 @@ dependencies {
     implementation 'com.amulyakhare:com.amulyakhare.textdrawable:1.0.1'
     implementation 'com.google.android.material:material:1.1.0-beta01'
     implementation 'me.gujun.android:span:1.7'
-    implementation "ru.noties.markwon:core:$markwon_version"
-    implementation "ru.noties.markwon:html:$markwon_version"
+    implementation "io.noties.markwon:core:$markwon_version"
+    implementation "io.noties.markwon:html:$markwon_version"
     implementation 'me.saket:better-link-movement-method:2.2.0'
     implementation 'com.google.android:flexbox:1.1.1'
 

--- a/vector/src/main/java/im/vector/riotx/core/platform/MaxHeightScrollView.kt
+++ b/vector/src/main/java/im/vector/riotx/core/platform/MaxHeightScrollView.kt
@@ -16,17 +16,15 @@
 
 package im.vector.riotx.core.platform
 
-import android.annotation.TargetApi
 import android.content.Context
-import android.os.Build
 import android.util.AttributeSet
-import android.widget.ScrollView
-
+import androidx.core.widget.NestedScrollView
 import im.vector.riotx.R
 
 private const val DEFAULT_MAX_HEIGHT = 200
 
-class MaxHeightScrollView : ScrollView {
+class MaxHeightScrollView @JvmOverloads constructor(context: Context, attrs: AttributeSet? = null, defStyle: Int = 0)
+    : NestedScrollView(context, attrs, defStyle) {
 
     var maxHeight: Int = 0
         set(value) {
@@ -34,28 +32,7 @@ class MaxHeightScrollView : ScrollView {
             requestLayout()
         }
 
-    constructor(context: Context) : super(context) {}
-
-    constructor(context: Context, attrs: AttributeSet) : super(context, attrs) {
-        if (!isInEditMode) {
-            init(context, attrs)
-        }
-    }
-
-    constructor(context: Context, attrs: AttributeSet, defStyleAttr: Int) : super(context, attrs, defStyleAttr) {
-        if (!isInEditMode) {
-            init(context, attrs)
-        }
-    }
-
-    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
-    constructor(context: Context, attrs: AttributeSet, defStyleAttr: Int, defStyleRes: Int) : super(context, attrs, defStyleAttr, defStyleRes) {
-        if (!isInEditMode) {
-            init(context, attrs)
-        }
-    }
-
-    private fun init(context: Context, attrs: AttributeSet?) {
+    init {
         if (attrs != null) {
             val styledAttrs = context.obtainStyledAttributes(attrs, R.styleable.MaxHeightScrollView)
             maxHeight = styledAttrs.getDimensionPixelSize(R.styleable.MaxHeightScrollView_maxHeight, DEFAULT_MAX_HEIGHT)

--- a/vector/src/main/java/im/vector/riotx/features/home/room/detail/RoomDetailFragment.kt
+++ b/vector/src/main/java/im/vector/riotx/features/home/room/detail/RoomDetailFragment.kt
@@ -480,7 +480,7 @@ class RoomDetailFragment :
                 jumpToReadMarkerView.render(show, readMarkerId)
             }
         }
-        recyclerView.setController(timelineEventController)
+        recyclerView.adapter = timelineEventController.adapter
         recyclerView.addOnScrollListener(object : RecyclerView.OnScrollListener() {
             override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
                 if (recyclerView.scrollState == RecyclerView.SCROLL_STATE_IDLE) {

--- a/vector/src/main/java/im/vector/riotx/features/home/room/detail/timeline/factory/MessageItemFactory.kt
+++ b/vector/src/main/java/im/vector/riotx/features/home/room/detail/timeline/factory/MessageItemFactory.kt
@@ -228,7 +228,6 @@ class MessageItemFactory @Inject constructor(
                                         highlight: Boolean,
                                         callback: TimelineEventController.Callback?,
                                         attributes: AbsMessageItem.Attributes): VectorEpoxyModel<*>? {
-
         val isFormatted = messageContent.formattedBody.isNullOrBlank().not()
         return if (isFormatted) {
             val localFormattedBody = htmlRenderer.get().parse(messageContent.body) as Document
@@ -282,8 +281,6 @@ class MessageItemFactory @Inject constructor(
                                    highlight: Boolean,
                                    callback: TimelineEventController.Callback?,
                                    attributes: AbsMessageItem.Attributes): MessageBlockCodeItem? {
-
-
         return MessageBlockCodeItem_()
                 .apply {
                     if (informationData.hasBeenEdited) {

--- a/vector/src/main/java/im/vector/riotx/features/home/room/detail/timeline/item/MessageBlockCodeItem.kt
+++ b/vector/src/main/java/im/vector/riotx/features/home/room/detail/timeline/item/MessageBlockCodeItem.kt
@@ -17,13 +17,11 @@
 package im.vector.riotx.features.home.room.detail.timeline.item
 
 import android.widget.TextView
-import androidx.core.view.isVisible
 import com.airbnb.epoxy.EpoxyAttribute
 import com.airbnb.epoxy.EpoxyModelClass
 import im.vector.riotx.R
 import im.vector.riotx.core.extensions.setTextOrHide
 import me.saket.bettermovementmethod.BetterLinkMovementMethod
-
 
 @EpoxyModelClass(layout = R.layout.item_timeline_event_base)
 abstract class MessageBlockCodeItem : AbsMessageItem<MessageBlockCodeItem.Holder>() {

--- a/vector/src/main/java/im/vector/riotx/features/home/room/detail/timeline/item/MessageBlockCodeItem.kt
+++ b/vector/src/main/java/im/vector/riotx/features/home/room/detail/timeline/item/MessageBlockCodeItem.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.riotx.features.home.room.detail.timeline.item
+
+import com.airbnb.epoxy.EpoxyAttribute
+import com.airbnb.epoxy.EpoxyModelClass
+import im.vector.riotx.R
+import im.vector.riotx.features.home.room.detail.timeline.TimelineEventController
+
+@EpoxyModelClass(layout = R.layout.item_timeline_event_base)
+abstract class MessageBlockCodeItem : AbsMessageItem<MessageBlockCodeItem.Holder>() {
+
+    @EpoxyAttribute
+    var message: CharSequence? = null
+
+    override fun bind(holder: Holder) {
+        super.bind(holder)
+
+    }
+
+    override fun getViewType() = STUB_ID
+
+    class Holder : AbsMessageItem.Holder(STUB_ID) {
+
+    }
+
+    companion object {
+        private const val STUB_ID = R.id.messageContentCodeBlockStub
+    }
+}

--- a/vector/src/main/java/im/vector/riotx/features/home/room/detail/timeline/item/MessageBlockCodeItem.kt
+++ b/vector/src/main/java/im/vector/riotx/features/home/room/detail/timeline/item/MessageBlockCodeItem.kt
@@ -16,26 +16,38 @@
 
 package im.vector.riotx.features.home.room.detail.timeline.item
 
+import android.widget.TextView
+import androidx.core.view.isVisible
 import com.airbnb.epoxy.EpoxyAttribute
 import com.airbnb.epoxy.EpoxyModelClass
 import im.vector.riotx.R
-import im.vector.riotx.features.home.room.detail.timeline.TimelineEventController
+import im.vector.riotx.core.extensions.setTextOrHide
+import me.saket.bettermovementmethod.BetterLinkMovementMethod
+
 
 @EpoxyModelClass(layout = R.layout.item_timeline_event_base)
 abstract class MessageBlockCodeItem : AbsMessageItem<MessageBlockCodeItem.Holder>() {
 
     @EpoxyAttribute
     var message: CharSequence? = null
+    @EpoxyAttribute
+    var editedSpan: CharSequence? = null
 
     override fun bind(holder: Holder) {
         super.bind(holder)
-
+        holder.messageView.text = message
+        renderSendState(holder.messageView, holder.messageView)
+        holder.messageView.setOnClickListener(attributes.itemClickListener)
+        holder.messageView.setOnLongClickListener(attributes.itemLongClickListener)
+        holder.editedView.movementMethod = BetterLinkMovementMethod.getInstance()
+        holder.editedView.setTextOrHide(editedSpan)
     }
 
     override fun getViewType() = STUB_ID
 
     class Holder : AbsMessageItem.Holder(STUB_ID) {
-
+        val messageView by bind<TextView>(R.id.codeBlockTextView)
+        val editedView by bind<TextView>(R.id.codeBlockEditedView)
     }
 
     companion object {

--- a/vector/src/main/java/im/vector/riotx/features/html/CodeVisitor.kt
+++ b/vector/src/main/java/im/vector/riotx/features/html/CodeVisitor.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.riotx.features.html
+
+import org.commonmark.node.AbstractVisitor
+import org.commonmark.node.Code
+import org.commonmark.node.FencedCodeBlock
+import org.commonmark.node.IndentedCodeBlock
+
+/**
+ * This class is in charge of visiting nodes and tells if we have some code nodes (inline or block).
+ */
+class CodeVisitor : AbstractVisitor() {
+
+    var codeKind: Kind = Kind.NONE
+        private set
+
+    override fun visit(fencedCodeBlock: FencedCodeBlock?) {
+        if (codeKind == Kind.NONE) {
+            codeKind = Kind.BLOCK
+        }
+    }
+
+    override fun visit(indentedCodeBlock: IndentedCodeBlock?) {
+        if (codeKind == Kind.NONE) {
+            codeKind = Kind.BLOCK
+        }
+    }
+
+    override fun visit(code: Code?) {
+        if (codeKind == Kind.NONE) {
+            codeKind = Kind.INLINE
+        }
+    }
+
+    enum class Kind {
+        NONE,
+        INLINE,
+        BLOCK
+    }
+
+}

--- a/vector/src/main/java/im/vector/riotx/features/html/CodeVisitor.kt
+++ b/vector/src/main/java/im/vector/riotx/features/html/CodeVisitor.kt
@@ -52,5 +52,4 @@ class CodeVisitor : AbstractVisitor() {
         INLINE,
         BLOCK
     }
-
 }

--- a/vector/src/main/java/im/vector/riotx/features/html/EventHtmlRenderer.kt
+++ b/vector/src/main/java/im/vector/riotx/features/html/EventHtmlRenderer.kt
@@ -17,171 +17,47 @@
 package im.vector.riotx.features.html
 
 import android.content.Context
-import android.text.style.URLSpan
-import im.vector.matrix.android.api.permalinks.PermalinkData
-import im.vector.matrix.android.api.permalinks.PermalinkParser
 import im.vector.riotx.core.di.ActiveSessionHolder
 import im.vector.riotx.core.glide.GlideApp
-import im.vector.riotx.core.glide.GlideRequests
 import im.vector.riotx.features.home.AvatarRenderer
-import org.commonmark.node.BlockQuote
-import org.commonmark.node.HtmlBlock
-import org.commonmark.node.HtmlInline
+import io.noties.markwon.Markwon
+import io.noties.markwon.html.HtmlPlugin
+import io.noties.markwon.html.TagHandlerNoOp
 import org.commonmark.node.Node
-import ru.noties.markwon.*
-import ru.noties.markwon.html.HtmlTag
-import ru.noties.markwon.html.MarkwonHtmlParserImpl
-import ru.noties.markwon.html.MarkwonHtmlRenderer
-import ru.noties.markwon.html.TagHandler
-import ru.noties.markwon.html.tag.*
-import java.util.Arrays.asList
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 class EventHtmlRenderer @Inject constructor(context: Context,
-                                            avatarRenderer: AvatarRenderer,
-                                            sessionHolder: ActiveSessionHolder) {
+                                            htmlConfigure: MatrixHtmlPluginConfigure) {
+
     private val markwon = Markwon.builder(context)
-            .usePlugin(MatrixPlugin.create(GlideApp.with(context), context, avatarRenderer, sessionHolder))
+            .usePlugin(HtmlPlugin.create(htmlConfigure))
             .build()
+
+    fun parse(text: String): Node {
+        return markwon.parse(text)
+    }
 
     fun render(text: String): CharSequence {
         return markwon.toMarkdown(text)
     }
 
-    fun render(node: Node) : CharSequence {
+    fun render(node: Node): CharSequence {
         return markwon.render(node)
     }
 }
 
-private class MatrixPlugin private constructor(private val glideRequests: GlideRequests,
-                                               private val context: Context,
-                                               private val avatarRenderer: AvatarRenderer,
-                                               private val session: ActiveSessionHolder) : AbstractMarkwonPlugin() {
+class MatrixHtmlPluginConfigure @Inject constructor(private val context: Context,
+                                                    private val avatarRenderer: AvatarRenderer,
+                                                    private val session: ActiveSessionHolder) : HtmlPlugin.HtmlConfigure {
 
-    override fun configureConfiguration(builder: MarkwonConfiguration.Builder) {
-        builder.htmlParser(MarkwonHtmlParserImpl.create())
+    override fun configureHtml(plugin: HtmlPlugin) {
+        plugin
+                .addHandler(TagHandlerNoOp.create("a"))
+                .addHandler(FontTagHandler())
+                .addHandler(MxLinkTagHandler(GlideApp.with(context), context, avatarRenderer, session))
+                .addHandler(MxReplyTagHandler())
     }
 
-    override fun configureHtmlRenderer(builder: MarkwonHtmlRenderer.Builder) {
-        builder
-                .setHandler(
-                        "img",
-                        ImageHandler.create())
-                .setHandler(
-                        "a",
-                        MxLinkHandler(glideRequests, context, avatarRenderer, session))
-                .setHandler(
-                        "blockquote",
-                        BlockquoteHandler())
-                .setHandler(
-                        "font",
-                        FontTagHandler())
-                .setHandler(
-                        "sub",
-                        SubScriptHandler())
-                .setHandler(
-                        "sup",
-                        SuperScriptHandler())
-                .setHandler(
-                        asList<String>("b", "strong"),
-                        StrongEmphasisHandler())
-                .setHandler(
-                        asList<String>("s", "del"),
-                        StrikeHandler())
-                .setHandler(
-                        asList<String>("u", "ins"),
-                        UnderlineHandler())
-                .setHandler(
-                        asList<String>("ul", "ol"),
-                        ListHandler())
-                .setHandler(
-                        asList<String>("i", "em", "cite", "dfn"),
-                        EmphasisHandler())
-                .setHandler(
-                        asList<String>("h1", "h2", "h3", "h4", "h5", "h6"),
-                        HeadingHandler())
-                .setHandler("mx-reply",
-                            MxReplyTagHandler())
-    }
-
-    override fun afterRender(node: Node, visitor: MarkwonVisitor) {
-        val configuration = visitor.configuration()
-        configuration.htmlRenderer().render(visitor, configuration.htmlParser())
-    }
-
-    override fun configureVisitor(builder: MarkwonVisitor.Builder) {
-        builder
-                .on(HtmlBlock::class.java) { visitor, htmlBlock -> visitHtml(visitor, htmlBlock.literal) }
-                .on(HtmlInline::class.java) { visitor, htmlInline -> visitHtml(visitor, htmlInline.literal) }
-    }
-
-    private fun visitHtml(visitor: MarkwonVisitor, html: String?) {
-        if (html != null) {
-            visitor.configuration().htmlParser().processFragment(visitor.builder(), html)
-        }
-    }
-
-    companion object {
-
-        fun create(glideRequests: GlideRequests, context: Context, avatarRenderer: AvatarRenderer, session: ActiveSessionHolder): MatrixPlugin {
-            return MatrixPlugin(glideRequests, context, avatarRenderer, session)
-        }
-    }
-}
-
-private class MxLinkHandler(private val glideRequests: GlideRequests,
-                            private val context: Context,
-                            private val avatarRenderer: AvatarRenderer,
-                            private val sessionHolder: ActiveSessionHolder) : TagHandler() {
-
-    private val linkHandler = LinkHandler()
-
-    override fun handle(visitor: MarkwonVisitor, renderer: MarkwonHtmlRenderer, tag: HtmlTag) {
-        val link = tag.attributes()["href"]
-        if (link != null) {
-            val permalinkData = PermalinkParser.parse(link)
-            when (permalinkData) {
-                is PermalinkData.UserLink -> {
-                    val user = sessionHolder.getSafeActiveSession()?.getUser(permalinkData.userId)
-                    val span = PillImageSpan(glideRequests, avatarRenderer, context, permalinkData.userId, user)
-                    SpannableBuilder.setSpans(
-                            visitor.builder(),
-                            span,
-                            tag.start(),
-                            tag.end()
-                    )
-                    // also add clickable span
-                    SpannableBuilder.setSpans(
-                            visitor.builder(),
-                            URLSpan(link),
-                            tag.start(),
-                            tag.end()
-                    )
-                }
-                else                      -> linkHandler.handle(visitor, renderer, tag)
-            }
-        } else {
-            linkHandler.handle(visitor, renderer, tag)
-        }
-    }
-}
-
-private class MxReplyTagHandler : TagHandler() {
-
-    override fun handle(visitor: MarkwonVisitor, renderer: MarkwonHtmlRenderer, tag: HtmlTag) {
-        val configuration = visitor.configuration()
-        val factory = configuration.spansFactory().get(BlockQuote::class.java)
-        if (factory != null) {
-            SpannableBuilder.setSpans(
-                    visitor.builder(),
-                    factory.getSpans(configuration, visitor.renderProps()),
-                    tag.start(),
-                    tag.end()
-            )
-            val replyText = visitor.builder().removeFromEnd(tag.end())
-            visitor.builder().append("\n\n").append(replyText)
-        }
-    }
 }

--- a/vector/src/main/java/im/vector/riotx/features/html/EventHtmlRenderer.kt
+++ b/vector/src/main/java/im/vector/riotx/features/html/EventHtmlRenderer.kt
@@ -59,5 +59,4 @@ class MatrixHtmlPluginConfigure @Inject constructor(private val context: Context
                 .addHandler(MxLinkTagHandler(GlideApp.with(context), context, avatarRenderer, session))
                 .addHandler(MxReplyTagHandler())
     }
-
 }

--- a/vector/src/main/java/im/vector/riotx/features/html/FontTagHandler.kt
+++ b/vector/src/main/java/im/vector/riotx/features/html/FontTagHandler.kt
@@ -17,15 +17,18 @@ package im.vector.riotx.features.html
 
 import android.graphics.Color
 import android.text.style.ForegroundColorSpan
-import ru.noties.markwon.MarkwonConfiguration
-import ru.noties.markwon.RenderProps
-import ru.noties.markwon.html.HtmlTag
-import ru.noties.markwon.html.tag.SimpleTagHandler
+import io.noties.markwon.MarkwonConfiguration
+import io.noties.markwon.RenderProps
+import io.noties.markwon.html.HtmlTag
+import io.noties.markwon.html.tag.SimpleTagHandler
 
 /**
  * custom to matrix for IRC-style font coloring
  */
 class FontTagHandler : SimpleTagHandler() {
+
+    override fun supportedTags() = listOf("font")
+
     override fun getSpans(configuration: MarkwonConfiguration, renderProps: RenderProps, tag: HtmlTag): Any? {
         val colorString = tag.attributes()["color"]?.let { parseColor(it) } ?: Color.BLACK
         return ForegroundColorSpan(colorString)
@@ -37,23 +40,23 @@ class FontTagHandler : SimpleTagHandler() {
         } catch (e: Exception) {
             // try other w3c colors?
             return when (color_name) {
-                "white" -> Color.WHITE
-                "yellow" -> Color.YELLOW
+                "white"   -> Color.WHITE
+                "yellow"  -> Color.YELLOW
                 "fuchsia" -> Color.parseColor("#FF00FF")
-                "red" -> Color.RED
-                "silver" -> Color.parseColor("#C0C0C0")
-                "gray" -> Color.GRAY
-                "olive" -> Color.parseColor("#808000")
-                "purple" -> Color.parseColor("#800080")
-                "maroon" -> Color.parseColor("#800000")
-                "aqua" -> Color.parseColor("#00FFFF")
-                "lime" -> Color.parseColor("#00FF00")
-                "teal" -> Color.parseColor("#008080")
-                "green" -> Color.GREEN
-                "blue" -> Color.BLUE
-                "orange" -> Color.parseColor("#FFA500")
-                "navy" -> Color.parseColor("#000080")
-                else -> Color.BLACK
+                "red"     -> Color.RED
+                "silver"  -> Color.parseColor("#C0C0C0")
+                "gray"    -> Color.GRAY
+                "olive"   -> Color.parseColor("#808000")
+                "purple"  -> Color.parseColor("#800080")
+                "maroon"  -> Color.parseColor("#800000")
+                "aqua"    -> Color.parseColor("#00FFFF")
+                "lime"    -> Color.parseColor("#00FF00")
+                "teal"    -> Color.parseColor("#008080")
+                "green"   -> Color.GREEN
+                "blue"    -> Color.BLUE
+                "orange"  -> Color.parseColor("#FFA500")
+                "navy"    -> Color.parseColor("#000080")
+                else      -> Color.BLACK
             }
         }
     }

--- a/vector/src/main/java/im/vector/riotx/features/html/MxLinkTagHandler.kt
+++ b/vector/src/main/java/im/vector/riotx/features/html/MxLinkTagHandler.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2019 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.riotx.features.html
+
+import android.content.Context
+import android.text.style.URLSpan
+import im.vector.matrix.android.api.permalinks.PermalinkData
+import im.vector.matrix.android.api.permalinks.PermalinkParser
+import im.vector.riotx.core.di.ActiveSessionHolder
+import im.vector.riotx.core.glide.GlideRequests
+import im.vector.riotx.features.home.AvatarRenderer
+import io.noties.markwon.MarkwonVisitor
+import io.noties.markwon.SpannableBuilder
+import io.noties.markwon.html.HtmlTag
+import io.noties.markwon.html.MarkwonHtmlRenderer
+import io.noties.markwon.html.tag.LinkHandler
+
+class MxLinkTagHandler(private val glideRequests: GlideRequests,
+                       private val context: Context,
+                       private val avatarRenderer: AvatarRenderer,
+                       private val sessionHolder: ActiveSessionHolder) : LinkHandler() {
+
+    override fun handle(visitor: MarkwonVisitor, renderer: MarkwonHtmlRenderer, tag: HtmlTag) {
+        val link = tag.attributes()["href"]
+        if (link != null) {
+            val permalinkData = PermalinkParser.parse(link)
+            when (permalinkData) {
+                is PermalinkData.UserLink -> {
+                    val user = sessionHolder.getSafeActiveSession()?.getUser(permalinkData.userId)
+                    val span = PillImageSpan(glideRequests, avatarRenderer, context, permalinkData.userId, user)
+                    SpannableBuilder.setSpans(
+                            visitor.builder(),
+                            span,
+                            tag.start(),
+                            tag.end()
+                    )
+                    // also add clickable span
+                    SpannableBuilder.setSpans(
+                            visitor.builder(),
+                            URLSpan(link),
+                            tag.start(),
+                            tag.end()
+                    )
+                }
+                else                      -> super.handle(visitor, renderer, tag)
+            }
+        } else {
+            super.handle(visitor, renderer, tag)
+        }
+    }
+}

--- a/vector/src/main/java/im/vector/riotx/features/html/MxReplyTagHandler.kt
+++ b/vector/src/main/java/im/vector/riotx/features/html/MxReplyTagHandler.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.riotx.features.html
+
+import io.noties.markwon.MarkwonVisitor
+import io.noties.markwon.SpannableBuilder
+import io.noties.markwon.html.HtmlTag
+import io.noties.markwon.html.MarkwonHtmlRenderer
+import io.noties.markwon.html.TagHandler
+import org.commonmark.node.BlockQuote
+
+class MxReplyTagHandler : TagHandler() {
+
+    override fun supportedTags() = listOf("mx-reply")
+
+    override fun handle(visitor: MarkwonVisitor, renderer: MarkwonHtmlRenderer, tag: HtmlTag) {
+        val configuration = visitor.configuration()
+        val factory = configuration.spansFactory().get(BlockQuote::class.java)
+        if (factory != null) {
+            SpannableBuilder.setSpans(
+                    visitor.builder(),
+                    factory.getSpans(configuration, visitor.renderProps()),
+                    tag.start(),
+                    tag.end()
+            )
+            val replyText = visitor.builder().removeFromEnd(tag.end())
+            visitor.builder().append("\n\n").append(replyText)
+        }
+    }
+}

--- a/vector/src/main/res/layout/fragment_room_detail.xml
+++ b/vector/src/main/res/layout/fragment_room_detail.xml
@@ -86,7 +86,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/roomToolbar" />
 
-    <com.airbnb.epoxy.EpoxyRecyclerView
+    <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recyclerView"
         android:layout_width="0dp"
         android:layout_height="0dp"

--- a/vector/src/main/res/layout/item_timeline_event_base.xml
+++ b/vector/src/main/res/layout/item_timeline_event_base.xml
@@ -82,7 +82,6 @@
             android:id="@+id/messageContentCodeBlockStub"
             style="@style/TimelineContentStubBaseParams"
             android:layout_height="wrap_content"
-            android:inflatedId="@id/messageTextView"
             android:layout="@layout/item_timeline_event_code_block_stub"
             tools:visibility="visible" />
 

--- a/vector/src/main/res/layout/item_timeline_event_base.xml
+++ b/vector/src/main/res/layout/item_timeline_event_base.xml
@@ -79,6 +79,14 @@
             tools:visibility="visible" />
 
         <ViewStub
+            android:id="@+id/messageContentCodeBlockStub"
+            style="@style/TimelineContentStubBaseParams"
+            android:layout_height="wrap_content"
+            android:inflatedId="@id/messageTextView"
+            android:layout="@layout/item_timeline_event_code_block_stub"
+            tools:visibility="visible" />
+
+        <ViewStub
             android:id="@+id/messageContentMediaStub"
             style="@style/TimelineContentStubBaseParams"
             android:layout_height="wrap_content"

--- a/vector/src/main/res/layout/item_timeline_event_code_block_stub.xml
+++ b/vector/src/main/res/layout/item_timeline_event_code_block_stub.xml
@@ -13,7 +13,6 @@
             android:id="@+id/codeBlockTextView"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginStart="4dp"
             android:fontFamily="monospace"
             android:textSize="14sp" />
 

--- a/vector/src/main/res/layout/item_timeline_event_code_block_stub.xml
+++ b/vector/src/main/res/layout/item_timeline_event_code_block_stub.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/messagesAdapter_body_hsv"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:maxHeight="500dp">
+
+    <androidx.core.widget.NestedScrollView
+        android:id="@+id/codeBlockScrollView"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:fadeScrollbars="false"
+        android:scrollbars="vertical|horizontal"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <HorizontalScrollView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <TextView
+                android:id="@+id/codeBlockTextView"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="4dp"
+                android:layout_marginLeft="4dp"
+                android:autoLink="none"
+                android:fontFamily="monospace"
+                android:textSize="14sp"
+                tools:text="" />
+
+        </HorizontalScrollView>
+
+    </androidx.core.widget.NestedScrollView>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/vector/src/main/res/layout/item_timeline_event_code_block_stub.xml
+++ b/vector/src/main/res/layout/item_timeline_event_code_block_stub.xml
@@ -1,40 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/messagesAdapter_body_hsv"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:maxHeight="500dp">
+    android:orientation="vertical">
 
-    <androidx.core.widget.NestedScrollView
-        android:id="@+id/codeBlockScrollView"
-        android:layout_width="0dp"
+    <HorizontalScrollView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <TextView
+            android:id="@+id/codeBlockTextView"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="4dp"
+            android:fontFamily="monospace"
+            android:textSize="14sp" />
+
+    </HorizontalScrollView>
+
+    <TextView
+        android:id="@+id/codeBlockEditedView"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:fadeScrollbars="false"
-        android:scrollbars="vertical|horizontal"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
+        android:layout_marginTop="4dp" />
 
-        <HorizontalScrollView
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content">
-
-            <TextView
-                android:id="@+id/codeBlockTextView"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="4dp"
-                android:layout_marginLeft="4dp"
-                android:autoLink="none"
-                android:fontFamily="monospace"
-                android:textSize="14sp"
-                tools:text="" />
-
-        </HorizontalScrollView>
-
-    </androidx.core.widget.NestedScrollView>
-
-</androidx.constraintlayout.widget.ConstraintLayout>
+</LinearLayout>


### PR DESCRIPTION
Handling code tag (with markdown) fixing #567 and #356 

For the moment, it only uses an HorizontalScrollView and wrap the height. In the future we might want to have a two way scroll and even a detail "code" view. 

![Screenshot_20191030-190533](https://user-images.githubusercontent.com/8754928/67885942-caca8d80-fb48-11e9-8dba-7e4c06c0fbce.png)
