### PR TITLE
QuickFix / key banner not clickable

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Bugfix 🐛:
  - Message transitions in encrypted rooms are jarring #518
  - Images that failed to send are waiting to be sent forever #1145
  - Fix / Crashed when trying to send a gif from the Gboard #1136
+ - Fix / Cannot click on key backup banner when new keys are available
 
 Translations 🗣:
  -

--- a/vector/src/main/java/im/vector/riotx/core/ui/views/KeysBackupBanner.kt
+++ b/vector/src/main/java/im/vector/riotx/core/ui/views/KeysBackupBanner.kt
@@ -123,6 +123,7 @@ class KeysBackupBanner @JvmOverloads constructor(
             is State.Setup   -> {
                 delegate?.setupKeysBackup()
             }
+            is State.Update,
             is State.Recover -> {
                 delegate?.recoverKeysBackup()
             }

--- a/vector/src/main/java/im/vector/riotx/features/crypto/keysbackup/settings/KeysBackupSettingsRecyclerViewController.kt
+++ b/vector/src/main/java/im/vector/riotx/features/crypto/keysbackup/settings/KeysBackupSettingsRecyclerViewController.kt
@@ -31,10 +31,12 @@ import im.vector.riotx.core.epoxy.loadingItem
 import im.vector.riotx.core.resources.StringProvider
 import im.vector.riotx.core.ui.list.GenericItem
 import im.vector.riotx.core.ui.list.genericItem
+import im.vector.riotx.features.settings.VectorPreferences
 import java.util.UUID
 import javax.inject.Inject
 
 class KeysBackupSettingsRecyclerViewController @Inject constructor(private val stringProvider: StringProvider,
+                                                                   private val vectorPreferences: VectorPreferences,
                                                                    private val session: Session) : TypedEpoxyController<KeysBackupSettingViewState>() {
 
     var listener: Listener? = null
@@ -149,7 +151,9 @@ class KeysBackupSettingsRecyclerViewController @Inject constructor(private val s
                 description(keyVersionResult?.algorithm ?: "")
             }
 
-            buildKeysBackupTrust(data.keysBackupVersionTrust)
+            if (vectorPreferences.developerMode()) {
+                buildKeysBackupTrust(data.keysBackupVersionTrust)
+            }
         }
 
         // Footer

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -1461,7 +1461,7 @@ Why choose Riot.im?
     <string name="keys_backup_banner_recover_line1">Never lose encrypted messages</string>
     <string name="keys_backup_banner_recover_line2">Use Key Backup</string>
 
-    <string name="keys_backup_banner_update_line1">New encrypted messages keys</string>
+    <string name="keys_backup_banner_update_line1">New secure message keys</string>
     <string name="keys_backup_banner_update_line2">Manage in Key Backup</string>
 
     <string name="keys_backup_banner_in_progress">Backing up keys…</string>


### PR DESCRIPTION
Fix / When there are locally unknown keys available on the backup the banner is not clickable