### PR TITLE
Remember ignored unknown sessions

### DIFF
--- a/vector/src/main/java/im/vector/riotx/features/home/HomeDetailFragment.kt
+++ b/vector/src/main/java/im/vector/riotx/features/home/HomeDetailFragment.kt
@@ -1,4 +1,3 @@
-
 /*
  * Copyright 2019 New Vector Ltd
  *
@@ -61,7 +60,7 @@ class HomeDetailFragment @Inject constructor(
     private val unreadCounterBadgeViews = arrayListOf<UnreadCounterBadgeView>()
 
     private val viewModel: HomeDetailViewModel by fragmentViewModel()
-    private val unknownDeviceDetectorSharedViewModel : UnknownDeviceDetectorSharedViewModel by activityViewModel()
+    private val unknownDeviceDetectorSharedViewModel: UnknownDeviceDetectorSharedViewModel by activityViewModel()
 
     private lateinit var sharedActionViewModel: HomeSharedActionViewModel
 
@@ -112,7 +111,11 @@ class HomeDetailFragment @Inject constructor(
                                             ?.navigator
                                             ?.requestSessionVerification(requireContext(), newest.deviceId ?: "")
                                 }
-                                dismissedAction = Runnable {}
+                                dismissedAction = Runnable {
+                                    unknownDeviceDetectorSharedViewModel.handle(
+                                            UnknownDeviceDetectorSharedViewModel.Action.IgnoreDevice(newest.deviceId ?: "")
+                                    )
+                                }
                             }
                     )
                 }

--- a/vector/src/main/java/im/vector/riotx/features/settings/VectorPreferences.kt
+++ b/vector/src/main/java/im/vector/riotx/features/settings/VectorPreferences.kt
@@ -24,6 +24,7 @@ import android.provider.MediaStore
 import androidx.core.content.edit
 import androidx.preference.PreferenceManager
 import com.squareup.seismic.ShakeDetector
+import im.vector.matrix.android.api.extensions.tryThis
 import im.vector.riotx.BuildConfig
 import im.vector.riotx.R
 import im.vector.riotx.features.homeserver.ServerUrlsRepository
@@ -165,6 +166,8 @@ class VectorPreferences @Inject constructor(private val context: Context) {
         private const val MEDIA_SAVING_1_WEEK = 1
         private const val MEDIA_SAVING_1_MONTH = 2
         private const val MEDIA_SAVING_FOREVER = 3
+
+        private const val SETTINGS_UNKNOWN_DEVICE_DISMISSED_LIST = "SETTINGS_UNKNWON_DEVICE_DISMISSED_LIST"
 
         // some preferences keys must be kept after a logout
         private val mKeysToKeepAfterLogout = listOf(
@@ -362,6 +365,18 @@ class VectorPreferences @Inject constructor(private val context: Context) {
      */
     fun useShutterSound(): Boolean {
         return defaultPrefs.getBoolean(SETTINGS_PLAY_SHUTTER_SOUND_KEY, true)
+    }
+
+    fun storeUnknownDeviceDismissedList(deviceIds: List<String>) {
+        defaultPrefs.edit(true) {
+            putStringSet(SETTINGS_UNKNOWN_DEVICE_DISMISSED_LIST, deviceIds.toSet())
+        }
+    }
+
+    fun getUnknownDeviceDismissedList(): List<String> {
+        return tryThis {
+            defaultPrefs.getStringSet(SETTINGS_UNKNOWN_DEVICE_DISMISSED_LIST, null)?.toList()
+        } ?: emptyList()
     }
 
     /**


### PR DESCRIPTION
Currently 'unknown device security notice' will keep poping up even if you dismissed it.
This PR will fix that, once dismissed it wont show + it will remember it also for next login.

-> Now users have to go to Security&Privacy to verify a session if the alert was dismissed

-- This will need some re-work, and a cross platform strategy. This PR is a quick change to avoid annoying users indefinitly (also given that some clients -old riot- cannot complete this flow)
