### PR TITLE
Better connectivity lost indicator when airplane mode is on

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@ Features ✨:
  -
 
 Improvements 🙌:
- -
+ - Better connectivity lost indicator when airplane mode is on
 
 Bugfix 🐛:
  -

--- a/vector/src/main/java/im/vector/riotx/core/utils/SystemUtils.kt
+++ b/vector/src/main/java/im/vector/riotx/core/utils/SystemUtils.kt
@@ -53,6 +53,10 @@ fun isIgnoringBatteryOptimizations(context: Context): Boolean {
             || (context.getSystemService(Context.POWER_SERVICE) as PowerManager?)?.isIgnoringBatteryOptimizations(context.packageName) == true
 }
 
+fun isAirplaneModeOn(context: Context): Boolean {
+    return Settings.Global.getInt(context.contentResolver, Settings.Global.AIRPLANE_MODE_ON, 0) != 0
+}
+
 /**
  * display the system dialog for granting this permission. If previously granted, the
  * system will not show it (so you should call this method).

--- a/vector/src/main/java/im/vector/riotx/features/sync/widget/SyncStateView.kt
+++ b/vector/src/main/java/im/vector/riotx/features/sync/widget/SyncStateView.kt
@@ -23,6 +23,7 @@ import android.widget.FrameLayout
 import androidx.core.view.isVisible
 import im.vector.matrix.android.api.session.sync.SyncState
 import im.vector.riotx.R
+import im.vector.riotx.core.utils.isAirplaneModeOn
 import kotlinx.android.synthetic.main.view_sync_state.view.*
 
 class SyncStateView @JvmOverloads constructor(context: Context, attrs: AttributeSet? = null, defStyle: Int = 0)
@@ -33,10 +34,15 @@ class SyncStateView @JvmOverloads constructor(context: Context, attrs: Attribute
     }
 
     fun render(newState: SyncState) {
-        syncStateProgressBar.visibility = when (newState) {
-            is SyncState.Running -> if (newState.afterPause) View.VISIBLE else View.GONE
-            else                 -> View.GONE
+        syncStateProgressBar.isVisible = newState is SyncState.Running && newState.afterPause
+
+        if (newState == SyncState.NoNetwork) {
+            val isAirplaneModeOn = isAirplaneModeOn(context)
+            syncStateNoNetwork.isVisible = isAirplaneModeOn.not()
+            syncStateNoNetworkAirplane.isVisible = isAirplaneModeOn
+        } else {
+            syncStateNoNetwork.isVisible = false
+            syncStateNoNetworkAirplane.isVisible = false
         }
-        syncStateNoNetwork.isVisible = newState == SyncState.NoNetwork
     }
 }

--- a/vector/src/main/res/layout/view_sync_state.xml
+++ b/vector/src/main/res/layout/view_sync_state.xml
@@ -33,6 +33,19 @@
         android:text="@string/no_connectivity_to_the_server_indicator"
         android:textColor="@color/white"
         android:visibility="gone"
+        tools:layout_marginTop="10dp"
+        tools:visibility="visible" />
+
+    <TextView
+        android:id="@+id/syncStateNoNetworkAirplane"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/notification_accent_color"
+        android:gravity="center"
+        android:text="@string/no_connectivity_to_the_server_indicator_airplane"
+        android:textColor="@color/white"
+        android:visibility="gone"
+        tools:layout_marginTop="10dp"
         tools:visibility="visible" />
 
 </merge>

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -2163,6 +2163,7 @@ Not all features in Riot are implemented in RiotX yet. Main missing (and coming 
     <string name="qr_code_scanned_by_other_no">No</string>
 
     <string name="no_connectivity_to_the_server_indicator">Connectivity to the server has been lost</string>
+    <string name="no_connectivity_to_the_server_indicator_airplane">Airplane mode is on</string>
 
     <string name="settings_dev_tools">Dev Tools</string>
     <string name="settings_account_data">Account Data</string>


### PR DESCRIPTION
Make the message more specific when airplane mode is on (and less 'red' because it's a user decision).
A request has been done to the design team to get an icon, but we can merge this small PR befoer waiting for it.

So when visible, the three possible renderings are (copy pasted from layout preview):

<img width="348" alt="image" src="https://user-images.githubusercontent.com/3940906/82216992-0fb5e600-991a-11ea-8349-da2d8cd90c05.png">

This PR is a quick improvement, it does not handle the case were airplane is set to On, and connectivity to the server was already lost, or airplane mode set to Off, but connectivity to the server cannot be retrieved. The last state will be displayed.

