### PR TITLE
Increase default timeout to match old riot

### DIFF
--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/di/NetworkModule.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/di/NetworkModule.kt
@@ -72,8 +72,8 @@ internal object NetworkModule {
                              okReplayInterceptor: OkReplayInterceptor): OkHttpClient {
         return OkHttpClient.Builder()
                 .connectTimeout(30, TimeUnit.SECONDS)
-                .readTimeout(30, TimeUnit.SECONDS)
-                .writeTimeout(30, TimeUnit.SECONDS)
+                .readTimeout(60, TimeUnit.SECONDS)
+                .writeTimeout(60, TimeUnit.SECONDS)
                 .addNetworkInterceptor(stethoInterceptor)
                 .addInterceptor(timeoutInterceptor)
                 .addInterceptor(userAgentInterceptor)


### PR DESCRIPTION
Increase default timeout to match old riot
https://github.com/matrix-org/matrix-android-sdk/blob/3427bf4d96fb707e4d5429b8739af6aa4cbcc179/matrix-sdk-core/src/main/java/org/matrix/androidsdk/RestClientHttpClientFactory.kt#L35

-> helps for verification with toDevice on mx

Ideally we should do dynamic timeouts based on connection type like former SDK was doing
