### PR TITLE
Several fixes on room creation collpasing events (Fixes #1309)

### DIFF
--- a/matrix-sdk-android/src/main/res/values/strings.xml
+++ b/matrix-sdk-android/src/main/res/values/strings.xml
@@ -7,8 +7,8 @@
     <string name="notice_room_invite_no_invitee">%s\'s invitation</string>
     <string name="notice_room_invite">%1$s invited %2$s</string>
     <string name="notice_room_invite_you">%1$s invited you</string>
-    <string name="notice_room_join">%1$s joined</string>
-    <string name="notice_room_leave">%1$s left</string>
+    <string name="notice_room_join">%1$s joined the room</string>
+    <string name="notice_room_leave">%1$s left the room</string>
     <string name="notice_room_reject">%1$s rejected the invitation</string>
     <string name="notice_room_kick">%1$s kicked %2$s</string>
     <string name="notice_room_unban">%1$s unbanned %2$s</string>
@@ -246,8 +246,8 @@
     <string name="notice_room_invite_no_invitee_with_reason">%1$s\'s invitation. Reason: %2$s</string>
     <string name="notice_room_invite_with_reason">%1$s invited %2$s. Reason: %3$s</string>
     <string name="notice_room_invite_you_with_reason">%1$s invited you. Reason: %2$s</string>
-    <string name="notice_room_join_with_reason">%1$s joined. Reason: %2$s</string>
-    <string name="notice_room_leave_with_reason">%1$s left. Reason: %2$s</string>
+    <string name="notice_room_join_with_reason">%1$s joined the room. Reason: %2$s</string>
+    <string name="notice_room_leave_with_reason">%1$s left the room. Reason: %2$s</string>
     <string name="notice_room_reject_with_reason">%1$s rejected the invitation. Reason: %2$s</string>
     <string name="notice_room_kick_with_reason">%1$s kicked %2$s. Reason: %3$s</string>
     <string name="notice_room_unban_with_reason">%1$s unbanned %2$s. Reason: %3$s</string>

--- a/vector/src/main/java/im/vector/riotx/features/home/room/detail/timeline/helper/TimelineDisplayableEvents.kt
+++ b/vector/src/main/java/im/vector/riotx/features/home/room/detail/timeline/helper/TimelineDisplayableEvents.kt
@@ -50,14 +50,23 @@ fun TimelineEvent.canBeMerged(): Boolean {
     return root.getClearType() == EventType.STATE_ROOM_MEMBER
 }
 
-fun TimelineEvent.isRoomConfiguration(): Boolean {
+fun TimelineEvent.isRoomConfiguration(roomCreatorUserId: String?): Boolean {
     return when (root.getClearType()) {
         EventType.STATE_ROOM_GUEST_ACCESS,
         EventType.STATE_ROOM_HISTORY_VISIBILITY,
         EventType.STATE_ROOM_JOIN_RULES,
-        EventType.STATE_ROOM_MEMBER,
         EventType.STATE_ROOM_NAME,
+        EventType.STATE_ROOM_TOPIC,
+        EventType.STATE_ROOM_AVATAR,
+        EventType.STATE_ROOM_ALIASES,
+        EventType.STATE_ROOM_CANONICAL_ALIAS,
+        EventType.STATE_ROOM_POWER_LEVELS,
         EventType.STATE_ROOM_ENCRYPTION -> true
+        EventType.STATE_ROOM_MEMBER     -> {
+            // Keep only room member events regarding the room creator (when he joined the room),
+            // but exclude events where the room creator invite others, or where others join
+            roomCreatorUserId != null && root.stateKey == roomCreatorUserId
+        }
         else                            -> false
     }
 }

--- a/vector/src/main/java/im/vector/riotx/features/home/room/detail/timeline/item/MergedRoomCreationItem.kt
+++ b/vector/src/main/java/im/vector/riotx/features/home/room/detail/timeline/item/MergedRoomCreationItem.kt
@@ -43,7 +43,8 @@ abstract class MergedRoomCreationItem : BasedMergedItem<MergedRoomCreationItem.H
         super.bind(holder)
 
         if (attributes.isCollapsed) {
-            val data = distinctMergeData.firstOrNull()
+            // Take the oldest data
+            val data = distinctMergeData.lastOrNull()
 
             val summary = holder.expandView.resources.getString(R.string.room_created_summary_item,
                     data?.memberName ?: data?.userId ?: "")


### PR DESCRIPTION
#1309

- do not collapse room member events
- collapse other type of event: topic, alias, canonical alias, powel level
- Use correct user name for collapsed version (should be fixed twice due to the previous change of excluding some room member events)
- align "join" and "left" string with Riot-Web

<img width="359" alt="image" src="https://user-images.githubusercontent.com/3940906/80702567-94fb6700-8ae1-11ea-8b76-4832be563a6a.png">

<img width="366" alt="image" src="https://user-images.githubusercontent.com/3940906/80702595-9e84cf00-8ae1-11ea-98a9-675367462219.png">

With encryption:

<img width="362" alt="image" src="https://user-images.githubusercontent.com/3940906/80702715-caa05000-8ae1-11ea-9cd9-d4394a3a3816.png">

<img width="353" alt="image" src="https://user-images.githubusercontent.com/3940906/80702741-d429b800-8ae1-11ea-87cb-e90c9affee55.png">

