### PR TITLE
Update shield logic for DM

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Features ✨:
 
 Improvements 🙌:
  - Verification DM / Handle concurrent .start after .ready (#794)
+ - CrossSigning / Update Shield Logic for DM (#963)
 
 Bugfix 🐛:
  - Missing avatar/displayname after verification request message (#841)

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/RoomSummaryUpdater.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/RoomSummaryUpdater.kt
@@ -161,7 +161,15 @@ internal class RoomSummaryUpdater @Inject constructor(
             roomSummaryEntity.otherMemberIds.clear()
             roomSummaryEntity.otherMemberIds.addAll(otherRoomMembers)
             if (roomSummaryEntity.isEncrypted) {
-                eventBus.post(SessionToCryptoRoomMembersUpdate(roomId, roomSummaryEntity.otherMemberIds.toList() + userId))
+                // The set of “all users” depends on the type of room:
+                // For regular / topic rooms, all users including yourself, are considered when decorating a room
+                // For 1:1 and group DM rooms, all other users (i.e. excluding yourself) are considered when decorating a room
+                val listToCheck = if (roomSummaryEntity.isDirect) {
+                    roomSummaryEntity.otherMemberIds.toList()
+                } else {
+                    roomSummaryEntity.otherMemberIds.toList() + userId
+                }
+                eventBus.post(SessionToCryptoRoomMembersUpdate(roomId, listToCheck))
             }
         }
     }


### PR DESCRIPTION
Fixes #963 

> (Added 2020-02-24) The set of “all users” depends on the type of room:
For regular / topic rooms, all users including yourself, are considered when decorating a room
For 1:1 and group DM rooms, all other users (i.e. excluding yourself) are considered when decorating a room
