### PR TITLE
Fixes #1174

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ Improvements 🙌:
 
 Bugfix 🐛:
  - Missing avatar/displayname after verification request message (#841)
+ - RiotX can't restore cross signing keys saved by web in SSSS (#1174)
 
 Translations 🗣:
  -


### PR DESCRIPTION
Fix / Since migration to symetric SSSS RiotX can't restore cross signing keys saved by web in SSSS 
