### PR TITLE
File decryption path was writing incorrect stream to file 

### DIFF
--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/DefaultFileService.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/DefaultFileService.kt
@@ -74,7 +74,7 @@ internal class DefaultFileService @Inject constructor(private val context: Conte
                                     .build()
 
                             val response = okHttpClient.newCall(request).execute()
-                            val inputStream = response.body?.byteStream()
+                            var inputStream = response.body?.byteStream()
                             Timber.v("Response size ${response.body?.contentLength()} - Stream available: ${inputStream?.available()}")
                             if (!response.isSuccessful
                                     || inputStream == null) {
@@ -83,7 +83,7 @@ internal class DefaultFileService @Inject constructor(private val context: Conte
 
                             if (elementToDecrypt != null) {
                                 Timber.v("## decrypt file")
-                                MXEncryptedAttachments.decryptAttachment(inputStream, elementToDecrypt)
+                                inputStream = MXEncryptedAttachments.decryptAttachment(inputStream, elementToDecrypt)
                                         ?: throw IllegalStateException("Decryption error")
                             }
 


### PR DESCRIPTION
NOTE: this hasn't really gone through any testing.
It's a possible solution. @bmarty please take a look.

DefaultFileService - code was passing the inputStream to the decryption method

but not storing the output of the method anywhere
then it was writing inputStream to file and returning that file handle
changed inputStream to var and used it to store output of decryption method

Signed-off-by: David Hyman dghyman@gmail.com

### Pull Request Checklist

<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/riotX-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->

- [x] Changes has been tested on an Android device or Android emulator with API 16
- [ ] UI change has been tested on both light and dark themes
- [x] Pull request is based on the develop branch
- [ ] Pull request updates [CHANGES.md](https://github.com/vector-im/riotX-android/blob/develop/CHANGES.md)
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#sign-off)
