### PR TITLE
Add direct shortcuts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@ Changes in RiotX 0.20.0 (2020-XX-XX)
 ===================================================
 
 Features ✨:
- -
+ - Add Direct Shortcuts
 
 Improvements 🙌:
  -

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@ Changes in RiotX 0.20.0 (2020-XX-XX)
 ===================================================
 
 Features ✨:
- - Add Direct Shortcuts
+ - Add Direct Shortcuts (#652)
 
 Improvements 🙌:
  -

--- a/vector/src/main/java/im/vector/riotx/features/home/AvatarRenderer.kt
+++ b/vector/src/main/java/im/vector/riotx/features/home/AvatarRenderer.kt
@@ -17,11 +17,13 @@
 package im.vector.riotx.features.home
 
 import android.content.Context
+import android.graphics.Bitmap
 import android.graphics.drawable.Drawable
 import android.widget.ImageView
 import androidx.annotation.AnyThread
 import androidx.annotation.UiThread
 import androidx.core.content.ContextCompat
+import androidx.core.graphics.drawable.toBitmap
 import com.amulyakhare.textdrawable.TextDrawable
 import com.bumptech.glide.request.RequestOptions
 import com.bumptech.glide.request.target.DrawableImageViewTarget
@@ -73,9 +75,9 @@ class AvatarRenderer @Inject constructor(private val activeSessionHolder: Active
     }
 
     @AnyThread
-    fun shortcutDrawable(context: Context, glideRequest: GlideRequests, matrixItem: MatrixItem): Drawable {
+    fun shortcutDrawable(context: Context, glideRequest: GlideRequests, matrixItem: MatrixItem, iconSize: Int): Bitmap {
         return glideRequest
-                .asDrawable()
+                .asBitmap()
                 .apply {
                     val resolvedUrl = resolvedUrl(matrixItem.avatarUrl)
                     if (resolvedUrl != null) {
@@ -86,10 +88,11 @@ class AvatarRenderer @Inject constructor(private val activeSessionHolder: Active
                                 .beginConfig()
                                 .bold()
                                 .endConfig()
-                                .buildRect(matrixItem.firstLetterOfDisplayName(), avatarColor))
+                                .buildRect(matrixItem.firstLetterOfDisplayName(), avatarColor)
+                                .toBitmap(width = iconSize, height = iconSize))
                     }
                 }
-                .submit()
+                .submit(iconSize, iconSize)
                 .get()
     }
 
@@ -103,10 +106,7 @@ class AvatarRenderer @Inject constructor(private val activeSessionHolder: Active
 
     @AnyThread
     fun getPlaceholderDrawable(context: Context, matrixItem: MatrixItem): Drawable {
-        val avatarColor = when (matrixItem) {
-            is MatrixItem.UserItem -> ContextCompat.getColor(context, getColorFromUserId(matrixItem.id))
-            else                   -> ContextCompat.getColor(context, getColorFromRoomId(matrixItem.id))
-        }
+        val avatarColor = avatarColor(matrixItem, context)
         return TextDrawable.builder()
                 .beginConfig()
                 .bold()
@@ -117,9 +117,7 @@ class AvatarRenderer @Inject constructor(private val activeSessionHolder: Active
     // PRIVATE API *********************************************************************************
 
     private fun buildGlideRequest(glideRequest: GlideRequests, avatarUrl: String?): GlideRequest<Drawable> {
-        val resolvedUrl = activeSessionHolder.getSafeActiveSession()?.contentUrlResolver()
-                ?.resolveThumbnail(avatarUrl, THUMBNAIL_SIZE, THUMBNAIL_SIZE, ContentUrlResolver.ThumbnailMethod.SCALE)
-
+        val resolvedUrl = resolvedUrl(avatarUrl)
         return glideRequest
                 .load(resolvedUrl)
                 .apply(RequestOptions.circleCropTransform())

--- a/vector/src/main/java/im/vector/riotx/features/home/HomeActivity.kt
+++ b/vector/src/main/java/im/vector/riotx/features/home/HomeActivity.kt
@@ -65,6 +65,7 @@ class HomeActivity : VectorBaseActivity(), ToolbarConfigurable {
     @Inject lateinit var notificationDrawerManager: NotificationDrawerManager
     @Inject lateinit var vectorPreferences: VectorPreferences
     @Inject lateinit var popupAlertManager: PopupAlertManager
+    @Inject lateinit var shortcutsHandler: ShortcutsHandler
 
     private val drawerListener = object : DrawerLayout.SimpleDrawerListener() {
         override fun onDrawerStateChanged(newState: Int) {
@@ -144,6 +145,8 @@ class HomeActivity : VectorBaseActivity(), ToolbarConfigurable {
                 && activeSessionHolder.getSafeActiveSession()?.hasAlreadySynced() == true) {
             promptCompleteSecurityIfNeeded()
         }
+
+        shortcutsHandler.observeRoomsAndBuildShortcuts(context = this)
     }
 
     private fun promptCompleteSecurityIfNeeded() {

--- a/vector/src/main/java/im/vector/riotx/features/home/HomeActivity.kt
+++ b/vector/src/main/java/im/vector/riotx/features/home/HomeActivity.kt
@@ -146,7 +146,8 @@ class HomeActivity : VectorBaseActivity(), ToolbarConfigurable {
             promptCompleteSecurityIfNeeded()
         }
 
-        shortcutsHandler.observeRoomsAndBuildShortcuts(context = this)
+        shortcutsHandler.observeRoomsAndBuildShortcuts()
+                .disposeOnDestroy()
     }
 
     private fun promptCompleteSecurityIfNeeded() {

--- a/vector/src/main/java/im/vector/riotx/features/home/HomeDetailViewModel.kt
+++ b/vector/src/main/java/im/vector/riotx/features/home/HomeDetailViewModel.kt
@@ -16,7 +16,6 @@
 
 package im.vector.riotx.features.home
 
-import androidx.core.content.pm.ShortcutInfoCompat
 import com.airbnb.mvrx.FragmentViewModelContext
 import com.airbnb.mvrx.MvRxViewModelFactory
 import com.airbnb.mvrx.ViewModelContext

--- a/vector/src/main/java/im/vector/riotx/features/home/HomeDetailViewModel.kt
+++ b/vector/src/main/java/im/vector/riotx/features/home/HomeDetailViewModel.kt
@@ -16,6 +16,7 @@
 
 package im.vector.riotx.features.home
 
+import androidx.core.content.pm.ShortcutInfoCompat
 import com.airbnb.mvrx.FragmentViewModelContext
 import com.airbnb.mvrx.MvRxViewModelFactory
 import com.airbnb.mvrx.ViewModelContext

--- a/vector/src/main/java/im/vector/riotx/features/home/ShortcutsHandler.kt
+++ b/vector/src/main/java/im/vector/riotx/features/home/ShortcutsHandler.kt
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2020 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.riotx.features.home
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.drawable.Drawable
+import android.os.Build
+import androidx.core.content.pm.ShortcutInfoCompat
+import androidx.core.content.pm.ShortcutManagerCompat
+import androidx.core.graphics.drawable.IconCompat
+import im.vector.matrix.android.api.session.room.model.RoomSummary
+import im.vector.matrix.android.api.session.room.model.tag.RoomTag
+import im.vector.matrix.android.api.util.toMatrixItem
+import im.vector.riotx.core.glide.GlideApp
+import im.vector.riotx.core.utils.DimensionConverter
+import im.vector.riotx.features.home.room.detail.RoomDetailActivity
+import io.reactivex.schedulers.Schedulers
+import javax.inject.Inject
+
+private val useAdaptiveIcon = Build.VERSION.SDK_INT >= Build.VERSION_CODES.O
+private const val adaptiveIconSizeDp = 108
+private const val adaptiveIconOuterSidesDp = 18
+
+class ShortcutsHandler @Inject constructor(
+        private val homeRoomListStore: HomeRoomListDataSource,
+        private val avatarRenderer: AvatarRenderer,
+        private val dimensionConverter: DimensionConverter
+) {
+
+    @SuppressLint("CheckResult")
+    fun observeRoomsAndBuildShortcuts(context: Context) {
+        homeRoomListStore
+                .observe()
+                .observeOn(Schedulers.computation())
+                .subscribe { rooms ->
+                    val shortcuts = rooms
+                            .favoriteRooms()
+                            .map { room ->
+                                val intent = RoomDetailActivity.shortcutIntent(context, room.roomId)
+                                val drawable = avatarRenderer.shortcutDrawable(context, GlideApp.with(context), room.toMatrixItem())
+
+                                ShortcutInfoCompat.Builder(context, room.roomId)
+                                        .setShortLabel(room.displayName)
+                                        .setIcon(drawable.toProfileImageIcon())
+                                        .setIntent(intent)
+                                        .build()
+                            }
+
+                    ShortcutManagerCompat.removeAllDynamicShortcuts(context)
+                    ShortcutManagerCompat.addDynamicShortcuts(context, shortcuts)
+                }
+    }
+
+    // PRIVATE API *********************************************************************************
+
+    private fun List<RoomSummary>.favoriteRooms(): List<RoomSummary> {
+        return filter { room -> room.tags.any { it.name == RoomTag.ROOM_TAG_FAVOURITE } }
+                .take(n = 4) // Android only allows us to create 4 shortcuts
+    }
+
+    private fun Drawable.toProfileImageIcon(): IconCompat {
+        val adaptiveIconSize = dimensionConverter.dpToPx(adaptiveIconSizeDp)
+        val adaptiveIconOuterSides = dimensionConverter.dpToPx(adaptiveIconOuterSidesDp)
+
+        val bitmap = Bitmap.createBitmap(adaptiveIconSize, adaptiveIconSize, Bitmap.Config.ARGB_8888)
+        val canvas = Canvas(bitmap)
+
+        return if (useAdaptiveIcon) {
+            setBounds(adaptiveIconOuterSides, adaptiveIconOuterSides, adaptiveIconSize - adaptiveIconOuterSides, adaptiveIconSize - adaptiveIconOuterSides)
+            draw(canvas)
+
+            IconCompat.createWithAdaptiveBitmap(bitmap)
+        } else {
+            setBounds(0, 0, bitmap.width, bitmap.height)
+            draw(canvas)
+
+            IconCompat.createWithBitmap(bitmap)
+        }
+    }
+}

--- a/vector/src/main/java/im/vector/riotx/features/home/room/detail/RoomDetailActivity.kt
+++ b/vector/src/main/java/im/vector/riotx/features/home/room/detail/RoomDetailActivity.kt
@@ -44,8 +44,14 @@ class RoomDetailActivity : VectorBaseActivity(), ToolbarConfigurable {
         super.onCreate(savedInstanceState)
         waitingView = waiting_view
         if (isFirstCreation()) {
-            val roomDetailArgs: RoomDetailArgs = intent?.extras?.getParcelable(EXTRA_ROOM_DETAIL_ARGS)
-                    ?: return
+            val roomDetailArgs: RoomDetailArgs? = if (intent?.action == ACTION_ROOM_DETAILS_FROM_SHORTCUT) {
+                RoomDetailArgs(roomId = intent?.extras?.getString(EXTRA_ROOM_ID)!!)
+            } else {
+                intent?.extras?.getParcelable(EXTRA_ROOM_DETAIL_ARGS)
+            }
+
+            if (roomDetailArgs == null) return
+
             currentRoomId = roomDetailArgs.roomId
             replaceFragment(R.id.roomDetailContainer, RoomDetailFragment::class.java, roomDetailArgs)
             replaceFragment(R.id.roomDetailDrawerContainer, BreadcrumbsFragment::class.java)
@@ -110,10 +116,19 @@ class RoomDetailActivity : VectorBaseActivity(), ToolbarConfigurable {
     companion object {
 
         const val EXTRA_ROOM_DETAIL_ARGS = "EXTRA_ROOM_DETAIL_ARGS"
+        const val EXTRA_ROOM_ID = "EXTRA_ROOM_ID"
+        const val ACTION_ROOM_DETAILS_FROM_SHORTCUT = "ROOM_DETAILS_FROM_SHORTCUT"
 
         fun newIntent(context: Context, roomDetailArgs: RoomDetailArgs): Intent {
             return Intent(context, RoomDetailActivity::class.java).apply {
                 putExtra(EXTRA_ROOM_DETAIL_ARGS, roomDetailArgs)
+            }
+        }
+
+        fun shortcutIntent(context: Context, roomId: String): Intent {
+            return Intent(context, RoomDetailActivity::class.java).apply {
+                action = ACTION_ROOM_DETAILS_FROM_SHORTCUT
+                putExtra(EXTRA_ROOM_ID, roomId)
             }
         }
     }


### PR DESCRIPTION
### Pull Request Checklist

👋 Hello! I started using Riot recently and found myself missing having direct shortcuts, so I added them. Fixes #652.

I kept it simple and just allow creating shortcuts from rooms which have been favourited. Android restricts the number of shortcuts you can have to 4, so this seemed like a reasonable thing to do!

I wasn't sure the best place to trigger the creation of the shortcuts - so I decided to do so in home. So when the user opens the app, we'll subscribe and start listening for room changes, and update the available shortcuts as needed. 

Tested on a Pixel 1 running Android 9.x. I've tried to get it going on an Android 6.x or 7.x emulators, but I couldn't get the app installing. Hardware acceleration isn't available on the older emulators, and installing the app just times out 😭. I've used the AndroidX backwards compatible implementation, so that should take care of the earlier versions.

Here's how it looks to set some shortcuts up - I've tested with rooms which do and don't have images:

| add shortcut dialog | example shortcuts  |
|---|---|
| ![device-2020-05-09-205940](https://user-images.githubusercontent.com/1143801/81483706-0d77cb80-9238-11ea-9687-665f136199de.png) | ![device-2020-05-09-205607](https://user-images.githubusercontent.com/1143801/81483712-15377000-9238-11ea-93a2-94f2d90619c9.png) |

- [x] Pull request is based on the develop branch
- [x] Pull request updates [CHANGES.md](https://github.com/vector-im/riotX-android/blob/develop/CHANGES.md)
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
