### PR TITLE
Fix join room over federation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ Bugfix 🐛:
  - Fix crash in the room directory, when public room has no name (#1023)
  - Fix restoring keys backup with passphrase (#526)
  - Fix joining rooms from directory via federation isn't working. (#808)
+ - Leaving a room creates a stuck "leaving room" loading screen. (#1041)
 
 Translations 🗣:
  -

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ Bugfix 🐛:
  - Account creation: wrongly hints that an email can be used to create an account (#941)
  - Fix crash in the room directory, when public room has no name (#1023)
  - Fix restoring keys backup with passphrase (#526)
+ - Fix joining rooms from directory via federation isn't working. (#808)
 
 Translations 🗣:
  -

--- a/matrix-sdk-android-rx/src/main/java/im/vector/matrix/rx/RxSession.kt
+++ b/matrix-sdk-android-rx/src/main/java/im/vector/matrix/rx/RxSession.kt
@@ -95,10 +95,10 @@ class RxSession(private val session: Session) {
         session.searchUsersDirectory(search, limit, excludedUserIds, it)
     }
 
-    fun joinRoom(roomId: String,
+    fun joinRoom(roomIdOrAlias: String,
                  reason: String? = null,
                  viaServers: List<String> = emptyList()): Single<Unit> = singleBuilder {
-        session.joinRoom(roomId, reason, viaServers, it)
+        session.joinRoom(roomIdOrAlias, reason, viaServers, it)
     }
 
     fun getRoomIdByAlias(roomAlias: String,

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/MatrixPatterns.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/MatrixPatterns.kt
@@ -122,9 +122,9 @@ object MatrixPatterns {
      */
     fun isEventId(str: String?): Boolean {
         return str != null
-               && (str matches PATTERN_CONTAIN_MATRIX_EVENT_IDENTIFIER
-                   || str matches PATTERN_CONTAIN_MATRIX_EVENT_IDENTIFIER_V3
-                   || str matches PATTERN_CONTAIN_MATRIX_EVENT_IDENTIFIER_V4)
+                && (str matches PATTERN_CONTAIN_MATRIX_EVENT_IDENTIFIER
+                || str matches PATTERN_CONTAIN_MATRIX_EVENT_IDENTIFIER_V3
+                || str matches PATTERN_CONTAIN_MATRIX_EVENT_IDENTIFIER_V4)
     }
 
     /**
@@ -144,14 +144,6 @@ object MatrixPatterns {
      * @return null if not found or if matrixId is null
      */
     fun extractServerNameFromId(matrixId: String?): String? {
-        if (matrixId == null) {
-            return null
-        }
-
-        val index = matrixId.indexOf(":")
-
-        return if (index == -1) {
-            null
-        } else matrixId.substring(index + 1)
+        return matrixId?.substringAfter(":", missingDelimiterValue = "")?.takeIf { it.isNotEmpty() }
     }
 }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/RoomDirectoryService.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/RoomDirectoryService.kt
@@ -35,9 +35,9 @@ interface RoomDirectoryService {
                        callback: MatrixCallback<PublicRoomsResponse>): Cancelable
 
     /**
-     * Join a room by id
+     * Join a room by id, or room alias
      */
-    fun joinRoom(roomId: String,
+    fun joinRoom(roomIdOrAlias: String,
                  reason: String? = null,
                  callback: MatrixCallback<Unit>): Cancelable
 

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/RoomService.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/RoomService.kt
@@ -36,11 +36,11 @@ interface RoomService {
 
     /**
      * Join a room by id
-     * @param roomId the roomId of the room to join
+     * @param roomIdOrAlias the roomId or the room alias of the room to join
      * @param reason optional reason for joining the room
      * @param viaServers the servers to attempt to join the room through. One of the servers must be participating in the room.
      */
-    fun joinRoom(roomId: String,
+    fun joinRoom(roomIdOrAlias: String,
                  reason: String? = null,
                  viaServers: List<String> = emptyList(),
                  callback: MatrixCallback<Unit>): Cancelable

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/model/create/CreateRoomResponse.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/model/create/CreateRoomResponse.kt
@@ -21,5 +21,10 @@ import com.squareup.moshi.JsonClass
 
 @JsonClass(generateAdapter = true)
 internal data class CreateRoomResponse(
-        @Json(name = "room_id") var roomId: String? = null
+        /**
+         * Required. The created room's ID.
+         */
+        @Json(name = "room_id") var roomId: String
 )
+
+internal typealias JoinRoomResponse = CreateRoomResponse

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/model/roomdirectory/PublicRoom.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/model/roomdirectory/PublicRoom.kt
@@ -85,7 +85,7 @@ data class PublicRoom(
         val isFederated: Boolean = false
 ) {
     /**
-     * Return the canonical alias, or the first alias from the list of alias, or null
+     * Return the canonical alias, or the first alias from the list of aliases, or null
      */
     fun getPrimaryAlias(): String? {
         return canonicalAlias ?: aliases?.firstOrNull()

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/model/roomdirectory/PublicRoom.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/model/roomdirectory/PublicRoom.kt
@@ -23,66 +23,71 @@ import com.squareup.moshi.JsonClass
  */
 @JsonClass(generateAdapter = true)
 data class PublicRoom(
-
         /**
          * Aliases of the room. May be empty.
          */
         @Json(name = "aliases")
-        var aliases: List<String>? = null,
+        val aliases: List<String>? = null,
 
         /**
          * The canonical alias of the room, if any.
          */
         @Json(name = "canonical_alias")
-        var canonicalAlias: String? = null,
+        val canonicalAlias: String? = null,
 
         /**
          * The name of the room, if any.
          */
         @Json(name = "name")
-        var name: String? = null,
+        val name: String? = null,
 
         /**
          * Required. The number of members joined to the room.
          */
         @Json(name = "num_joined_members")
-        var numJoinedMembers: Int = 0,
+        val numJoinedMembers: Int = 0,
 
         /**
          * Required. The ID of the room.
          */
         @Json(name = "room_id")
-        var roomId: String,
+        val roomId: String,
 
         /**
          * The topic of the room, if any.
          */
         @Json(name = "topic")
-        var topic: String? = null,
+        val topic: String? = null,
 
         /**
          * Required. Whether the room may be viewed by guest users without joining.
          */
         @Json(name = "world_readable")
-        var worldReadable: Boolean = false,
+        val worldReadable: Boolean = false,
 
         /**
          * Required. Whether guest users may join the room and participate in it. If they can,
          * they will be subject to ordinary power level rules like any other user.
          */
         @Json(name = "guest_can_join")
-        var guestCanJoin: Boolean = false,
+        val guestCanJoin: Boolean = false,
 
         /**
          * The URL for the room's avatar, if one is set.
          */
         @Json(name = "avatar_url")
-        var avatarUrl: String? = null,
+        val avatarUrl: String? = null,
 
         /**
          * Undocumented item
          */
         @Json(name = "m.federate")
-        var isFederated: Boolean = false
-
-)
+        val isFederated: Boolean = false
+) {
+    /**
+     * Return the canonical alias, or the first alias from the list of alias, or null
+     */
+    fun getPrimaryAlias(): String? {
+        return canonicalAlias ?: aliases?.firstOrNull()
+    }
+}

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/model/tombstone/RoomTombstoneContent.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/model/tombstone/RoomTombstoneContent.kt
@@ -23,6 +23,13 @@ import com.squareup.moshi.JsonClass
  */
 @JsonClass(generateAdapter = true)
 data class RoomTombstoneContent(
+        /**
+         * Required. A server-defined message.
+         */
         @Json(name = "body") val body: String? = null,
-        @Json(name = "replacement_room") val replacementRoom: String?
+
+        /**
+         * Required. The new room the client should be visiting.
+         */
+        @Json(name = "replacement_room") val replacementRoomId: String?
 )

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/util/MatrixItem.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/util/MatrixItem.kt
@@ -151,6 +151,6 @@ fun RoomSummary.toMatrixItem() = MatrixItem.RoomItem(roomId, displayName, avatar
 fun RoomSummary.toRoomAliasMatrixItem() = MatrixItem.RoomAliasItem(canonicalAlias ?: roomId, displayName, avatarUrl)
 
 // If no name is available, use room alias as Riot-Web does
-fun PublicRoom.toMatrixItem() = MatrixItem.RoomItem(roomId, name ?: canonicalAlias, avatarUrl)
+fun PublicRoom.toMatrixItem() = MatrixItem.RoomItem(roomId, name ?: getPrimaryAlias() ?: "", avatarUrl)
 
 fun RoomMemberSummary.toMatrixItem() = MatrixItem.UserItem(userId, displayName, avatarUrl)

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/DefaultRoomDirectoryService.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/DefaultRoomDirectoryService.kt
@@ -44,9 +44,9 @@ internal class DefaultRoomDirectoryService @Inject constructor(private val getPu
                 .executeBy(taskExecutor)
     }
 
-    override fun joinRoom(roomId: String, reason: String?, callback: MatrixCallback<Unit>): Cancelable {
+    override fun joinRoom(roomIdOrAlias: String, reason: String?, callback: MatrixCallback<Unit>): Cancelable {
         return joinRoomTask
-                .configureWith(JoinRoomTask.Params(roomId, reason)) {
+                .configureWith(JoinRoomTask.Params(roomIdOrAlias, reason)) {
                     this.callback = callback
                 }
                 .executeBy(taskExecutor)

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/DefaultRoomService.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/DefaultRoomService.kt
@@ -139,9 +139,9 @@ internal class DefaultRoomService @Inject constructor(
                 .executeBy(taskExecutor)
     }
 
-    override fun joinRoom(roomId: String, reason: String?, viaServers: List<String>, callback: MatrixCallback<Unit>): Cancelable {
+    override fun joinRoom(roomIdOrAlias: String, reason: String?, viaServers: List<String>, callback: MatrixCallback<Unit>): Cancelable {
         return joinRoomTask
-                .configureWith(JoinRoomTask.Params(roomId, reason, viaServers)) {
+                .configureWith(JoinRoomTask.Params(roomIdOrAlias, reason, viaServers)) {
                     this.callback = callback
                 }
                 .executeBy(taskExecutor)

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/RoomAPI.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/RoomAPI.kt
@@ -20,6 +20,7 @@ import im.vector.matrix.android.api.session.events.model.Content
 import im.vector.matrix.android.api.session.events.model.Event
 import im.vector.matrix.android.api.session.room.model.create.CreateRoomParams
 import im.vector.matrix.android.api.session.room.model.create.CreateRoomResponse
+import im.vector.matrix.android.api.session.room.model.create.JoinRoomResponse
 import im.vector.matrix.android.api.session.room.model.roomdirectory.PublicRoomsParams
 import im.vector.matrix.android.api.session.room.model.roomdirectory.PublicRoomsResponse
 import im.vector.matrix.android.api.session.room.model.thirdparty.ThirdPartyProtocol
@@ -223,13 +224,13 @@ internal interface RoomAPI {
      * Join the given room.
      *
      * @param roomIdOrAlias the room id or alias
-     * @param server_name the servers to attempt to join the room through
+     * @param viaServers the servers to attempt to join the room through
      * @param params the request body
      */
     @POST(NetworkConstants.URI_API_PREFIX_PATH_R0 + "join/{roomIdOrAlias}")
     fun join(@Path("roomIdOrAlias") roomIdOrAlias: String,
              @Query("server_name") viaServers: List<String>,
-             @Body params: Map<String, String?>): Call<Unit>
+             @Body params: Map<String, String?>): Call<JoinRoomResponse>
 
     /**
      * Leave the given room.

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/create/CreateRoomTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/create/CreateRoomTask.kt
@@ -66,7 +66,7 @@ internal class DefaultCreateRoomTask @Inject constructor(
         val createRoomResponse = executeRequest<CreateRoomResponse>(eventBus) {
             apiCall = roomAPI.createRoom(createRoomParams)
         }
-        val roomId = createRoomResponse.roomId!!
+        val roomId = createRoomResponse.roomId
         // Wait for room to come back from the sync (but it can maybe be in the DB if the sync response is received before)
         try {
             awaitNotEmptyResult(realmConfiguration, TimeUnit.MINUTES.toMillis(1L)) { realm ->

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/tombstone/RoomTombstoneEventLiveObserver.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/tombstone/RoomTombstoneEventLiveObserver.kt
@@ -62,7 +62,7 @@ internal class RoomTombstoneEventLiveObserver @Inject constructor(@SessionDataba
         for (event in tombstoneEvents) {
             if (event.roomId == null) continue
             val createRoomContent = event.getClearContent().toModel<RoomTombstoneContent>()
-            if (createRoomContent?.replacementRoom == null) continue
+            if (createRoomContent?.replacementRoomId == null) continue
 
             val predecessorRoomSummary = RoomSummaryEntity.where(realm, event.roomId).findFirst()
                                          ?: RoomSummaryEntity(event.roomId)

--- a/vector/src/main/java/im/vector/riotx/core/platform/EllipsizingTextView.kt
+++ b/vector/src/main/java/im/vector/riotx/core/platform/EllipsizingTextView.kt
@@ -242,7 +242,7 @@ class EllipsizingTextView @JvmOverloads constructor(context: Context, attrs: Att
         @Suppress("DEPRECATION")
         protected fun createWorkingLayout(workingText: CharSequence?): Layout {
             return StaticLayout(
-                    workingText,
+                    workingText ?: "",
                     paint,
                     width - compoundPaddingLeft - compoundPaddingRight,
                     Layout.Alignment.ALIGN_NORMAL,

--- a/vector/src/main/java/im/vector/riotx/features/home/room/detail/RoomDetailViewModel.kt
+++ b/vector/src/main/java/im/vector/riotx/features/home/room/detail/RoomDetailViewModel.kt
@@ -292,7 +292,7 @@ class RoomDetailViewModel @AssistedInject constructor(@Assisted initialState: Ro
     private fun handleTombstoneEvent(action: RoomDetailAction.HandleTombstoneEvent) {
         val tombstoneContent = action.event.getClearContent().toModel<RoomTombstoneContent>() ?: return
 
-        val roomId = tombstoneContent.replacementRoom ?: ""
+        val roomId = tombstoneContent.replacementRoomId ?: ""
         val isRoomJoined = session.getRoom(roomId)?.roomSummary()?.membership == Membership.JOIN
         if (isRoomJoined) {
             setState { copy(tombstoneEventHandling = Success(roomId)) }

--- a/vector/src/main/java/im/vector/riotx/features/home/room/detail/RoomDetailViewModel.kt
+++ b/vector/src/main/java/im/vector/riotx/features/home/room/detail/RoomDetailViewModel.kt
@@ -297,15 +297,11 @@ class RoomDetailViewModel @AssistedInject constructor(@Assisted initialState: Ro
         if (isRoomJoined) {
             setState { copy(tombstoneEventHandling = Success(roomId)) }
         } else {
-            val viaServer = MatrixPatterns.extractServerNameFromId(action.event.senderId).let {
-                if (it.isNullOrBlank()) {
-                    emptyList()
-                } else {
-                    listOf(it)
-                }
-            }
+            val viaServers = MatrixPatterns.extractServerNameFromId(action.event.senderId)
+                    ?.let { listOf(it) }
+                    .orEmpty()
             session.rx()
-                    .joinRoom(roomId, viaServers = viaServer)
+                    .joinRoom(roomId, viaServers = viaServers)
                     .map { roomId }
                     .execute {
                         copy(tombstoneEventHandling = it)

--- a/vector/src/main/java/im/vector/riotx/features/home/room/list/RoomListFragment.kt
+++ b/vector/src/main/java/im/vector/riotx/features/home/room/list/RoomListFragment.kt
@@ -105,6 +105,7 @@ class RoomListFragment @Inject constructor(
                 is RoomListViewEvents.Loading    -> showLoading(it.message)
                 is RoomListViewEvents.Failure    -> showFailure(it.throwable)
                 is RoomListViewEvents.SelectRoom -> handleSelectRoom(it)
+                is RoomListViewEvents.Done       -> Unit
             }.exhaustive
         }
 

--- a/vector/src/main/java/im/vector/riotx/features/home/room/list/RoomListViewEvents.kt
+++ b/vector/src/main/java/im/vector/riotx/features/home/room/list/RoomListViewEvents.kt
@@ -28,4 +28,5 @@ sealed class RoomListViewEvents : VectorViewEvents {
     data class Failure(val throwable: Throwable) : RoomListViewEvents()
 
     data class SelectRoom(val roomSummary: RoomSummary) : RoomListViewEvents()
+    object Done : RoomListViewEvents()
 }

--- a/vector/src/main/java/im/vector/riotx/features/home/room/list/RoomListViewModel.kt
+++ b/vector/src/main/java/im/vector/riotx/features/home/room/list/RoomListViewModel.kt
@@ -197,6 +197,10 @@ class RoomListViewModel @Inject constructor(initialState: RoomListViewState,
     private fun handleLeaveRoom(action: RoomListAction.LeaveRoom) {
         _viewEvents.post(RoomListViewEvents.Loading(null))
         session.getRoom(action.roomId)?.leave(null, object : MatrixCallback<Unit> {
+            override fun onSuccess(data: Unit) {
+                _viewEvents.post(RoomListViewEvents.Done)
+            }
+
             override fun onFailure(failure: Throwable) {
                 _viewEvents.post(RoomListViewEvents.Failure(failure))
             }

--- a/vector/src/main/java/im/vector/riotx/features/roomdirectory/PublicRoomsController.kt
+++ b/vector/src/main/java/im/vector/riotx/features/roomdirectory/PublicRoomsController.kt
@@ -85,7 +85,7 @@ class PublicRoomsController @Inject constructor(private val stringProvider: Stri
             avatarRenderer(avatarRenderer)
             id(publicRoom.roomId)
             matrixItem(publicRoom.toMatrixItem())
-            roomAlias(publicRoom.canonicalAlias)
+            roomAlias(publicRoom.getPrimaryAlias())
             roomTopic(publicRoom.topic)
             nbOfMembers(publicRoom.numJoinedMembers)
 

--- a/vector/src/main/java/im/vector/riotx/features/roomdirectory/PublicRoomsFragment.kt
+++ b/vector/src/main/java/im/vector/riotx/features/roomdirectory/PublicRoomsFragment.kt
@@ -134,7 +134,7 @@ class PublicRoomsFragment @Inject constructor(
 
     override fun onPublicRoomJoin(publicRoom: PublicRoom) {
         Timber.v("PublicRoomJoinClicked: $publicRoom")
-        viewModel.handle(RoomDirectoryAction.JoinRoom(publicRoom.roomId))
+        viewModel.handle(RoomDirectoryAction.JoinRoom(publicRoom.getPrimaryAlias(), publicRoom.roomId))
     }
 
     override fun loadMore() {

--- a/vector/src/main/java/im/vector/riotx/features/roomdirectory/RoomDirectoryAction.kt
+++ b/vector/src/main/java/im/vector/riotx/features/roomdirectory/RoomDirectoryAction.kt
@@ -23,5 +23,5 @@ sealed class RoomDirectoryAction : VectorViewModelAction {
     data class SetRoomDirectoryData(val roomDirectoryData: RoomDirectoryData) : RoomDirectoryAction()
     data class FilterWith(val filter: String) : RoomDirectoryAction()
     object LoadMore : RoomDirectoryAction()
-    data class JoinRoom(val roomId: String) : RoomDirectoryAction()
+    data class JoinRoom(val roomAlias: String?, val roomId: String) : RoomDirectoryAction()
 }

--- a/vector/src/main/java/im/vector/riotx/features/roomdirectory/RoomDirectoryViewModel.kt
+++ b/vector/src/main/java/im/vector/riotx/features/roomdirectory/RoomDirectoryViewModel.kt
@@ -216,7 +216,7 @@ class RoomDirectoryViewModel @AssistedInject constructor(@Assisted initialState:
             )
         }
 
-        session.joinRoom(action.roomId, callback = object : MatrixCallback<Unit> {
+        session.joinRoom(action.roomAlias ?: action.roomId, callback = object : MatrixCallback<Unit> {
             override fun onSuccess(data: Unit) {
                 // We do not update the joiningRoomsIds here, because, the room is not joined yet regarding the sync data.
                 // Instead, we wait for the room to be joined

--- a/vector/src/main/java/im/vector/riotx/features/roomdirectory/roompreview/RoomPreviewAction.kt
+++ b/vector/src/main/java/im/vector/riotx/features/roomdirectory/roompreview/RoomPreviewAction.kt
@@ -19,5 +19,5 @@ package im.vector.riotx.features.roomdirectory.roompreview
 import im.vector.riotx.core.platform.VectorViewModelAction
 
 sealed class RoomPreviewAction : VectorViewModelAction {
-    object Join : RoomPreviewAction()
+    data class Join(val roomAlias: String?) : RoomPreviewAction()
 }

--- a/vector/src/main/java/im/vector/riotx/features/roomdirectory/roompreview/RoomPreviewActivity.kt
+++ b/vector/src/main/java/im/vector/riotx/features/roomdirectory/roompreview/RoomPreviewActivity.kt
@@ -32,12 +32,13 @@ import kotlinx.android.parcel.Parcelize
 data class RoomPreviewData(
         val roomId: String,
         val roomName: String?,
+        val roomAlias: String?,
         val topic: String?,
         val worldReadable: Boolean,
         val avatarUrl: String?
 ) : Parcelable {
     val matrixItem: MatrixItem
-        get() = MatrixItem.RoomItem(roomId, roomName, avatarUrl)
+        get() = MatrixItem.RoomItem(roomId, roomName ?: roomAlias, avatarUrl)
 }
 
 class RoomPreviewActivity : VectorBaseActivity(), ToolbarConfigurable {
@@ -50,6 +51,7 @@ class RoomPreviewActivity : VectorBaseActivity(), ToolbarConfigurable {
                 putExtra(ARG, RoomPreviewData(
                         roomId = publicRoom.roomId,
                         roomName = publicRoom.name,
+                        roomAlias = publicRoom.getPrimaryAlias(),
                         topic = publicRoom.topic,
                         worldReadable = publicRoom.worldReadable,
                         avatarUrl = publicRoom.avatarUrl

--- a/vector/src/main/java/im/vector/riotx/features/roomdirectory/roompreview/RoomPreviewNoPreviewFragment.kt
+++ b/vector/src/main/java/im/vector/riotx/features/roomdirectory/roompreview/RoomPreviewNoPreviewFragment.kt
@@ -65,7 +65,7 @@ class RoomPreviewNoPreviewFragment @Inject constructor(
 
         roomPreviewNoPreviewJoin.callback = object : ButtonStateView.Callback {
             override fun onButtonClicked() {
-                roomPreviewViewModel.handle(RoomPreviewAction.Join)
+                roomPreviewViewModel.handle(RoomPreviewAction.Join(roomPreviewData.roomAlias))
             }
 
             override fun onRetryClicked() {

--- a/vector/src/main/java/im/vector/riotx/features/roomdirectory/roompreview/RoomPreviewNoPreviewFragment.kt
+++ b/vector/src/main/java/im/vector/riotx/features/roomdirectory/roompreview/RoomPreviewNoPreviewFragment.kt
@@ -50,11 +50,11 @@ class RoomPreviewNoPreviewFragment @Inject constructor(
         setupToolbar(roomPreviewNoPreviewToolbar)
         // Toolbar
         avatarRenderer.render(roomPreviewData.matrixItem, roomPreviewNoPreviewToolbarAvatar)
-        roomPreviewNoPreviewToolbarTitle.text = roomPreviewData.roomName
+        roomPreviewNoPreviewToolbarTitle.text = roomPreviewData.roomName ?: roomPreviewData.roomAlias
 
         // Screen
         avatarRenderer.render(roomPreviewData.matrixItem, roomPreviewNoPreviewAvatar)
-        roomPreviewNoPreviewName.text = roomPreviewData.roomName
+        roomPreviewNoPreviewName.text = roomPreviewData.roomName ?: roomPreviewData.roomAlias
         roomPreviewNoPreviewTopic.setTextOrHide(roomPreviewData.topic)
 
         if (roomPreviewData.worldReadable) {

--- a/vector/src/main/java/im/vector/riotx/features/roomdirectory/roompreview/RoomPreviewViewModel.kt
+++ b/vector/src/main/java/im/vector/riotx/features/roomdirectory/roompreview/RoomPreviewViewModel.kt
@@ -26,6 +26,7 @@ import im.vector.matrix.android.api.session.Session
 import im.vector.matrix.android.api.session.room.model.Membership
 import im.vector.matrix.android.api.session.room.roomSummaryQueryParams
 import im.vector.matrix.rx.rx
+import im.vector.riotx.core.extensions.exhaustive
 import im.vector.riotx.core.platform.EmptyViewEvents
 import im.vector.riotx.core.platform.VectorViewModel
 import im.vector.riotx.features.roomdirectory.JoinState
@@ -82,11 +83,11 @@ class RoomPreviewViewModel @AssistedInject constructor(@Assisted initialState: R
 
     override fun handle(action: RoomPreviewAction) {
         when (action) {
-            RoomPreviewAction.Join -> joinRoom()
-        }
+            is RoomPreviewAction.Join -> handleJoinRoom(action)
+        }.exhaustive
     }
 
-    private fun joinRoom() = withState { state ->
+    private fun handleJoinRoom(action: RoomPreviewAction.Join) = withState { state ->
         if (state.roomJoinState == JoinState.JOINING) {
             // Request already sent, should not happen
             Timber.w("Try to join an already joining room. Should not happen")
@@ -100,7 +101,7 @@ class RoomPreviewViewModel @AssistedInject constructor(@Assisted initialState: R
             )
         }
 
-        session.joinRoom(state.roomId, callback = object : MatrixCallback<Unit> {
+        session.joinRoom(action.roomAlias ?: state.roomId, callback = object : MatrixCallback<Unit> {
             override fun onSuccess(data: Unit) {
                 // We do not update the joiningRoomsIds here, because, the room is not joined yet regarding the sync data.
                 // Instead, we wait for the room to be joined


### PR DESCRIPTION
Fixes #808 
Fixes #1041 

the room `#voice:matrix.org` has no name and no canonical alias, so is a good candidate to test robustness of the app.

To test #808, you have to be on another home server. I reproduced the bug using a modular homerver, so I can confirm that the issue is fixed by this PR.

@onurays you should just do a static review of the code
