### PR TITLE
Display internal id of a room section in room profile

### DIFF
--- a/vector/src/main/java/im/vector/riotx/features/roomprofile/RoomProfileController.kt
+++ b/vector/src/main/java/im/vector/riotx/features/roomprofile/RoomProfileController.kt
@@ -25,10 +25,12 @@ import im.vector.riotx.core.epoxy.profiles.buildProfileSection
 import im.vector.riotx.core.resources.ColorProvider
 import im.vector.riotx.core.resources.StringProvider
 import im.vector.riotx.core.ui.list.genericFooterItem
+import im.vector.riotx.features.settings.VectorPreferences
 import javax.inject.Inject
 
 class RoomProfileController @Inject constructor(
         private val stringProvider: StringProvider,
+        private val vectorPreferences: VectorPreferences,
         colorProvider: ColorProvider
 ) : TypedEpoxyController<RoomProfileViewState>() {
 
@@ -43,6 +45,7 @@ class RoomProfileController @Inject constructor(
         fun onUploadsClicked()
         fun onSettingsClicked()
         fun onLeaveRoomClicked()
+        fun onRoomIdClicked()
     }
 
     override fun buildModels(data: RoomProfileViewState?) {
@@ -105,5 +108,19 @@ class RoomProfileController @Inject constructor(
                 editable = false,
                 action = { callback?.onLeaveRoomClicked() }
         )
+
+        // Advanced
+        if (vectorPreferences.developerMode()) {
+            buildProfileSection(stringProvider.getString(R.string.room_settings_category_advanced_title))
+            buildProfileAction(
+                    id = "roomId",
+                    title = stringProvider.getString(R.string.room_settings_room_internal_id),
+                    subtitle = roomSummary.roomId,
+                    dividerColor = dividerColor,
+                    divider = false,
+                    editable = false,
+                    action = { callback?.onRoomIdClicked() }
+            )
+        }
     }
 }

--- a/vector/src/main/java/im/vector/riotx/features/roomprofile/RoomProfileFragment.kt
+++ b/vector/src/main/java/im/vector/riotx/features/roomprofile/RoomProfileFragment.kt
@@ -36,6 +36,7 @@ import im.vector.riotx.core.extensions.configureWith
 import im.vector.riotx.core.extensions.exhaustive
 import im.vector.riotx.core.extensions.setTextOrHide
 import im.vector.riotx.core.platform.VectorBaseFragment
+import im.vector.riotx.core.utils.copyToClipboard
 import im.vector.riotx.core.utils.startSharePlainTextIntent
 import im.vector.riotx.features.crypto.util.toImageRes
 import im.vector.riotx.features.home.AvatarRenderer
@@ -201,6 +202,10 @@ class RoomProfileFragment @Inject constructor(
                 }
                 .setNegativeButton(R.string.cancel, null)
                 .show()
+    }
+
+    override fun onRoomIdClicked() {
+        copyToClipboard(requireContext(), roomProfileArgs.roomId)
     }
 
     private fun onShareRoomProfile(permalink: String) {


### PR DESCRIPTION
Display internal id of a room section in room profile, with copy to clipboard action, only in developer mode

French screenshot:

<img width="460" alt="image" src="https://user-images.githubusercontent.com/3940906/75241862-3951ec00-57c7-11ea-9987-4d4d6b0d22fa.png">
