### PR TITLE
Fixes #841

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@ Improvements 🙌:
  -
 
 Bugfix 🐛:
- -
+ - Missing avatar/displayname after verification request message (#841)
 
 Translations 🗣:
  -


### PR DESCRIPTION
Fixes #841
 Missing avatar/displayname after verification request message 

After a verificati

Before:
<img width="375" alt="image" src="https://user-images.githubusercontent.com/9841565/76953552-2dad9d00-690f-11ea-9067-07645e99b4c9.png">

After:
<img width="381" alt="image" src="https://user-images.githubusercontent.com/9841565/76953574-3605d800-690f-11ea-8962-45e2d41bf59d.png">
