### PR TITLE
 Hide Use recovery key when 4S is not setup

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,7 @@ Improvements 🙌:
  - Emoji Verification | It's not the same butterfly! (#1220)
  - Cross-Signing | Composer decoration: shields (#1077)
  - Cross-Signing | Migrate existing keybackup to cross signing with 4S from mobile (#1197)
+ - Cross-Signing | Hide Use recovery key when 4S is not setup (#1007)
 
 Bugfix 🐛:
  - Fix summary notification staying after "mark as read"

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/secrets/DefaultSharedSecretStorageService.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/secrets/DefaultSharedSecretStorageService.kt
@@ -419,7 +419,7 @@ internal class DefaultSharedSecretStorageService @Inject constructor(
                 ?: return IntegrityResult.Error(SharedSecretStorageError.UnknownKey(keyId ?: ""))
 
         if (keyInfo.content.algorithm != SSSS_ALGORITHM_AES_HMAC_SHA2
-                || keyInfo.content.algorithm != SSSS_ALGORITHM_CURVE25519_AES_SHA2) {
+                && keyInfo.content.algorithm != SSSS_ALGORITHM_CURVE25519_AES_SHA2) {
             // Unsupported algorithm
             return IntegrityResult.Error(
                     SharedSecretStorageError.UnsupportedAlgorithm(keyInfo.content.algorithm ?: "")

--- a/vector/src/main/java/im/vector/riotx/features/crypto/verification/VerificationBottomSheetViewModel.kt
+++ b/vector/src/main/java/im/vector/riotx/features/crypto/verification/VerificationBottomSheetViewModel.kt
@@ -44,6 +44,7 @@ import im.vector.matrix.android.api.session.crypto.verification.VerificationTran
 import im.vector.matrix.android.api.session.crypto.verification.VerificationTxState
 import im.vector.matrix.android.api.session.events.model.LocalEcho
 import im.vector.matrix.android.api.session.room.model.create.CreateRoomParams
+import im.vector.matrix.android.api.session.securestorage.IntegrityResult
 import im.vector.matrix.android.api.util.MatrixItem
 import im.vector.matrix.android.api.util.toMatrixItem
 import im.vector.matrix.android.internal.crypto.crosssigning.fromBase64
@@ -73,7 +74,8 @@ data class VerificationBottomSheetViewState(
         val isMe: Boolean = false,
         val currentDeviceCanCrossSign: Boolean = false,
         val userWantsToCancel: Boolean = false,
-        val userThinkItsNotHim: Boolean = false
+        val userThinkItsNotHim: Boolean = false,
+        val quadSContainsSecrets: Boolean = true
 ) : MvRxState
 
 class VerificationBottomSheetViewModel @AssistedInject constructor(
@@ -116,6 +118,10 @@ class VerificationBottomSheetViewModel @AssistedInject constructor(
             session.cryptoService().verificationService().getExistingTransaction(args.otherUserId, it) as? QrCodeVerificationTransaction
         }
 
+        val ssssOk = session.sharedSecretStorageService.checkShouldBeAbleToAccessSecrets(
+                listOf(MASTER_KEY_SSSS_NAME, USER_SIGNING_KEY_SSSS_NAME, SELF_SIGNING_KEY_SSSS_NAME),
+                null // default key
+        ) is IntegrityResult.Success
         setState {
             copy(
                     otherUserMxItem = userItem?.toMatrixItem(),
@@ -126,7 +132,8 @@ class VerificationBottomSheetViewModel @AssistedInject constructor(
                     selfVerificationMode = selfVerificationMode,
                     roomId = args.roomId,
                     isMe = args.otherUserId == session.myUserId,
-                    currentDeviceCanCrossSign = session.cryptoService().crossSigningService().canCrossSign()
+                    currentDeviceCanCrossSign = session.cryptoService().crossSigningService().canCrossSign(),
+                    quadSContainsSecrets = ssssOk
             )
         }
 

--- a/vector/src/main/java/im/vector/riotx/features/crypto/verification/request/VerificationRequestController.kt
+++ b/vector/src/main/java/im/vector/riotx/features/crypto/verification/request/VerificationRequestController.kt
@@ -65,14 +65,16 @@ class VerificationRequestController @Inject constructor(
                 title(stringProvider.getString(R.string.verification_request_waiting, matrixItem.getBestName()))
             }
 
-            bottomSheetVerificationActionItem {
-                id("passphrase")
-                title(stringProvider.getString(R.string.verification_cannot_access_other_session))
-                titleColor(colorProvider.getColorFromAttribute(R.attr.riotx_text_primary))
-                subTitle(stringProvider.getString(R.string.verification_use_passphrase))
-                iconRes(R.drawable.ic_arrow_right)
-                iconColor(colorProvider.getColorFromAttribute(R.attr.riotx_text_primary))
-                listener { listener?.onClickRecoverFromPassphrase() }
+            if (state.quadSContainsSecrets) {
+                bottomSheetVerificationActionItem {
+                    id("passphrase")
+                    title(stringProvider.getString(R.string.verification_cannot_access_other_session))
+                    titleColor(colorProvider.getColorFromAttribute(R.attr.riotx_text_primary))
+                    subTitle(stringProvider.getString(R.string.verification_use_passphrase))
+                    iconRes(R.drawable.ic_arrow_right)
+                    iconColor(colorProvider.getColorFromAttribute(R.attr.riotx_text_primary))
+                    listener { listener?.onClickRecoverFromPassphrase() }
+                }
             }
         } else {
             val styledText =


### PR DESCRIPTION
Fixes #1007 Cross-Signing | Hide Use recovery key when 4S is not setup 
