### PR TITLE
Feature/attachment e2e

### DIFF
--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/database/helper/TimelineEventEntityHelper.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/database/helper/TimelineEventEntityHelper.kt
@@ -18,6 +18,7 @@ package im.vector.matrix.android.internal.database.helper
 
 import im.vector.matrix.android.internal.database.model.TimelineEventEntity
 import im.vector.matrix.android.internal.database.model.TimelineEventEntityFields
+import im.vector.matrix.android.internal.extensions.assertIsManaged
 import io.realm.Realm
 
 internal fun TimelineEventEntity.Companion.nextId(realm: Realm): Long {
@@ -27,4 +28,12 @@ internal fun TimelineEventEntity.Companion.nextId(realm: Realm): Long {
     } else {
         currentIdNum.toLong() + 1
     }
+}
+
+internal fun TimelineEventEntity.deleteOnCascade() {
+    assertIsManaged()
+    root?.deleteFromRealm()
+    annotations?.deleteFromRealm()
+    readReceipts?.deleteFromRealm()
+    deleteFromRealm()
 }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/database/query/TimelineEventFilter.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/database/query/TimelineEventFilter.kt
@@ -29,6 +29,13 @@ internal object TimelineEventFilter {
     }
 
     /**
+     * To apply to Event.decryptionResultJson
+     */
+    internal object DecryptedContent {
+        internal const val URL = """{*"file":*"url":*}"""
+    }
+
+    /**
      * To apply to Event.unsigned
      */
     internal object Unsigned {

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/send/SendResponse.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/send/SendResponse.kt
@@ -21,5 +21,8 @@ import com.squareup.moshi.JsonClass
 
 @JsonClass(generateAdapter = true)
 internal data class SendResponse(
+        /**
+         * A unique identifier for the event.
+         */
         @Json(name = "event_id") val eventId: String
 )

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/uploads/DefaultUploadsService.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/uploads/DefaultUploadsService.kt
@@ -19,6 +19,7 @@ package im.vector.matrix.android.internal.session.room.uploads
 import com.squareup.inject.assisted.Assisted
 import com.squareup.inject.assisted.AssistedInject
 import im.vector.matrix.android.api.MatrixCallback
+import im.vector.matrix.android.api.session.crypto.CryptoService
 import im.vector.matrix.android.api.session.room.uploads.GetUploadsResult
 import im.vector.matrix.android.api.session.room.uploads.UploadsService
 import im.vector.matrix.android.api.util.Cancelable
@@ -28,7 +29,8 @@ import im.vector.matrix.android.internal.task.configureWith
 internal class DefaultUploadsService @AssistedInject constructor(
         @Assisted private val roomId: String,
         private val taskExecutor: TaskExecutor,
-        private val getUploadsTask: GetUploadsTask
+        private val getUploadsTask: GetUploadsTask,
+        private val cryptoService: CryptoService
 ) : UploadsService {
 
     @AssistedInject.Factory
@@ -38,7 +40,7 @@ internal class DefaultUploadsService @AssistedInject constructor(
 
     override fun getUploads(numberOfEvents: Int, since: String?, callback: MatrixCallback<GetUploadsResult>): Cancelable {
         return getUploadsTask
-                .configureWith(GetUploadsTask.Params(roomId, numberOfEvents, since)) {
+                .configureWith(GetUploadsTask.Params(roomId, cryptoService.isRoomEncrypted(roomId), numberOfEvents, since)) {
                     this.callback = callback
                 }
                 .executeBy(taskExecutor)

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/uploads/GetUploadsTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/uploads/GetUploadsTask.kt
@@ -22,7 +22,6 @@ import im.vector.matrix.android.api.session.events.model.EventType
 import im.vector.matrix.android.api.session.events.model.toModel
 import im.vector.matrix.android.api.session.room.model.message.MessageContent
 import im.vector.matrix.android.api.session.room.model.message.MessageWithAttachmentContent
-import im.vector.matrix.android.api.session.room.send.SendState
 import im.vector.matrix.android.api.session.room.sender.SenderInfo
 import im.vector.matrix.android.api.session.room.uploads.GetUploadsResult
 import im.vector.matrix.android.api.session.room.uploads.UploadEvent
@@ -76,8 +75,6 @@ internal class DefaultGetUploadsTask @Inject constructor(
             monarchy.doWithRealm { realm ->
                 eventsFromRealm = EventEntity.whereType(realm, EventType.ENCRYPTED, params.roomId)
                         .like(EventEntityFields.DECRYPTION_RESULT_JSON, TimelineEventFilter.DecryptedContent.URL)
-                        // FIXME Send event are stored twice in the DB. This is not normal. Keep only synced events
-                        .like(EventEntityFields.SEND_STATE_STR, SendState.SYNCED.name)
                         .findAll()
                         .map { it.asDomain() }
                         // Exclude stickers

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/uploads/GetUploadsTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/uploads/GetUploadsTask.kt
@@ -17,12 +17,20 @@
 package im.vector.matrix.android.internal.session.room.uploads
 
 import com.zhuinden.monarchy.Monarchy
+import im.vector.matrix.android.api.session.events.model.Event
+import im.vector.matrix.android.api.session.events.model.EventType
 import im.vector.matrix.android.api.session.events.model.toModel
 import im.vector.matrix.android.api.session.room.model.message.MessageContent
 import im.vector.matrix.android.api.session.room.model.message.MessageWithAttachmentContent
+import im.vector.matrix.android.api.session.room.send.SendState
 import im.vector.matrix.android.api.session.room.sender.SenderInfo
 import im.vector.matrix.android.api.session.room.uploads.GetUploadsResult
 import im.vector.matrix.android.api.session.room.uploads.UploadEvent
+import im.vector.matrix.android.internal.database.mapper.asDomain
+import im.vector.matrix.android.internal.database.model.EventEntity
+import im.vector.matrix.android.internal.database.model.EventEntityFields
+import im.vector.matrix.android.internal.database.query.TimelineEventFilter
+import im.vector.matrix.android.internal.database.query.whereType
 import im.vector.matrix.android.internal.network.executeRequest
 import im.vector.matrix.android.internal.session.filter.FilterFactory
 import im.vector.matrix.android.internal.session.room.RoomAPI
@@ -38,6 +46,7 @@ internal interface GetUploadsTask : Task<GetUploadsTask.Params, GetUploadsResult
 
     data class Params(
             val roomId: String,
+            val isRoomEncrypted: Boolean,
             val numberOfEvents: Int,
             val since: String?
     )
@@ -51,11 +60,44 @@ internal class DefaultGetUploadsTask @Inject constructor(
     : GetUploadsTask {
 
     override suspend fun execute(params: GetUploadsTask.Params): GetUploadsResult {
-        val since = params.since ?: tokenStore.getLastToken() ?: throw IllegalStateException("No token available")
+        val result: GetUploadsResult
+        val events: List<Event>
 
-        val filter = FilterFactory.createUploadsFilter(params.numberOfEvents).toJSONString()
-        val chunk = executeRequest<PaginationResponse>(eventBus) {
-            apiCall = roomAPI.getRoomMessagesFrom(params.roomId, since, PaginationDirection.BACKWARDS.value, params.numberOfEvents, filter)
+        if (params.isRoomEncrypted) {
+            // Get a chunk of events from cache for e2e rooms
+
+            result = GetUploadsResult(
+                    uploadEvents = emptyList(),
+                    nextToken = "",
+                    hasMore = false
+            )
+
+            var eventsFromRealm = emptyList<Event>()
+            monarchy.doWithRealm { realm ->
+                eventsFromRealm = EventEntity.whereType(realm, EventType.ENCRYPTED, params.roomId)
+                        .like(EventEntityFields.DECRYPTION_RESULT_JSON, TimelineEventFilter.DecryptedContent.URL)
+                        // FIXME Send event are stored twice in the DB. This is not normal. Keep only synced events
+                        .like(EventEntityFields.SEND_STATE_STR, SendState.SYNCED.name)
+                        .findAll()
+                        .map { it.asDomain() }
+                        // Exclude stickers
+                        .filter { it.getClearType() != EventType.STICKER }
+            }
+            events = eventsFromRealm
+        } else {
+            val since = params.since ?: tokenStore.getLastToken() ?: throw IllegalStateException("No token available")
+
+            val filter = FilterFactory.createUploadsFilter(params.numberOfEvents).toJSONString()
+            val chunk = executeRequest<PaginationResponse>(eventBus) {
+                apiCall = roomAPI.getRoomMessagesFrom(params.roomId, since, PaginationDirection.BACKWARDS.value, params.numberOfEvents, filter)
+            }
+
+            result = GetUploadsResult(
+                    uploadEvents = emptyList(),
+                    nextToken = chunk.end ?: "",
+                    hasMore = chunk.hasMore()
+            )
+            events = chunk.events
         }
 
         var uploadEvents = listOf<UploadEvent>()
@@ -66,7 +108,7 @@ internal class DefaultGetUploadsTask @Inject constructor(
         monarchy.doWithRealm { realm ->
             val roomMemberHelper = RoomMemberHelper(realm, params.roomId)
 
-            uploadEvents = chunk.events.mapNotNull { event ->
+            uploadEvents = events.mapNotNull { event ->
                 val eventId = event.eventId ?: return@mapNotNull null
                 val messageContent = event.getClearContent()?.toModel<MessageContent>() ?: return@mapNotNull null
                 val messageWithAttachmentContent = (messageContent as? MessageWithAttachmentContent) ?: return@mapNotNull null
@@ -91,10 +133,6 @@ internal class DefaultGetUploadsTask @Inject constructor(
             }
         }
 
-        return GetUploadsResult(
-                uploadEvents = uploadEvents,
-                nextToken = chunk.end ?: "",
-                hasMore = chunk.hasMore()
-        )
+        return result.copy(uploadEvents = uploadEvents)
     }
 }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/sync/RoomSyncHandler.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/sync/RoomSyncHandler.kt
@@ -29,6 +29,7 @@ import im.vector.matrix.android.internal.crypto.MXCRYPTO_ALGORITHM_MEGOLM
 import im.vector.matrix.android.internal.crypto.algorithms.olm.OlmDecryptionResult
 import im.vector.matrix.android.internal.database.helper.addOrUpdate
 import im.vector.matrix.android.internal.database.helper.addTimelineEvent
+import im.vector.matrix.android.internal.database.helper.deleteOnCascade
 import im.vector.matrix.android.internal.database.mapper.ContentMapper
 import im.vector.matrix.android.internal.database.mapper.toEntity
 import im.vector.matrix.android.internal.database.model.ChunkEntity
@@ -272,6 +273,8 @@ internal class RoomSyncHandler @Inject constructor(private val readReceiptHandle
                             event.mxDecryptionResult = adapter.fromJson(json)
                         }
                     }
+                    // Finally delete the local echo
+                    sendingEventEntity.deleteOnCascade()
                 } else {
                     Timber.v("Can't find corresponding local echo for tx:$it")
                 }


### PR DESCRIPTION
Fixes #1405 

The added code displays the list of already synced events with attachment in the upload section of a e2e room. It may be improve later, because the list of files should not be exhaustive.

The PR also contain a fix to avoid duplicated event in DB. I have done some tests and it seems ok, but please review carefully...
