### PR TITLE
a11y: file type selector

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@ Improvements 🙌:
  -
 
 Other changes:
- -
+ - Accessibility improvements to the attachment file type chooser
 
 Bugfix 🐛:
  - Fix issues with some member events rendering (#498)

--- a/vector/src/main/res/layout/view_attachment_type_selector.xml
+++ b/vector/src/main/res/layout/view_attachment_type_selector.xml
@@ -30,10 +30,12 @@
                 android:id="@+id/attachmentCameraButton"
                 style="@style/AttachmentTypeSelectorButton"
                 android:src="@drawable/ic_attachment_camera_white_24dp"
+                android:contentDescription="@string/attachment_type_camera"
                 tools:background="@color/colorAccent" />
 
             <TextView
                 style="@style/AttachmentTypeSelectorLabel"
+                android:importantForAccessibility="no"
                 android:text="@string/attachment_type_camera" />
 
         </LinearLayout>
@@ -50,10 +52,12 @@
                 android:id="@+id/attachmentGalleryButton"
                 style="@style/AttachmentTypeSelectorButton"
                 android:src="@drawable/ic_attachment_gallery_white_24dp"
+                android:contentDescription="@string/attachment_type_gallery"
                 tools:background="@color/colorAccent" />
 
             <TextView
                 style="@style/AttachmentTypeSelectorLabel"
+                android:importantForAccessibility="no"
                 android:text="@string/attachment_type_gallery" />
 
         </LinearLayout>
@@ -70,10 +74,12 @@
                 android:id="@+id/attachmentFileButton"
                 style="@style/AttachmentTypeSelectorButton"
                 android:src="@drawable/ic_attachment_file_white_24dp"
+                android:contentDescription="@string/attachment_type_file"
                 tools:background="@color/colorAccent" />
 
             <TextView
                 style="@style/AttachmentTypeSelectorLabel"
+                android:importantForAccessibility="no"
                 android:text="@string/attachment_type_file" />
 
         </LinearLayout>
@@ -99,10 +105,12 @@
                 android:id="@+id/attachmentAudioButton"
                 style="@style/AttachmentTypeSelectorButton"
                 android:src="@drawable/ic_attachment_audio_white_24dp"
+                android:contentDescription="@string/attachment_type_audio"
                 tools:background="@color/colorAccent" />
 
             <TextView
                 style="@style/AttachmentTypeSelectorLabel"
+                android:importantForAccessibility="no"
                 android:text="@string/attachment_type_audio" />
 
         </LinearLayout>
@@ -119,10 +127,12 @@
                 android:id="@+id/attachmentContactButton"
                 style="@style/AttachmentTypeSelectorButton"
                 android:src="@drawable/ic_attachment_contact_white_24dp"
+                android:contentDescription="@string/attachment_type_contact"
                 tools:background="@color/colorAccent" />
 
             <TextView
                 style="@style/AttachmentTypeSelectorLabel"
+                android:importantForAccessibility="no"
                 android:text="@string/attachment_type_contact" />
 
         </LinearLayout>
@@ -139,10 +149,12 @@
                 android:id="@+id/attachmentStickersButton"
                 style="@style/AttachmentTypeSelectorButton"
                 android:src="@drawable/ic_attachment_stickers_white_24dp"
+                android:contentDescription="@string/attachment_type_sticker"
                 tools:background="@color/colorAccent" />
 
             <TextView
                 style="@style/AttachmentTypeSelectorLabel"
+                android:importantForAccessibility="no"
                 android:text="@string/attachment_type_sticker" />
 
         </LinearLayout>


### PR DESCRIPTION
better presentation for file type selector buttons to screen reader users
It would be even better if we could add on click handler and contentDescription to the parent linear layout encapsulating both image and text. But I'd rather did minimal changes as I can't predict visual appearance changing it that way.

Signed-off-by: Peter Vágner <pvdeejay@gmail.com>

### Pull Request Checklist

<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/riotX-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->

- [x] Changes has been tested on an Android device or Android emulator with API 16
- [ ] UI change has been tested on both light and dark themes
- [x] Pull request is based on the develop branch
- [x] Pull request updates [CHANGES.md](https://github.com/vector-im/riotX-android/blob/develop/CHANGES.md)
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#sign-off)
