### PR TITLE
Temporary fix to show error when user is creating an account on matrix.org with userId containing only digits (#1410)

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,9 +1,6 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
     <option name="RIGHT_MARGIN" value="160" />
-    <AndroidXmlCodeStyleSettings>
-      <option name="ARRANGEMENT_SETTINGS_MIGRATED_TO_191" value="true" />
-    </AndroidXmlCodeStyleSettings>
     <JetCodeStyleSettings>
       <option name="PACKAGES_TO_USE_STAR_IMPORTS">
         <value>

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Improvements 🙌:
 
 Bugfix 🐛:
  - Switch theme is not fully taken into account without restarting the app
+ - Temporary fix to show error when user is creating an account on matrix.org with userId containing only digits (#1410)
 
 Translations 🗣:
  -

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/signout/SignOutTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/signout/SignOutTask.kt
@@ -49,7 +49,7 @@ internal class DefaultSignOutTask @Inject constructor(
                     apiCall = signOutAPI.signOut()
                 }
             } catch (throwable: Throwable) {
-                // Maybe due to https://github.com/matrix-org/synapse/issues/5755
+                // Maybe due to https://github.com/matrix-org/synapse/issues/5756
                 if (throwable is Failure.ServerError
                         && throwable.httpCode == HttpURLConnection.HTTP_UNAUTHORIZED /* 401 */
                         && throwable.error.code == MatrixError.M_UNKNOWN_TOKEN) {


### PR DESCRIPTION
Refer to #1410