### PR TITLE
Fix / sending event not always updating

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,7 @@ Bugfix 🐛:
  - Cross- Signing | After signin in new session, verification paper trail in DM is off (#1191)
  - Failed to encrypt message in room (message stays in red), [thanks to pwr22] (#925)
  - Cross-Signing | web <-> riotX After QR code scan, gossiping fails (#1210)
+ - Local echo are not updated in timeline (for failed & encrypted states)
 
 Translations 🗣:
  -

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/timeline/DefaultTimeline.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/timeline/DefaultTimeline.kt
@@ -171,10 +171,13 @@ internal class DefaultTimeline(
                 val realm = Realm.getInstance(realmConfiguration)
                 backgroundRealm.set(realm)
 
-                roomEntity = RoomEntity.where(realm, roomId = roomId).findFirst()?.also {
-                    it.sendingTimelineEvents.addChangeListener { _ ->
-                        postSnapshot()
+                roomEntity = RoomEntity.where(realm, roomId = roomId).findFirst()
+                roomEntity?.sendingTimelineEvents?.addChangeListener { events ->
+                    // Remove in memory as soon as they are known by database
+                    events.forEach { te ->
+                        inMemorySendingEvents.removeAll { te.eventId == it.eventId }
                     }
+                    postSnapshot()
                 }
 
                 nonFilteredEvents = buildEventQuery(realm).sort(TimelineEventEntityFields.DISPLAY_INDEX, Sort.DESCENDING).findAll()


### PR DESCRIPTION
Local echo in timeline was not anymore following database changes (encrypting, failed to send..)
It's because timeline has now 'inMemory' sending events for snappiness, but they were not synced with DB until sync