### PR TITLE
KeyBackup / Use 4S if key in quadS

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -455,6 +455,7 @@ Bugfix:
  - Fix messages with empty `in_reply_to` not rendering (#447)
  - Fix clear cache (#408) and Logout (#205)
  - Fix `(edited)` link can be copied to clipboard (#402)
+ - KeyBackup / SSSS | Should get the key from SSSS instead of asking recovery Key (#1163)
 
 Build:
  - Split APK: generate one APK per arch, to reduce APK size of about 30%

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/keysbackup/DefaultKeysBackupService.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/keysbackup/DefaultKeysBackupService.kt
@@ -728,7 +728,8 @@ internal class DefaultKeysBackupService @Inject constructor(
                     if (backUp) {
                         maybeBackupKeys()
                     }
-
+                    // Save for next time and for gossiping
+                    saveBackupRecoveryKey(recoveryKey, keysVersionResult.version)
                     result
                 }
             }.foldToCallback(callback)

--- a/vector/src/main/java/im/vector/riotx/features/crypto/keysbackup/restore/KeysBackupRestoreFromKeyFragment.kt
+++ b/vector/src/main/java/im/vector/riotx/features/crypto/keysbackup/restore/KeysBackupRestoreFromKeyFragment.kt
@@ -82,7 +82,7 @@ class KeysBackupRestoreFromKeyFragment @Inject constructor()
         if (value.isNullOrBlank()) {
             viewModel.recoveryCodeErrorText.value = context?.getString(R.string.keys_backup_recovery_code_empty_error_message)
         } else {
-            viewModel.recoverKeys(requireContext(), sharedViewModel)
+            viewModel.recoverKeys(sharedViewModel)
         }
     }
 

--- a/vector/src/main/java/im/vector/riotx/features/crypto/keysbackup/restore/KeysBackupRestoreFromPassphraseFragment.kt
+++ b/vector/src/main/java/im/vector/riotx/features/crypto/keysbackup/restore/KeysBackupRestoreFromPassphraseFragment.kt
@@ -36,7 +36,7 @@ import im.vector.riotx.core.extensions.showPassword
 import im.vector.riotx.core.platform.VectorBaseFragment
 import javax.inject.Inject
 
-class KeysBackupRestoreFromPassphraseFragment @Inject constructor(): VectorBaseFragment() {
+class KeysBackupRestoreFromPassphraseFragment @Inject constructor() : VectorBaseFragment() {
 
     override fun getLayoutResId() = R.layout.fragment_keys_backup_restore_from_passphrase
 
@@ -119,7 +119,7 @@ class KeysBackupRestoreFromPassphraseFragment @Inject constructor(): VectorBaseF
         if (value.isNullOrBlank()) {
             viewModel.passphraseErrorText.value = context?.getString(R.string.passphrase_empty_error_message)
         } else {
-            viewModel.recoverKeys(context!!, sharedViewModel)
+            viewModel.recoverKeys(sharedViewModel)
         }
     }
 }

--- a/vector/src/main/java/im/vector/riotx/features/crypto/keysbackup/restore/KeysBackupRestoreSharedViewModel.kt
+++ b/vector/src/main/java/im/vector/riotx/features/crypto/keysbackup/restore/KeysBackupRestoreSharedViewModel.kt
@@ -15,29 +15,51 @@
  */
 package im.vector.riotx.features.crypto.keysbackup.restore
 
-import android.content.Context
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import im.vector.matrix.android.api.MatrixCallback
+import im.vector.matrix.android.api.listeners.StepProgressListener
 import im.vector.matrix.android.api.session.Session
+import im.vector.matrix.android.api.session.crypto.crosssigning.KEYBACKUP_SECRET_SSSS_NAME
+import im.vector.matrix.android.api.session.crypto.keysbackup.KeysBackupService
+import im.vector.matrix.android.api.session.securestorage.KeyInfoResult
+import im.vector.matrix.android.internal.crypto.crosssigning.fromBase64
 import im.vector.matrix.android.internal.crypto.keysbackup.model.rest.KeysVersionResult
+import im.vector.matrix.android.internal.crypto.keysbackup.util.computeRecoveryKey
 import im.vector.matrix.android.internal.crypto.model.ImportRoomKeysResult
+import im.vector.matrix.android.internal.util.awaitCallback
 import im.vector.riotx.R
 import im.vector.riotx.core.platform.WaitingViewData
+import im.vector.riotx.core.resources.StringProvider
 import im.vector.riotx.core.utils.LiveEvent
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 
-class KeysBackupRestoreSharedViewModel @Inject constructor() : ViewModel() {
+class KeysBackupRestoreSharedViewModel @Inject constructor(
+        private val stringProvider: StringProvider
+) : ViewModel() {
+
+    data class KeySource(
+            val isInMemory: Boolean,
+            val isInQuadS: Boolean
+    )
 
     companion object {
         const val NAVIGATE_TO_RECOVER_WITH_KEY = "NAVIGATE_TO_RECOVER_WITH_KEY"
         const val NAVIGATE_TO_SUCCESS = "NAVIGATE_TO_SUCCESS"
+        const val NAVIGATE_TO_4S = "NAVIGATE_TO_4S"
+        const val NAVIGATE_FAILED_TO_LOAD_4S = "NAVIGATE_FAILED_TO_LOAD_4S"
     }
 
     lateinit var session: Session
 
     var keyVersionResult: MutableLiveData<KeysVersionResult> = MutableLiveData()
+
+    var keySourceModel: MutableLiveData<KeySource> = MutableLiveData()
 
     private var _keyVersionResultError: MutableLiveData<LiveEvent<String>> = MutableLiveData()
     val keyVersionResultError: LiveData<LiveEvent<String>>
@@ -62,30 +84,187 @@ class KeysBackupRestoreSharedViewModel @Inject constructor() : ViewModel() {
         this.session = session
     }
 
-    fun getLatestVersion(context: Context) {
-        val keysBackup = session.cryptoService().keysBackupService()
-
-        loadingEvent.value = WaitingViewData(context.getString(R.string.keys_backup_restore_is_getting_backup_version))
-
-        keysBackup.getCurrentVersion(object : MatrixCallback<KeysVersionResult?> {
-            override fun onSuccess(data: KeysVersionResult?) {
-                loadingEvent.value = null
-                if (data?.version.isNullOrBlank()) {
-                    // should not happen
-                    _keyVersionResultError.value = LiveEvent(context.getString(R.string.keys_backup_get_version_error, ""))
-                } else {
-                    keyVersionResult.value = data
+    val progressObserver = object : StepProgressListener {
+        override fun onStepProgress(step: StepProgressListener.Step) {
+            when (step) {
+                is StepProgressListener.Step.ComputingKey   -> {
+                    loadingEvent.postValue(WaitingViewData(stringProvider.getString(R.string.keys_backup_restoring_waiting_message)
+                            + "\n" + stringProvider.getString(R.string.keys_backup_restoring_computing_key_waiting_message),
+                            step.progress,
+                            step.total))
+                }
+                is StepProgressListener.Step.DownloadingKey -> {
+                    loadingEvent.postValue(WaitingViewData(stringProvider.getString(R.string.keys_backup_restoring_waiting_message)
+                            + "\n" + stringProvider.getString(R.string.keys_backup_restoring_downloading_backup_waiting_message),
+                            isIndeterminate = true))
+                }
+                is StepProgressListener.Step.ImportingKey   -> {
+                    Timber.d("backupKeys.ImportingKey.progress: ${step.progress}")
+                    // Progress 0 can take a while, display an indeterminate progress in this case
+                    if (step.progress == 0) {
+                        loadingEvent.postValue(WaitingViewData(stringProvider.getString(R.string.keys_backup_restoring_waiting_message)
+                                + "\n" + stringProvider.getString(R.string.keys_backup_restoring_importing_keys_waiting_message),
+                                isIndeterminate = true))
+                    } else {
+                        loadingEvent.postValue(WaitingViewData(stringProvider.getString(R.string.keys_backup_restoring_waiting_message)
+                                + "\n" + stringProvider.getString(R.string.keys_backup_restoring_importing_keys_waiting_message),
+                                step.progress,
+                                step.total))
+                    }
                 }
             }
+        }
+    }
 
-            override fun onFailure(failure: Throwable) {
-                loadingEvent.value = null
-                _keyVersionResultError.value = LiveEvent(context.getString(R.string.keys_backup_get_version_error, failure.localizedMessage))
+    fun getLatestVersion() {
+        val keysBackup = session.cryptoService().keysBackupService()
 
-                // TODO For network error
-                //  _keyVersionResultError.value = LiveEvent(context.getString(R.string.network_error_please_check_and_retry))
+        loadingEvent.value = WaitingViewData(stringProvider.getString(R.string.keys_backup_restore_is_getting_backup_version))
+
+        viewModelScope.launch(Dispatchers.IO) {
+            try {
+                val version = awaitCallback<KeysVersionResult?> {
+                    keysBackup.getCurrentVersion(it)
+                }
+                if (version?.version == null) {
+                    loadingEvent.postValue(null)
+                    _keyVersionResultError.postValue(LiveEvent(stringProvider.getString(R.string.keys_backup_get_version_error, "")))
+                    return@launch
+                }
+
+                keyVersionResult.postValue(version)
+                // Let's check if there is quads
+                val isBackupKeyInQuadS = isBackupKeyInQuadS()
+
+                val savedSecret = session.cryptoService().keysBackupService().getKeyBackupRecoveryKeyInfo()
+                if (savedSecret != null && savedSecret.version == version.version) {
+                    // key is in memory!
+                    keySourceModel.postValue(
+                            KeySource(isInMemory = true, isInQuadS = true)
+                    )
+                    // Go and use it!!
+                    try {
+                        recoverUsingBackupRecoveryKey(savedSecret.recoveryKey)
+                    } catch (failure: Throwable) {
+                        keySourceModel.postValue(
+                                KeySource(isInMemory = false, isInQuadS = true)
+                        )
+                    }
+                } else if (isBackupKeyInQuadS) {
+                    // key is in QuadS!
+                    keySourceModel.postValue(
+                            KeySource(isInMemory = false, isInQuadS = true)
+                    )
+                    _navigateEvent.postValue(LiveEvent(NAVIGATE_TO_4S))
+                } else {
+                    // we need to restore directly
+                    keySourceModel.postValue(
+                            KeySource(isInMemory = false, isInQuadS = false)
+                    )
+                }
+
+                loadingEvent.postValue(null)
+            } catch (failure: Throwable) {
+                loadingEvent.postValue(null)
+                _keyVersionResultError.postValue(LiveEvent(stringProvider.getString(R.string.keys_backup_get_version_error, failure.localizedMessage)))
             }
-        })
+        }
+    }
+
+    fun handleGotSecretFromSSSS(cipherData: String, alias: String) {
+        try {
+            cipherData.fromBase64().inputStream().use { ins ->
+                val res = session.loadSecureSecret<Map<String, String>>(ins, alias)
+                val secret = res?.get(KEYBACKUP_SECRET_SSSS_NAME)
+                if (secret == null) {
+                    _navigateEvent.postValue(
+                            LiveEvent(NAVIGATE_FAILED_TO_LOAD_4S)
+                    )
+                    return
+                }
+                loadingEvent.value = WaitingViewData(stringProvider.getString(R.string.keys_backup_restore_is_getting_backup_version))
+
+                viewModelScope.launch(Dispatchers.IO) {
+                    try {
+                        recoverUsingBackupRecoveryKey(computeRecoveryKey(secret.fromBase64()))
+                    } catch (failure: Throwable) {
+                        _navigateEvent.postValue(
+                                LiveEvent(NAVIGATE_FAILED_TO_LOAD_4S)
+                        )
+                    }
+                }
+            }
+        } catch (failure: Throwable) {
+        }
+    }
+
+    suspend fun recoverUsingBackupPass(passphrase: String) {
+        val keysBackup = session.cryptoService().keysBackupService()
+        val keyVersion = keyVersionResult.value ?: return
+
+        loadingEvent.postValue(WaitingViewData(stringProvider.getString(R.string.loading)))
+
+        try {
+            val result = awaitCallback<ImportRoomKeysResult> {
+                keysBackup.restoreKeyBackupWithPassword(keyVersion,
+                        passphrase,
+                        null,
+                        session.myUserId,
+                        progressObserver,
+                        it
+                )
+            }
+            loadingEvent.postValue(null)
+            didRecoverSucceed(result)
+            trustOnDecrypt(keysBackup, keyVersion)
+        } catch (failure: Throwable) {
+            throw failure
+        }
+    }
+
+    suspend fun recoverUsingBackupRecoveryKey(recoveryKey: String) {
+        val keysBackup = session.cryptoService().keysBackupService()
+        val keyVersion = keyVersionResult.value ?: return
+
+        loadingEvent.postValue(WaitingViewData(stringProvider.getString(R.string.loading)))
+
+        try {
+            val result = awaitCallback<ImportRoomKeysResult> {
+                keysBackup.restoreKeysWithRecoveryKey(keyVersion,
+                        recoveryKey,
+                        null,
+                        session.myUserId,
+                        progressObserver,
+                        it
+                )
+            }
+            loadingEvent.postValue(null)
+            didRecoverSucceed(result)
+            trustOnDecrypt(keysBackup, keyVersion)
+        } catch (failure: Throwable) {
+            throw failure
+        }
+    }
+
+    private fun isBackupKeyInQuadS(): Boolean {
+        val sssBackupSecret = session.getAccountDataEvent(KEYBACKUP_SECRET_SSSS_NAME)
+                ?: return false
+
+        // Some sanity ?
+        val defaultKeyResult = session.sharedSecretStorageService.getDefaultKey()
+        val keyInfo = (defaultKeyResult as? KeyInfoResult.Success)?.keyInfo
+                ?: return false
+
+        return (sssBackupSecret.content["encrypted"] as? Map<*, *>)?.containsKey(keyInfo.id) == true
+    }
+
+    private fun trustOnDecrypt(keysBackup: KeysBackupService, keysVersionResult: KeysVersionResult) {
+        keysBackup.trustKeysBackupVersion(keysVersionResult, true,
+                object : MatrixCallback<Unit> {
+                    override fun onSuccess(data: Unit) {
+                        Timber.v("##### trustKeysBackupVersion onSuccess")
+                    }
+                })
     }
 
     fun moveToRecoverWithKey() {
@@ -94,6 +273,6 @@ class KeysBackupRestoreSharedViewModel @Inject constructor() : ViewModel() {
 
     fun didRecoverSucceed(result: ImportRoomKeysResult) {
         importKeyResult = result
-        _navigateEvent.value = LiveEvent(NAVIGATE_TO_SUCCESS)
+        _navigateEvent.postValue(LiveEvent(NAVIGATE_TO_SUCCESS))
     }
 }


### PR DESCRIPTION
Fixes #1163
Keybackup created by bootstrapping could not be restored from riotX.


With this PR, on tapping restore backup, we will check:
- If the secret has been gossiped, and in this case automatically load keys
- If the secret is in SSSS, in this case ask for the 4S passphrase to get backup key and restore
- if none of above, ask directly for the backup passphrase/key

=> We need to open issues for when user tries to delete backup (to clean 4S), as well as when user creates a backup when SSSS is enabled