### PR TITLE
Fix crash in the room directory, when public room has no name (#1023)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ Improvements 🙌:
 
 Bugfix 🐛:
  - Account creation: wrongly hints that an email can be used to create an account (#941)
+ - Fix crash in the room directory, when public room has no name (#1023)
 
 Translations 🗣:
  -

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/model/roomdirectory/PublicRoomsResponse.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/model/roomdirectory/PublicRoomsResponse.kt
@@ -27,24 +27,24 @@ data class PublicRoomsResponse(
          * A pagination token for the response. The absence of this token means there are no more results to fetch and the client should stop paginating.
          */
         @Json(name = "next_batch")
-        var nextBatch: String? = null,
+        val nextBatch: String? = null,
 
         /**
          * A pagination token that allows fetching previous results. The absence of this token means there are no results before this batch,
          * i.e. this is the first batch.
          */
         @Json(name = "prev_batch")
-        var prevBatch: String? = null,
+        val prevBatch: String? = null,
 
         /**
          * A paginated chunk of public rooms.
          */
         @Json(name = "chunk")
-        var chunk: List<PublicRoom>? = null,
+        val chunk: List<PublicRoom>? = null,
 
         /**
          * An estimate on the total number of public rooms, if the server has an estimate.
          */
         @Json(name = "total_room_count_estimate")
-        var totalRoomCountEstimate: Int? = null
+        val totalRoomCountEstimate: Int? = null
 )

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/util/MatrixItem.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/util/MatrixItem.kt
@@ -22,7 +22,7 @@ import im.vector.matrix.android.api.session.room.model.RoomMemberSummary
 import im.vector.matrix.android.api.session.room.model.RoomSummary
 import im.vector.matrix.android.api.session.room.model.roomdirectory.PublicRoom
 import im.vector.matrix.android.api.session.user.model.User
-import java.util.*
+import java.util.Locale
 
 sealed class MatrixItem(
         open val id: String,
@@ -143,8 +143,14 @@ sealed class MatrixItem(
  * ========================================================================================== */
 
 fun User.toMatrixItem() = MatrixItem.UserItem(userId, displayName, avatarUrl)
+
 fun GroupSummary.toMatrixItem() = MatrixItem.GroupItem(groupId, displayName, avatarUrl)
+
 fun RoomSummary.toMatrixItem() = MatrixItem.RoomItem(roomId, displayName, avatarUrl)
+
 fun RoomSummary.toRoomAliasMatrixItem() = MatrixItem.RoomAliasItem(canonicalAlias ?: roomId, displayName, avatarUrl)
-fun PublicRoom.toMatrixItem() = MatrixItem.RoomItem(roomId, name, avatarUrl)
+
+// If no name is available, use room alias as Riot-Web does
+fun PublicRoom.toMatrixItem() = MatrixItem.RoomItem(roomId, name ?: canonicalAlias, avatarUrl)
+
 fun RoomMemberSummary.toMatrixItem() = MatrixItem.UserItem(userId, displayName, avatarUrl)

--- a/vector/src/main/java/im/vector/riotx/core/platform/EllipsizingTextView.kt
+++ b/vector/src/main/java/im/vector/riotx/core/platform/EllipsizingTextView.kt
@@ -116,7 +116,7 @@ class EllipsizingTextView @JvmOverloads constructor(context: Context, attrs: Att
         super.setLineSpacing(add, mult)
     }
 
-    override fun setText(text: CharSequence, type: BufferType) {
+    override fun setText(text: CharSequence?, type: BufferType) {
         if (!programmaticChange) {
             fullText = if (text is Spanned) text else text
             isStale = true


### PR DESCRIPTION
Fixes #1023 

Also use room alias when room name is not available, ex:

<img width="417" alt="image" src="https://user-images.githubusercontent.com/3940906/74724068-f7133280-523b-11ea-8fe7-4490f05222dd.png">
