### PR TITLE
Fix Message transitions in encrypted rooms

### DIFF
--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/send/EncryptEventWorker.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/send/EncryptEventWorker.kt
@@ -112,7 +112,7 @@ internal class EncryptEventWorker(context: Context, params: WorkerParameters)
                         senderCurve25519Key = result.eventContent["sender_key"] as? String,
                         claimedEd25519Key = crypto.getMyDevice().fingerprint()
                 )
-                localEchoUpdater.updateEncryptedEcho(localEvent.eventId, result.eventContent, decryptionLocalEcho)
+                localEchoUpdater.updateEncryptedEcho(localEvent.eventId, safeResult.eventContent, decryptionLocalEcho)
             }
 
             val nextWorkerParams = SendEventWorker.Params(params.sessionId, encryptedEvent)

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/send/EncryptEventWorker.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/send/EncryptEventWorker.kt
@@ -23,7 +23,10 @@ import com.squareup.moshi.JsonClass
 import im.vector.matrix.android.api.failure.Failure
 import im.vector.matrix.android.api.session.crypto.CryptoService
 import im.vector.matrix.android.api.session.events.model.Event
+import im.vector.matrix.android.api.session.events.model.toContent
 import im.vector.matrix.android.api.session.room.send.SendState
+import im.vector.matrix.android.internal.crypto.MXCRYPTO_ALGORITHM_MEGOLM
+import im.vector.matrix.android.internal.crypto.MXEventDecryptionResult
 import im.vector.matrix.android.internal.crypto.model.MXEncryptEventContentResult
 import im.vector.matrix.android.internal.util.awaitCallback
 import im.vector.matrix.android.internal.worker.SessionWorkerParams
@@ -96,6 +99,22 @@ internal class EncryptEventWorker(context: Context, params: WorkerParameters)
                     type = safeResult.eventType,
                     content = safeResult.eventContent
             )
+            // Better handling of local echo, to avoid decrypting transition on remote echo
+            // Should I only do it for text messages?
+            if (result.eventContent["algorithm"] == MXCRYPTO_ALGORITHM_MEGOLM) {
+                val decryptionLocalEcho = MXEventDecryptionResult(
+                        clearEvent = Event(
+                                type = localEvent.type,
+                                content = localEvent.content,
+                                roomId = localEvent.roomId
+                        ).toContent(),
+                        forwardingCurve25519KeyChain = emptyList(),
+                        senderCurve25519Key = result.eventContent["sender_key"] as? String,
+                        claimedEd25519Key = crypto.getMyDevice().fingerprint()
+                )
+                localEchoUpdater.updateEncryptedEcho(localEvent.eventId, result.eventContent, decryptionLocalEcho)
+            }
+
             val nextWorkerParams = SendEventWorker.Params(params.sessionId, encryptedEvent)
             return Result.success(WorkerParamsFactory.toData(nextWorkerParams))
         } else {

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/send/LocalEchoUpdater.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/send/LocalEchoUpdater.kt
@@ -17,7 +17,11 @@
 package im.vector.matrix.android.internal.session.room.send
 
 import com.zhuinden.monarchy.Monarchy
+import im.vector.matrix.android.api.session.events.model.Content
+import im.vector.matrix.android.api.session.events.model.EventType
 import im.vector.matrix.android.api.session.room.send.SendState
+import im.vector.matrix.android.internal.crypto.MXEventDecryptionResult
+import im.vector.matrix.android.internal.database.mapper.ContentMapper
 import im.vector.matrix.android.internal.database.model.EventEntity
 import im.vector.matrix.android.internal.database.query.where
 import timber.log.Timber
@@ -35,6 +39,17 @@ internal class LocalEchoUpdater @Inject constructor(private val monarchy: Monarc
                 } else {
                     sendingEventEntity.sendState = sendState
                 }
+            }
+        }
+    }
+
+    fun updateEncryptedEcho(eventId: String, encryptedContent: Content, mxEventDecryptionResult: MXEventDecryptionResult) {
+        monarchy.writeAsync { realm ->
+            val sendingEventEntity = EventEntity.where(realm, eventId).findFirst()
+            if (sendingEventEntity != null) {
+                sendingEventEntity.type = EventType.ENCRYPTED
+                sendingEventEntity.content = ContentMapper.map(encryptedContent)
+                sendingEventEntity.setDecryptionResult(mxEventDecryptionResult)
             }
         }
     }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/sync/RoomSyncHandler.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/sync/RoomSyncHandler.kt
@@ -25,6 +25,7 @@ import im.vector.matrix.android.api.session.room.model.RoomMemberContent
 import im.vector.matrix.android.api.session.room.model.tag.RoomTagContent
 import im.vector.matrix.android.api.session.room.send.SendState
 import im.vector.matrix.android.internal.crypto.DefaultCryptoService
+import im.vector.matrix.android.internal.crypto.algorithms.olm.OlmDecryptionResult
 import im.vector.matrix.android.internal.database.helper.addOrUpdate
 import im.vector.matrix.android.internal.database.helper.addTimelineEvent
 import im.vector.matrix.android.internal.database.mapper.ContentMapper
@@ -260,6 +261,22 @@ internal class RoomSyncHandler @Inject constructor(private val readReceiptHandle
                 if (sendingEventEntity != null) {
                     Timber.v("Remove local echo for tx:$it")
                     roomEntity.sendingTimelineEvents.remove(sendingEventEntity)
+                    if (event.isEncrypted()) {
+                        // Maybe just a temp work around?
+                        // Decrypt the remote echo right now, to avoid seeing it decrypt again
+                        try {
+                            val result = cryptoService.decryptEvent(event.copy(roomId = roomId), event.roomId ?: "")
+                            event.mxDecryptionResult = OlmDecryptionResult(
+                                    payload = result.clearEvent,
+                                    senderKey = result.senderCurve25519Key,
+                                    keysClaimed = result.claimedEd25519Key?.let { mapOf("ed25519" to it) },
+                                    forwardingCurve25519KeyChain = result.forwardingCurve25519KeyChain
+                            )
+                            eventEntity.setDecryptionResult(result)
+                        } catch (failure: Throwable) {
+                            Timber.v("Failed to decrypt remote echo: ${failure.localizedMessage}")
+                        }
+                    }
                 } else {
                     Timber.v("Can't find corresponding local echo for tx:$it")
                 }


### PR DESCRIPTION
Fixes #518

Immediatly decrypt remote echo of encrypted messages to avoid annoying transition


# Before 
<img width="410" alt="image" src="https://user-images.githubusercontent.com/9841565/76451951-91e0d600-63d0-11ea-90c5-39cd6b2403af.png">
<img width="414" alt="image" src="https://user-images.githubusercontent.com/9841565/76451967-97d6b700-63d0-11ea-9f74-fba740fa6452.png">
<img width="413" alt="image" src="https://user-images.githubusercontent.com/9841565/76451976-9c9b6b00-63d0-11ea-81e2-67535f23c09f.png">


# After
<img width="392" alt="image" src="https://user-images.githubusercontent.com/9841565/76452055-c05eb100-63d0-11ea-851f-c1b23acc6734.png">
<img width="395" alt="image" src="https://user-images.githubusercontent.com/9841565/76452073-c5bbfb80-63d0-11ea-8d88-9a4eaf52164c.png">


