### PR TITLE
Email domain can be limited on some homeserver, i18n of the displayed error (#754)

### DIFF
--- a/.idea/dictionaries/bmarty.xml
+++ b/.idea/dictionaries/bmarty.xml
@@ -20,6 +20,7 @@
       <w>signin</w>
       <w>signout</w>
       <w>signup</w>
+      <w>threepid</w>
     </words>
   </dictionary>
 </component>

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@ Improvements 🙌:
 Other changes:
  - Change the way RiotX identifies a session to allow the SDK to support several sessions with the same user (#800)
  - Exclude play-services-oss-licenses library from F-Droid build (#814)
+ - Email domain can be limited on some homeserver, i18n of the displayed error (#754)
 
 Bugfix 🐛:
  - Fix crash when opening room creation screen from the room filtering screen

--- a/vector/src/main/java/im/vector/riotx/core/error/ErrorFormatter.kt
+++ b/vector/src/main/java/im/vector/riotx/core/error/ErrorFormatter.kt
@@ -67,6 +67,9 @@ class DefaultErrorFormatter @Inject constructor(
                     throwable.error.code == MatrixError.M_NOT_JSON           -> {
                         stringProvider.getString(R.string.login_error_not_json)
                     }
+                    throwable.error.code == MatrixError.M_THREEPID_DENIED           -> {
+                        stringProvider.getString(R.string.login_error_threepid_denied)
+                    }
                     throwable.error.code == MatrixError.M_LIMIT_EXCEEDED     -> {
                         limitExceededError(throwable.error)
                     }

--- a/vector/src/main/res/values/strings_riotX.xml
+++ b/vector/src/main/res/values/strings_riotX.xml
@@ -23,4 +23,6 @@
     <string name="settings_developer_mode_fail_fast_title">Fail-fast</string>
     <string name="settings_developer_mode_fail_fast_summary">RiotX may crash more often when an unexpected error occurs</string>
 
+    <string name="login_error_threepid_denied">Your email domain is not authorized to register on this server</string>
+
 </resources>


### PR DESCRIPTION
Fixes #754 
Authorize email domain list cannot be retrieved from config.json file


