### PR TITLE
Remove dangerous runBlocking (and un-needed)

### DIFF
--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/DefaultCryptoService.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/DefaultCryptoService.kt
@@ -627,9 +627,7 @@ internal class DefaultCryptoService @Inject constructor(
      */
     @Throws(MXCryptoError::class)
     override fun decryptEvent(event: Event, timeline: String): MXEventDecryptionResult {
-        return runBlocking {
-            internalDecryptEvent(event, timeline)
-        }
+       return internalDecryptEvent(event, timeline)
     }
 
     /**
@@ -657,7 +655,7 @@ internal class DefaultCryptoService @Inject constructor(
      * @param timeline the id of the timeline where the event is decrypted. It is used to prevent replay attack.
      * @return the MXEventDecryptionResult data, or null in case of error
      */
-    private suspend fun internalDecryptEvent(event: Event, timeline: String): MXEventDecryptionResult {
+    private fun internalDecryptEvent(event: Event, timeline: String): MXEventDecryptionResult {
         val eventContent = event.content
         if (eventContent == null) {
             Timber.e("## decryptEvent : empty event content")

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/algorithms/IMXDecrypting.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/algorithms/IMXDecrypting.kt
@@ -34,7 +34,7 @@ internal interface IMXDecrypting {
      * @param timeline the id of the timeline where the event is decrypted. It is used to prevent replay attack.
      * @return the decryption information, or an error
      */
-    suspend fun decryptEvent(event: Event, timeline: String): MXEventDecryptionResult
+    fun decryptEvent(event: Event, timeline: String): MXEventDecryptionResult
 
     /**
      * Handle a key event.

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/algorithms/megolm/MXMegolmDecryption.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/algorithms/megolm/MXMegolmDecryption.kt
@@ -63,7 +63,7 @@ internal class MXMegolmDecryption(private val userId: String,
      */
     private var pendingEvents: MutableMap<String /* senderKey|sessionId */, MutableMap<String /* timelineId */, MutableList<Event>>> = HashMap()
 
-    override suspend fun decryptEvent(event: Event, timeline: String): MXEventDecryptionResult {
+    override fun decryptEvent(event: Event, timeline: String): MXEventDecryptionResult {
         // If cross signing is enabled, we don't send request until the keys are trusted
         // There could be a race effect here when xsigning is enabled, we should ensure that keys was downloaded once
         val requestOnFail = cryptoStore.getMyCrossSigningInfo()?.isTrusted() == true

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/algorithms/olm/MXOlmDecryption.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/algorithms/olm/MXOlmDecryption.kt
@@ -38,7 +38,7 @@ internal class MXOlmDecryption(
         private val userId: String)
     : IMXDecrypting {
 
-    override suspend fun decryptEvent(event: Event, timeline: String): MXEventDecryptionResult {
+    override fun decryptEvent(event: Event, timeline: String): MXEventDecryptionResult {
         val olmEventContent = event.content.toModel<OlmEventContent>() ?: run {
             Timber.e("## decryptEvent() : bad event format")
             throw MXCryptoError.Base(MXCryptoError.ErrorType.BAD_EVENT_FORMAT,


### PR DESCRIPTION
un needed runblocking, and dangerous (should not be used from a coroutine):

````
 * Runs a new coroutine and **blocks** the current thread _interruptibly_ until its completion.
 * This function should not be used from a coroutine. It is designed to bridge regular blocking code
 * to libraries that are written in suspending style, to be used in `main` functions and in tests.