### PR TITLE
Add help to reveal the long click on a room

### DIFF
--- a/vector/src/main/java/im/vector/riotx/core/epoxy/HelpFooterItem.kt
+++ b/vector/src/main/java/im/vector/riotx/core/epoxy/HelpFooterItem.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.riotx.core.epoxy
+
+import android.widget.TextView
+import com.airbnb.epoxy.EpoxyAttribute
+import com.airbnb.epoxy.EpoxyModelClass
+import im.vector.riotx.R
+
+@EpoxyModelClass(layout = R.layout.item_help_footer)
+abstract class HelpFooterItem : VectorEpoxyModel<HelpFooterItem.Holder>() {
+
+    @EpoxyAttribute
+    var text: String? = null
+
+    override fun bind(holder: Holder) {
+        holder.textView.text = text
+    }
+
+    class Holder : VectorEpoxyHolder() {
+        val textView by bind<TextView>(R.id.itemHelpText)
+    }
+}

--- a/vector/src/main/java/im/vector/riotx/core/resources/UserPreferencesProvider.kt
+++ b/vector/src/main/java/im/vector/riotx/core/resources/UserPreferencesProvider.kt
@@ -28,4 +28,12 @@ class UserPreferencesProvider @Inject constructor(private val vectorPreferences:
     fun shouldShowReadReceipts(): Boolean {
         return vectorPreferences.showReadReceipts()
     }
+
+    fun shouldShowLongClickOnRoomHelp(): Boolean {
+        return vectorPreferences.shouldShowLongClickOnRoomHelp()
+    }
+
+    fun neverShowLongClickOnRoomHelpAgain() {
+        vectorPreferences.neverShowLongClickOnRoomHelpAgain()
+    }
 }

--- a/vector/src/main/java/im/vector/riotx/features/home/room/list/RoomListFragment.kt
+++ b/vector/src/main/java/im/vector/riotx/features/home/room/list/RoomListFragment.kt
@@ -38,8 +38,8 @@ import im.vector.riotx.core.error.ErrorFormatter
 import im.vector.riotx.core.platform.OnBackPressed
 import im.vector.riotx.core.platform.StateView
 import im.vector.riotx.core.platform.VectorBaseFragment
-import im.vector.riotx.features.home.room.list.actions.RoomListQuickActionsSharedAction
 import im.vector.riotx.features.home.room.list.actions.RoomListQuickActionsBottomSheet
+import im.vector.riotx.features.home.room.list.actions.RoomListQuickActionsSharedAction
 import im.vector.riotx.features.home.room.list.actions.RoomListQuickActionsSharedActionViewModel
 import im.vector.riotx.features.home.room.list.widget.FabMenuView
 import im.vector.riotx.features.notifications.NotificationDrawerManager
@@ -345,6 +345,8 @@ class RoomListFragment @Inject constructor(
     }
 
     override fun onRoomLongClicked(room: RoomSummary): Boolean {
+        roomController.onRoomLongClicked()
+
         RoomListQuickActionsBottomSheet
                 .newInstance(room.roomId)
                 .show(requireActivity().supportFragmentManager, "ROOM_LIST_QUICK_ACTIONS")

--- a/vector/src/main/java/im/vector/riotx/features/home/room/list/RoomSummaryController.kt
+++ b/vector/src/main/java/im/vector/riotx/features/home/room/list/RoomSummaryController.kt
@@ -21,15 +21,18 @@ import com.airbnb.epoxy.EpoxyController
 import im.vector.matrix.android.api.session.room.model.Membership
 import im.vector.matrix.android.api.session.room.model.RoomSummary
 import im.vector.riotx.R
+import im.vector.riotx.core.epoxy.helpFooterItem
 import im.vector.riotx.core.epoxy.noResultItem
 import im.vector.riotx.core.resources.StringProvider
+import im.vector.riotx.core.resources.UserPreferencesProvider
 import im.vector.riotx.features.home.room.filtered.FilteredRoomFooterItem
 import im.vector.riotx.features.home.room.filtered.filteredRoomFooterItem
 import javax.inject.Inject
 
 class RoomSummaryController @Inject constructor(private val stringProvider: StringProvider,
                                                 private val roomSummaryItemFactory: RoomSummaryItemFactory,
-                                                private val roomListNameFilter: RoomListNameFilter
+                                                private val roomListNameFilter: RoomListNameFilter,
+                                                private val userPreferencesProvider: UserPreferencesProvider
 ) : EpoxyController() {
 
     var listener: Listener? = null
@@ -47,6 +50,11 @@ class RoomSummaryController @Inject constructor(private val stringProvider: Stri
         requestModelBuild()
     }
 
+    fun onRoomLongClicked() {
+        userPreferencesProvider.neverShowLongClickOnRoomHelpAgain()
+        requestModelBuild()
+    }
+
     override fun buildModels() {
         val nonNullViewState = viewState ?: return
         when (nonNullViewState.displayMode) {
@@ -55,6 +63,7 @@ class RoomSummaryController @Inject constructor(private val stringProvider: Stri
                 buildFilteredRooms(nonNullViewState)
             }
             else                               -> {
+                var showHelp = false
                 val roomSummaries = nonNullViewState.asyncFilteredRooms()
                 roomSummaries?.forEach { (category, summaries) ->
                     if (summaries.isEmpty()) {
@@ -70,8 +79,13 @@ class RoomSummaryController @Inject constructor(private val stringProvider: Stri
                                     nonNullViewState.joiningErrorRoomsIds,
                                     nonNullViewState.rejectingRoomsIds,
                                     nonNullViewState.rejectingErrorRoomsIds)
+                            showHelp = userPreferencesProvider.shouldShowLongClickOnRoomHelp()
                         }
                     }
+                }
+
+                if (showHelp) {
+                    buildLongClickHelp()
                 }
             }
         }
@@ -94,6 +108,13 @@ class RoomSummaryController @Inject constructor(private val stringProvider: Stri
         when {
             viewState.displayMode == RoomListFragment.DisplayMode.FILTERED -> addFilterFooter(viewState)
             filteredSummaries.isEmpty()                                    -> addEmptyFooter()
+        }
+    }
+
+    private fun buildLongClickHelp() {
+        helpFooterItem {
+            id("long_click_help")
+            text(stringProvider.getString(R.string.help_long_click_on_room_for_more_options))
         }
     }
 

--- a/vector/src/main/java/im/vector/riotx/features/settings/VectorPreferences.kt
+++ b/vector/src/main/java/im/vector/riotx/features/settings/VectorPreferences.kt
@@ -96,6 +96,9 @@ class VectorPreferences @Inject constructor(private val context: Context) {
         private const val SETTINGS_VIBRATE_ON_MENTION_KEY = "SETTINGS_VIBRATE_ON_MENTION_KEY"
         private const val SETTINGS_SEND_MESSAGE_WITH_ENTER = "SETTINGS_SEND_MESSAGE_WITH_ENTER"
 
+        // Help
+        private const val SETTINGS_SHOULD_SHOW_HELP_ON_ROOM_LIST_KEY = "SETTINGS_SHOULD_SHOW_HELP_ON_ROOM_LIST_KEY"
+
         // home
         private const val SETTINGS_PIN_UNREAD_MESSAGES_PREFERENCE_KEY = "SETTINGS_PIN_UNREAD_MESSAGES_PREFERENCE_KEY"
         private const val SETTINGS_PIN_MISSED_NOTIFICATIONS_PREFERENCE_KEY = "SETTINGS_PIN_MISSED_NOTIFICATIONS_PREFERENCE_KEY"
@@ -595,6 +598,24 @@ class VectorPreferences @Inject constructor(private val context: Context) {
      */
     fun showReadReceipts(): Boolean {
         return defaultPrefs.getBoolean(SETTINGS_SHOW_READ_RECEIPTS_KEY, true)
+    }
+
+    /**
+     * Tells if the help on room list should be shown
+     *
+     * @return true if the help on room list should be shown
+     */
+    fun shouldShowLongClickOnRoomHelp(): Boolean {
+        return defaultPrefs.getBoolean(SETTINGS_SHOULD_SHOW_HELP_ON_ROOM_LIST_KEY, true)
+    }
+
+    /**
+     * Prevent help on room list to be shown again
+     */
+    fun neverShowLongClickOnRoomHelpAgain() {
+        defaultPrefs.edit {
+            putBoolean(SETTINGS_SHOULD_SHOW_HELP_ON_ROOM_LIST_KEY, false)
+        }
     }
 
     /**

--- a/vector/src/main/res/drawable/ic_idea.xml
+++ b/vector/src/main/res/drawable/ic_idea.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#000"
+        android:pathData="M20,11H23V13H20V11M1,11H4V13H1V11M13,1V4H11V1H13M4.92,3.5L7.05,5.64L5.63,7.05L3.5,4.93L4.92,3.5M16.95,5.63L19.07,3.5L20.5,4.93L18.37,7.05L16.95,5.63M12,6A6,6 0 0,1 18,12C18,14.22 16.79,16.16 15,17.2V19A1,1 0 0,1 14,20H10A1,1 0 0,1 9,19V17.2C7.21,16.16 6,14.22 6,12A6,6 0 0,1 12,6M14,21V22A1,1 0 0,1 13,23H11A1,1 0 0,1 10,22V21H14M11,18H13V15.87C14.73,15.43 16,13.86 16,12A4,4 0 0,0 12,8A4,4 0 0,0 8,12C8,13.86 9.27,15.43 11,15.87V18Z" />
+</vector>

--- a/vector/src/main/res/layout/item_help_footer.xml
+++ b/vector/src/main/res/layout/item_help_footer.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <TextView
+        android:id="@+id/itemHelpText"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:drawableStart="@drawable/ic_idea"
+        android:drawablePadding="8dp"
+        android:drawableTint="?attr/riotx_text_secondary"
+        android:gravity="center"
+        android:maxWidth="240dp"
+        android:textColor="?attr/riotx_text_secondary"
+        android:textSize="18sp"
+        tools:text="@string/help_long_click_on_room_for_more_options" />
+
+</LinearLayout>

--- a/vector/src/main/res/layout/item_help_footer.xml
+++ b/vector/src/main/res/layout/item_help_footer.xml
@@ -1,23 +1,37 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
     android:padding="16dp">
 
+    <ImageView
+        android:id="@+id/itemHelpPicto"
+        android:layout_width="32dp"
+        android:layout_height="32dp"
+        android:src="@drawable/ic_idea"
+        android:tint="?attr/riotx_text_secondary"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/itemHelpText"
+        app:layout_constraintHorizontal_chainStyle="packed"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
     <TextView
         android:id="@+id/itemHelpText"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_gravity="center_horizontal"
-        android:drawableStart="@drawable/ic_idea"
-        android:drawablePadding="8dp"
-        android:drawableTint="?attr/riotx_text_secondary"
-        android:gravity="center"
+        android:layout_marginStart="12dp"
+        android:gravity="start"
         android:maxWidth="240dp"
         android:textColor="?attr/riotx_text_secondary"
         android:textSize="18sp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/itemHelpPicto"
+        app:layout_constraintTop_toTopOf="parent"
         tools:text="@string/help_long_click_on_room_for_more_options" />
 
-</LinearLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/vector/src/main/res/values/strings_riotX.xml
+++ b/vector/src/main/res/values/strings_riotX.xml
@@ -12,4 +12,6 @@
 
     <string name="no_ignored_users">You are not ignoring any users</string>
 
+    <string name="help_long_click_on_room_for_more_options">Long click on a room to see more options</string>
+
 </resources>


### PR DESCRIPTION
Display a small help, at the bottom of the list.

<img width="451" alt="image" src="https://user-images.githubusercontent.com/3940906/68665560-8c6aa080-0542-11ea-9f38-9747e4321eab.png">

The help is not displayed anymore once the user has perform a long click on a room
