### PR TITLE
Change icon to magnifying-glass to filter room (#1384)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ Improvements 🙌:
  - Better connectivity lost indicator when airplane mode is on
  - Add a setting to hide redacted events (#951)
  - Render formatted_body for m.notice and m.emote (#1196)
+ - Change icon to magnifying-glass to filter room (#1384)
 
 Bugfix 🐛:
  - After jump to unread, newer messages are never loaded (#1008)

--- a/vector/src/main/res/menu/home.xml
+++ b/vector/src/main/res/menu/home.xml
@@ -14,7 +14,7 @@
 
     <item
         android:id="@+id/menu_home_filter"
-        android:icon="@drawable/ic_filter"
+        android:icon="@drawable/ic_search"
         android:title="@string/home_filter_placeholder_home"
         app:showAsAction="always" />
 


### PR DESCRIPTION
Fixes #1384 

The filtering icon was not clear for some users.

Use the regular magnifying icon

Before:

<img width="407" alt="image" src="https://user-images.githubusercontent.com/3940906/82473930-91e50c80-9aca-11ea-9ea6-b5f3ec56602d.png">

After:

<img width="396" alt="image" src="https://user-images.githubusercontent.com/3940906/82475024-2439e000-9acc-11ea-9f4a-c551bf9c3006.png">

We may in the future have unified search so the icon will be replaced anyway

Note: I keep the filter icon on the other screens, for instance:

<img width="396" alt="image" src="https://user-images.githubusercontent.com/3940906/82473995-a88b6380-9aca-11ea-8e12-d8cde90daa82.png">

