### PR TITLE
Feature/ensure olm account unicity

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ Improvements 🙌:
 
 Bugfix 🐛:
  - Missing avatar/displayname after verification request message (#841)
+ - Crypto | RiotX sometimes rotate the current device keys (#1170)
 
 Translations 🗣:
  -

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/MXOlmDevice.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/MXOlmDevice.kt
@@ -89,7 +89,6 @@ internal class MXOlmDevice @Inject constructor(
             Timber.e(e, "MXOlmDevice : cannot initialize olmAccount")
         }
 
-
         try {
             olmUtility = OlmUtility()
         } catch (e: Exception) {
@@ -98,13 +97,13 @@ internal class MXOlmDevice @Inject constructor(
         }
 
         try {
-            deviceCurve25519Key = store.getAccount().identityKeys()[OlmAccount.JSON_KEY_IDENTITY_KEY]
+            deviceCurve25519Key = store.getOlmAccount().identityKeys()[OlmAccount.JSON_KEY_IDENTITY_KEY]
         } catch (e: Exception) {
             Timber.e(e, "## MXOlmDevice : cannot find ${OlmAccount.JSON_KEY_IDENTITY_KEY} with error")
         }
 
         try {
-            deviceEd25519Key = store.getAccount().identityKeys()[OlmAccount.JSON_KEY_FINGER_PRINT_KEY]
+            deviceEd25519Key = store.getOlmAccount().identityKeys()[OlmAccount.JSON_KEY_FINGER_PRINT_KEY]
         } catch (e: Exception) {
             Timber.e(e, "## MXOlmDevice : cannot find ${OlmAccount.JSON_KEY_FINGER_PRINT_KEY} with error")
         }
@@ -115,7 +114,7 @@ internal class MXOlmDevice @Inject constructor(
      */
     fun getOneTimeKeys(): Map<String, Map<String, String>>? {
         try {
-            return store.getAccount().oneTimeKeys()
+            return store.getOlmAccount().oneTimeKeys()
         } catch (e: Exception) {
             Timber.e(e, "## getOneTimeKeys() : failed")
         }
@@ -127,7 +126,7 @@ internal class MXOlmDevice @Inject constructor(
      * @return The maximum number of one-time keys the olm account can store.
      */
     fun getMaxNumberOfOneTimeKeys(): Long {
-        return store.getAccount().maxOneTimeKeys()
+        return store.getOlmAccount().maxOneTimeKeys()
     }
 
     /**
@@ -145,7 +144,7 @@ internal class MXOlmDevice @Inject constructor(
      */
     fun signMessage(message: String): String? {
         try {
-            return store.getAccount().signMessage(message)
+            return store.getOlmAccount().signMessage(message)
         } catch (e: Exception) {
             Timber.e(e, "## signMessage() : failed")
         }
@@ -158,8 +157,8 @@ internal class MXOlmDevice @Inject constructor(
      */
     fun markKeysAsPublished() {
         try {
-            store.getAccount().markOneTimeKeysAsPublished()
-            store.saveAccount()
+            store.getOlmAccount().markOneTimeKeysAsPublished()
+            store.saveOlmAccount()
         } catch (e: Exception) {
             Timber.e(e, "## markKeysAsPublished() : failed")
         }
@@ -172,8 +171,8 @@ internal class MXOlmDevice @Inject constructor(
      */
     fun generateOneTimeKeys(numKeys: Int) {
         try {
-            store.getAccount().generateOneTimeKeys(numKeys)
-            store.saveAccount()
+            store.getOlmAccount().generateOneTimeKeys(numKeys)
+            store.saveOlmAccount()
         } catch (e: Exception) {
             Timber.e(e, "## generateOneTimeKeys() : failed")
         }
@@ -193,7 +192,7 @@ internal class MXOlmDevice @Inject constructor(
 
         try {
             olmSession = OlmSession()
-            olmSession.initOutboundSession(store.getAccount(), theirIdentityKey, theirOneTimeKey)
+            olmSession.initOutboundSession(store.getOlmAccount(), theirIdentityKey, theirOneTimeKey)
 
             val olmSessionWrapper = OlmSessionWrapper(olmSession, 0)
 
@@ -233,7 +232,7 @@ internal class MXOlmDevice @Inject constructor(
         try {
             try {
                 olmSession = OlmSession()
-                olmSession.initInboundSessionFrom(store.getAccount(), theirDeviceIdentityKey, ciphertext)
+                olmSession.initInboundSessionFrom(store.getOlmAccount(), theirDeviceIdentityKey, ciphertext)
             } catch (e: Exception) {
                 Timber.e(e, "## createInboundSession() : the session creation failed")
                 return null
@@ -242,8 +241,8 @@ internal class MXOlmDevice @Inject constructor(
             Timber.v("## createInboundSession() : sessionId: ${olmSession.sessionIdentifier()}")
 
             try {
-                store.getAccount().removeOneTimeKeys(olmSession)
-                store.saveAccount()
+                store.getOlmAccount().removeOneTimeKeys(olmSession)
+                store.saveOlmAccount()
             } catch (e: Exception) {
                 Timber.e(e, "## createInboundSession() : removeOneTimeKeys failed")
             }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/MXOlmDevice.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/MXOlmDevice.kt
@@ -59,9 +59,6 @@ internal class MXOlmDevice @Inject constructor(
     var deviceEd25519Key: String? = null
         private set
 
-    // The OLM lib account instance.
-    private var olmAccount: OlmAccount? = null
-
     // The OLM lib utility instance.
     private var olmUtility: OlmUtility? = null
 
@@ -86,20 +83,12 @@ internal class MXOlmDevice @Inject constructor(
 
     init {
         // Retrieve the account from the store
-        olmAccount = store.getAccount()
-
-        if (null == olmAccount) {
-            Timber.v("MXOlmDevice : create a new olm account")
-            // Else, create it
-            try {
-                olmAccount = OlmAccount()
-                store.storeAccount(olmAccount!!)
-            } catch (e: Exception) {
-                Timber.e(e, "MXOlmDevice : cannot initialize olmAccount")
-            }
-        } else {
-            Timber.v("MXOlmDevice : use an existing account")
+        try {
+            store.getOrCreateOlmAccount()
+        } catch (e: Exception) {
+            Timber.e(e, "MXOlmDevice : cannot initialize olmAccount")
         }
+
 
         try {
             olmUtility = OlmUtility()
@@ -109,13 +98,13 @@ internal class MXOlmDevice @Inject constructor(
         }
 
         try {
-            deviceCurve25519Key = olmAccount!!.identityKeys()[OlmAccount.JSON_KEY_IDENTITY_KEY]
+            deviceCurve25519Key = store.getAccount().identityKeys()[OlmAccount.JSON_KEY_IDENTITY_KEY]
         } catch (e: Exception) {
             Timber.e(e, "## MXOlmDevice : cannot find ${OlmAccount.JSON_KEY_IDENTITY_KEY} with error")
         }
 
         try {
-            deviceEd25519Key = olmAccount!!.identityKeys()[OlmAccount.JSON_KEY_FINGER_PRINT_KEY]
+            deviceEd25519Key = store.getAccount().identityKeys()[OlmAccount.JSON_KEY_FINGER_PRINT_KEY]
         } catch (e: Exception) {
             Timber.e(e, "## MXOlmDevice : cannot find ${OlmAccount.JSON_KEY_FINGER_PRINT_KEY} with error")
         }
@@ -126,7 +115,7 @@ internal class MXOlmDevice @Inject constructor(
      */
     fun getOneTimeKeys(): Map<String, Map<String, String>>? {
         try {
-            return olmAccount!!.oneTimeKeys()
+            return store.getAccount().oneTimeKeys()
         } catch (e: Exception) {
             Timber.e(e, "## getOneTimeKeys() : failed")
         }
@@ -138,14 +127,13 @@ internal class MXOlmDevice @Inject constructor(
      * @return The maximum number of one-time keys the olm account can store.
      */
     fun getMaxNumberOfOneTimeKeys(): Long {
-        return olmAccount?.maxOneTimeKeys() ?: -1
+        return store.getAccount().maxOneTimeKeys()
     }
 
     /**
      * Release the instance
      */
     fun release() {
-        olmAccount?.releaseAccount()
         olmUtility?.releaseUtility()
     }
 
@@ -157,7 +145,7 @@ internal class MXOlmDevice @Inject constructor(
      */
     fun signMessage(message: String): String? {
         try {
-            return olmAccount!!.signMessage(message)
+            return store.getAccount().signMessage(message)
         } catch (e: Exception) {
             Timber.e(e, "## signMessage() : failed")
         }
@@ -170,8 +158,8 @@ internal class MXOlmDevice @Inject constructor(
      */
     fun markKeysAsPublished() {
         try {
-            olmAccount!!.markOneTimeKeysAsPublished()
-            store.storeAccount(olmAccount!!)
+            store.getAccount().markOneTimeKeysAsPublished()
+            store.saveAccount()
         } catch (e: Exception) {
             Timber.e(e, "## markKeysAsPublished() : failed")
         }
@@ -184,8 +172,8 @@ internal class MXOlmDevice @Inject constructor(
      */
     fun generateOneTimeKeys(numKeys: Int) {
         try {
-            olmAccount!!.generateOneTimeKeys(numKeys)
-            store.storeAccount(olmAccount!!)
+            store.getAccount().generateOneTimeKeys(numKeys)
+            store.saveAccount()
         } catch (e: Exception) {
             Timber.e(e, "## generateOneTimeKeys() : failed")
         }
@@ -205,7 +193,7 @@ internal class MXOlmDevice @Inject constructor(
 
         try {
             olmSession = OlmSession()
-            olmSession.initOutboundSession(olmAccount!!, theirIdentityKey, theirOneTimeKey)
+            olmSession.initOutboundSession(store.getAccount(), theirIdentityKey, theirOneTimeKey)
 
             val olmSessionWrapper = OlmSessionWrapper(olmSession, 0)
 
@@ -245,7 +233,7 @@ internal class MXOlmDevice @Inject constructor(
         try {
             try {
                 olmSession = OlmSession()
-                olmSession.initInboundSessionFrom(olmAccount!!, theirDeviceIdentityKey, ciphertext)
+                olmSession.initInboundSessionFrom(store.getAccount(), theirDeviceIdentityKey, ciphertext)
             } catch (e: Exception) {
                 Timber.e(e, "## createInboundSession() : the session creation failed")
                 return null
@@ -254,8 +242,8 @@ internal class MXOlmDevice @Inject constructor(
             Timber.v("## createInboundSession() : sessionId: ${olmSession.sessionIdentifier()}")
 
             try {
-                olmAccount!!.removeOneTimeKeys(olmSession)
-                store.storeAccount(olmAccount!!)
+                store.getAccount().removeOneTimeKeys(olmSession)
+                store.saveAccount()
             } catch (e: Exception) {
                 Timber.e(e, "## createInboundSession() : removeOneTimeKeys failed")
             }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/store/IMXCryptoStore.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/store/IMXCryptoStore.kt
@@ -49,7 +49,10 @@ internal interface IMXCryptoStore {
     /**
      * @return the olm account
      */
-    fun getAccount(): OlmAccount?
+    fun getAccount(): OlmAccount
+
+
+    fun getOrCreateOlmAccount(): OlmAccount
 
     /**
      * Retrieve the known inbound group sessions.
@@ -159,7 +162,7 @@ internal interface IMXCryptoStore {
      *
      * @param account the account to save
      */
-    fun storeAccount(account: OlmAccount)
+    fun saveAccount()
 
     /**
      * Store a device for a user.

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/store/IMXCryptoStore.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/store/IMXCryptoStore.kt
@@ -49,8 +49,7 @@ internal interface IMXCryptoStore {
     /**
      * @return the olm account
      */
-    fun getAccount(): OlmAccount
-
+    fun getOlmAccount(): OlmAccount
 
     fun getOrCreateOlmAccount(): OlmAccount
 
@@ -162,7 +161,7 @@ internal interface IMXCryptoStore {
      *
      * @param account the account to save
      */
-    fun saveAccount()
+    fun saveOlmAccount()
 
     /**
      * Store a device for a user.

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/store/db/RealmCryptoStore.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/store/db/RealmCryptoStore.kt
@@ -122,7 +122,6 @@ internal class RealmCryptoStore @Inject constructor(
             .setRealmConfiguration(realmConfiguration)
             .build()
 
-
     init {
         // Ensure CryptoMetadataEntity is inserted in DB
         doRealmTransaction(realmConfiguration) { realm ->
@@ -205,13 +204,13 @@ internal class RealmCryptoStore @Inject constructor(
         }?.deviceId ?: ""
     }
 
-    override fun saveAccount() {
+    override fun saveOlmAccount() {
         doRealmTransaction(realmConfiguration) {
             it.where<CryptoMetadataEntity>().findFirst()?.putOlmAccount(olmAccount)
         }
     }
 
-    override fun getAccount(): OlmAccount {
+    override fun getOlmAccount(): OlmAccount {
         return olmAccount!!
     }
 
@@ -231,7 +230,6 @@ internal class RealmCryptoStore @Inject constructor(
         }
         return olmAccount!!
     }
-
 
     override fun storeUserDevice(userId: String?, deviceInfo: CryptoDeviceInfo?) {
         if (userId == null || deviceInfo == null) {

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/tasks/UploadKeysTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/tasks/UploadKeysTask.kt
@@ -25,6 +25,7 @@ import im.vector.matrix.android.internal.network.executeRequest
 import im.vector.matrix.android.internal.task.Task
 import im.vector.matrix.android.internal.util.convertToUTF8
 import org.greenrobot.eventbus.EventBus
+import timber.log.Timber
 import javax.inject.Inject
 
 internal interface UploadKeysTask : Task<UploadKeysTask.Params, KeysUploadResponse> {
@@ -49,6 +50,8 @@ internal class DefaultUploadKeysTask @Inject constructor(
                 deviceKeys = params.deviceKeys,
                 oneTimeKeys = params.oneTimeKeys
         )
+
+        Timber.i("## Uploading device keys -> ${body}")
 
         return executeRequest(eventBus) {
             apiCall = if (encodedDeviceId.isBlank()) {

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/tasks/UploadKeysTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/tasks/UploadKeysTask.kt
@@ -51,7 +51,7 @@ internal class DefaultUploadKeysTask @Inject constructor(
                 oneTimeKeys = params.oneTimeKeys
         )
 
-        Timber.i("## Uploading device keys -> ${body}")
+        Timber.i("## Uploading device keys -> $body")
 
         return executeRequest(eventBus) {
             apiCall = if (encodedDeviceId.isBlank()) {


### PR DESCRIPTION
Fixes #1170

MXOlmDevice is accessing the store in constructor, thus before store.open() is called. And as the crypto meta data info is only created in open(), the current OlmAccount is not persisted .
So if something bad happens (crash / kill), a new Account will be created at next launch, thus new keys will be uploaded for this device