### PR TITLE
Fix dm chips

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@ Bugfix 🐛:
  - Fix joining rooms from directory via federation isn't working. (#808)
  - Leaving a room creates a stuck "leaving room" loading screen. (#1041)
  - Fix some invitation handling issues (#1013)
+ - New direct chat: selecting a participant sometimes results in two breadcrumbs (#1022)
 
 Translations 🗣:
  -

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/user/model/User.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/user/model/User.kt
@@ -24,4 +24,9 @@ data class User(
         val userId: String,
         val displayName: String? = null,
         val avatarUrl: String? = null
-)
+) {
+    /**
+     * Return the display name or the user id
+     */
+    fun getBestName() = displayName?.takeIf { it.isNotEmpty() } ?: userId
+}

--- a/vector/src/main/java/im/vector/riotx/features/createdirect/CreateDirectRoomKnownUsersFragment.kt
+++ b/vector/src/main/java/im/vector/riotx/features/createdirect/CreateDirectRoomKnownUsersFragment.kt
@@ -142,7 +142,7 @@ class CreateDirectRoomKnownUsersFragment @Inject constructor(
         if (data.isAdded) {
             addChipToGroup(data.user, chipGroup)
         } else {
-            if (chipGroup.size > data.index) {
+            if (data.index in 0..chipGroup.size) {
                 chipGroup.removeViewAt(data.index)
             }
         }

--- a/vector/src/main/java/im/vector/riotx/features/createdirect/CreateDirectRoomKnownUsersFragment.kt
+++ b/vector/src/main/java/im/vector/riotx/features/createdirect/CreateDirectRoomKnownUsersFragment.kt
@@ -23,17 +23,14 @@ import android.view.Menu
 import android.view.MenuItem
 import android.view.View
 import android.widget.ScrollView
-import androidx.core.view.size
 import com.airbnb.mvrx.activityViewModel
 import com.airbnb.mvrx.withState
 import com.google.android.material.chip.Chip
-import com.google.android.material.chip.ChipGroup
 import com.jakewharton.rxbinding3.widget.textChanges
 import im.vector.matrix.android.api.session.user.model.User
 import im.vector.riotx.R
 import im.vector.riotx.core.extensions.cleanup
 import im.vector.riotx.core.extensions.configureWith
-import im.vector.riotx.core.extensions.exhaustive
 import im.vector.riotx.core.extensions.hideKeyboard
 import im.vector.riotx.core.extensions.setupAsSearch
 import im.vector.riotx.core.platform.VectorBaseFragment
@@ -61,11 +58,6 @@ class CreateDirectRoomKnownUsersFragment @Inject constructor(
         setupFilterView()
         setupAddByMatrixIdView()
         setupCloseView()
-        viewModel.observeViewEvents {
-            when (it) {
-                is CreateDirectRoomViewEvents.SelectUserAction -> updateChipsView(it)
-            }.exhaustive
-        }
         viewModel.selectSubscribe(this, CreateDirectRoomViewState::selectedUsers) {
             renderSelectedUsers(it)
         }
@@ -138,24 +130,24 @@ class CreateDirectRoomKnownUsersFragment @Inject constructor(
         knownUsersController.setData(it)
     }
 
-    private fun updateChipsView(data: CreateDirectRoomViewEvents.SelectUserAction) {
-        if (data.isAdded) {
-            addChipToGroup(data.user, chipGroup)
-        } else {
-            if (data.index in 0..chipGroup.size) {
-                chipGroup.removeViewAt(data.index)
+    private fun renderSelectedUsers(selectedUsers: Set<User>) {
+        invalidateOptionsMenu()
+
+        val currentNumberOfChips = chipGroup.childCount
+        val newNumberOfChips = selectedUsers.size
+
+        chipGroup.removeAllViews()
+        selectedUsers.forEach { addChipToGroup(it) }
+
+        // Scroll to the bottom when adding chips. When removing chips, do not scroll
+        if (newNumberOfChips >= currentNumberOfChips) {
+            chipGroupScrollView.post {
+                chipGroupScrollView.fullScroll(ScrollView.FOCUS_DOWN)
             }
         }
     }
 
-    private fun renderSelectedUsers(selectedUsers: Set<User>) {
-        invalidateOptionsMenu()
-        if (selectedUsers.isNotEmpty() && chipGroup.size == 0) {
-            selectedUsers.forEach { addChipToGroup(it, chipGroup) }
-        }
-    }
-
-    private fun addChipToGroup(user: User, chipGroup: ChipGroup) {
+    private fun addChipToGroup(user: User) {
         val chip = Chip(requireContext())
         chip.setChipBackgroundColorResource(android.R.color.transparent)
         chip.chipStrokeWidth = dimensionConverter.dpToPx(1).toFloat()
@@ -166,9 +158,6 @@ class CreateDirectRoomKnownUsersFragment @Inject constructor(
         chipGroup.addView(chip)
         chip.setOnCloseIconClickListener {
             viewModel.handle(CreateDirectRoomAction.RemoveSelectedUser(user))
-        }
-        chipGroupScrollView.post {
-            chipGroupScrollView.fullScroll(ScrollView.FOCUS_DOWN)
         }
     }
 

--- a/vector/src/main/java/im/vector/riotx/features/createdirect/CreateDirectRoomKnownUsersFragment.kt
+++ b/vector/src/main/java/im/vector/riotx/features/createdirect/CreateDirectRoomKnownUsersFragment.kt
@@ -159,7 +159,7 @@ class CreateDirectRoomKnownUsersFragment @Inject constructor(
         val chip = Chip(requireContext())
         chip.setChipBackgroundColorResource(android.R.color.transparent)
         chip.chipStrokeWidth = dimensionConverter.dpToPx(1).toFloat()
-        chip.text = if (user.displayName.isNullOrBlank()) user.userId else user.displayName
+        chip.text = user.getBestName()
         chip.isClickable = true
         chip.isCheckable = false
         chip.isCloseIconVisible = true

--- a/vector/src/main/java/im/vector/riotx/features/createdirect/CreateDirectRoomViewEvents.kt
+++ b/vector/src/main/java/im/vector/riotx/features/createdirect/CreateDirectRoomViewEvents.kt
@@ -16,16 +16,9 @@
 
 package im.vector.riotx.features.createdirect
 
-import im.vector.matrix.android.api.session.user.model.User
 import im.vector.riotx.core.platform.VectorViewEvents
 
 /**
  * Transient events for create direct room screen
  */
-sealed class CreateDirectRoomViewEvents : VectorViewEvents {
-    data class SelectUserAction(
-            val user: User,
-            val isAdded: Boolean,
-            val index: Int
-    ) : CreateDirectRoomViewEvents()
-}
+sealed class CreateDirectRoomViewEvents : VectorViewEvents

--- a/vector/src/main/java/im/vector/riotx/features/createdirect/CreateDirectRoomViewModel.kt
+++ b/vector/src/main/java/im/vector/riotx/features/createdirect/CreateDirectRoomViewModel.kt
@@ -27,9 +27,9 @@ import com.squareup.inject.assisted.Assisted
 import com.squareup.inject.assisted.AssistedInject
 import im.vector.matrix.android.api.session.Session
 import im.vector.matrix.android.api.session.room.model.create.CreateRoomParams
-import im.vector.matrix.android.api.session.user.model.User
 import im.vector.matrix.android.api.util.toMatrixItem
 import im.vector.matrix.rx.rx
+import im.vector.riotx.core.extensions.toggle
 import im.vector.riotx.core.platform.VectorViewModel
 import io.reactivex.Single
 import io.reactivex.android.schedulers.AndroidSchedulers
@@ -91,30 +91,15 @@ class CreateDirectRoomViewModel @AssistedInject constructor(@Assisted
     }
 
     private fun handleRemoveSelectedUser(action: CreateDirectRoomAction.RemoveSelectedUser) = withState { state ->
-        val index = state.selectedUsers.indexOfFirst { it.userId == action.user.userId }
         val selectedUsers = state.selectedUsers.minus(action.user)
         setState { copy(selectedUsers = selectedUsers) }
-        _viewEvents.post(CreateDirectRoomViewEvents.SelectUserAction(action.user, false, index))
     }
 
     private fun handleSelectUser(action: CreateDirectRoomAction.SelectUser) = withState { state ->
         // Reset the filter asap
         directoryUsersSearch.accept("")
-        val isAddOperation: Boolean
-        val selectedUsers: Set<User>
-        val indexOfUser = state.selectedUsers.indexOfFirst { it.userId == action.user.userId }
-        val changeIndex: Int
-        if (indexOfUser == -1) {
-            changeIndex = state.selectedUsers.size
-            selectedUsers = state.selectedUsers.plus(action.user)
-            isAddOperation = true
-        } else {
-            changeIndex = indexOfUser
-            selectedUsers = state.selectedUsers.minus(action.user)
-            isAddOperation = false
-        }
+        val selectedUsers = state.selectedUsers.toggle(action.user)
         setState { copy(selectedUsers = selectedUsers) }
-        _viewEvents.post(CreateDirectRoomViewEvents.SelectUserAction(action.user, isAddOperation, changeIndex))
     }
 
     private fun observeDirectoryUsers() {

--- a/vector/src/main/java/im/vector/riotx/features/notifications/NotificationDrawerManager.kt
+++ b/vector/src/main/java/im/vector/riotx/features/notifications/NotificationDrawerManager.kt
@@ -203,7 +203,7 @@ class NotificationDrawerManager @Inject constructor(private val context: Context
 
         val user = session.getUser(session.myUserId)
         // myUserDisplayName cannot be empty else NotificationCompat.MessagingStyle() will crash
-        val myUserDisplayName = user?.displayName?.takeIf { it.isNotBlank() } ?: session.myUserId
+        val myUserDisplayName = user?.getBestName() ?: session.myUserId
         val myUserAvatarUrl = session.contentUrlResolver().resolveThumbnail(user?.avatarUrl, avatarSize, avatarSize, ContentUrlResolver.ThumbnailMethod.SCALE)
         synchronized(eventList) {
             Timber.v("%%%%%%%% REFRESH NOTIFICATION DRAWER ")


### PR DESCRIPTION
A race condition was sometimes adding twice the first chip (#1032) 
This PR also fixes the fact that adding from userId was not working well if there was already a user selected.
