### PR TITLE
Use "you" instead of your display name for notice events you have sent

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@ Features ✨:
  -
 
 Improvements 🙌:
- -
+ - New wording for notice when current user is the sender
 
 Bugfix 🐛:
  - Switch theme is not fully taken into account without restarting the app

--- a/matrix-sdk-android/src/main/res/values/strings.xml
+++ b/matrix-sdk-android/src/main/res/values/strings.xml
@@ -32,7 +32,7 @@
     <string name="notice_display_name_set">%1$s set their display name to %2$s</string>
     <string name="notice_display_name_set_by_you">You set your display name to %1$s</string>
     <string name="notice_display_name_changed_from">%1$s changed their display name from %2$s to %3$s</string>
-    <string name="notice_display_name_changed_from_by_you">You changed their display name from %1$s to %2$s</string>
+    <string name="notice_display_name_changed_from_by_you">You changed your display name from %1$s to %2$s</string>
     <string name="notice_display_name_removed">%1$s removed their display name (%2$s)</string>
     <string name="notice_display_name_removed_by_you">You removed your display name (%1$s)</string>
     <string name="notice_room_topic_changed">%1$s changed the topic to: %2$s</string>
@@ -74,7 +74,7 @@
     <string name="notice_event_redacted_with_reason">Message removed [reason: %1$s]</string>
     <string name="notice_event_redacted_by_with_reason">Message removed by %1$s [reason: %2$s]</string>
     <string name="notice_profile_change_redacted">%1$s updated their profile %2$s</string>
-    <string name="notice_profile_change_redacted_by_you">You updated your profile %2$s</string>
+    <string name="notice_profile_change_redacted_by_you">You updated your profile %1$s</string>
     <string name="notice_room_third_party_invite">%1$s sent an invitation to %2$s to join the room</string>
     <string name="notice_room_third_party_invite_by_you">You sent an invitation to %1$s to join the room</string>
     <string name="notice_room_third_party_revoked_invite">%1$s revoked the invitation for %2$s to join the room</string>
@@ -277,7 +277,7 @@
     <string name="clear_timeline_send_queue">Clear sending queue</string>
 
     <string name="notice_room_invite_no_invitee_with_reason">%1$s\'s invitation. Reason: %2$s</string>
-    <string name="notice_room_invite_no_invitee_with_reason_by_you">Your invitation. Reason: %2$s</string>
+    <string name="notice_room_invite_no_invitee_with_reason_by_you">Your invitation. Reason: %1$s</string>
     <string name="notice_room_invite_with_reason">%1$s invited %2$s. Reason: %3$s</string>
     <string name="notice_room_invite_with_reason_by_you">You invited %1$s. Reason: %2$s</string>
     <string name="notice_room_invite_you_with_reason">%1$s invited you. Reason: %2$s</string>

--- a/matrix-sdk-android/src/main/res/values/strings.xml
+++ b/matrix-sdk-android/src/main/res/values/strings.xml
@@ -2,53 +2,85 @@
 <resources>
     <string name="summary_message">%1$s: %2$s</string>
     <string name="summary_user_sent_image">%1$s sent an image.</string>
+    <string name="summary_you_sent_image">You sent an image.</string>
     <string name="summary_user_sent_sticker">%1$s sent a sticker.</string>
+    <string name="summary_you_sent_sticker">You sent a sticker.</string>
 
     <string name="notice_room_invite_no_invitee">%s\'s invitation</string>
+    <string name="notice_room_invite_no_invitee_by_you">Your invitation</string>
     <string name="notice_room_created">%1$s created the room</string>
+    <string name="notice_room_created_by_you">You created the room</string>
     <string name="notice_room_invite">%1$s invited %2$s</string>
+    <string name="notice_room_invite_by_you">You invited %1$s</string>
     <string name="notice_room_invite_you">%1$s invited you</string>
     <string name="notice_room_join">%1$s joined the room</string>
+    <string name="notice_room_join_by_you">You joined the room</string>
     <string name="notice_room_leave">%1$s left the room</string>
+    <string name="notice_room_leave_by_you">You left the room</string>
     <string name="notice_room_reject">%1$s rejected the invitation</string>
+    <string name="notice_room_reject_by_you">You rejected the invitation</string>
     <string name="notice_room_kick">%1$s kicked %2$s</string>
+    <string name="notice_room_kick_by_you">You kicked %1$s</string>
     <string name="notice_room_unban">%1$s unbanned %2$s</string>
+    <string name="notice_room_unban_by_you">You unbanned %1$s</string>
     <string name="notice_room_ban">%1$s banned %2$s</string>
+    <string name="notice_room_ban_by_you">You banned %1$s</string>
     <string name="notice_room_withdraw">%1$s withdrew %2$s\'s invitation</string>
+    <string name="notice_room_withdraw_by_you">You withdrew %1$s\'s invitation</string>
     <string name="notice_avatar_url_changed">%1$s changed their avatar</string>
+    <string name="notice_avatar_url_changed_by_you">You changed your avatar</string>
     <string name="notice_display_name_set">%1$s set their display name to %2$s</string>
+    <string name="notice_display_name_set_by_you">You set your display name to %1$s</string>
     <string name="notice_display_name_changed_from">%1$s changed their display name from %2$s to %3$s</string>
+    <string name="notice_display_name_changed_from_by_you">You changed their display name from %1$s to %2$s</string>
     <string name="notice_display_name_removed">%1$s removed their display name (%2$s)</string>
+    <string name="notice_display_name_removed_by_you">You removed your display name (%1$s)</string>
     <string name="notice_room_topic_changed">%1$s changed the topic to: %2$s</string>
+    <string name="notice_room_topic_changed_by_you">You changed the topic to: %1$s</string>
     <string name="notice_room_name_changed">%1$s changed the room name to: %2$s</string>
+    <string name="notice_room_name_changed_by_you">You changed the room name to: %1$s</string>
     <string name="notice_placed_video_call">%s placed a video call.</string>
+    <string name="notice_placed_video_call_by_you">You placed a video call.</string>
     <string name="notice_placed_voice_call">%s placed a voice call.</string>
+    <string name="notice_placed_voice_call_by_you">You placed a voice call.</string>
     <string name="notice_answered_call">%s answered the call.</string>
+    <string name="notice_answered_call_by_you">You answered the call.</string>
     <string name="notice_ended_call">%s ended the call.</string>
+    <string name="notice_ended_call_by_you">You ended the call.</string>
     <string name="notice_made_future_room_visibility">%1$s made future room history visible to %2$s</string>
+    <string name="notice_made_future_room_visibility_by_you">You made future room history visible to %1$s</string>
     <string name="notice_room_visibility_invited">all room members, from the point they are invited.</string>
     <string name="notice_room_visibility_joined">all room members, from the point they joined.</string>
     <string name="notice_room_visibility_shared">all room members.</string>
     <string name="notice_room_visibility_world_readable">anyone.</string>
     <string name="notice_room_visibility_unknown">unknown (%s).</string>
     <string name="notice_end_to_end">%1$s turned on end-to-end encryption (%2$s)</string>
+    <string name="notice_end_to_end_by_you">You turned on end-to-end encryption (%1$s)</string>
     <string name="notice_room_update">%s upgraded this room.</string>
+    <string name="notice_room_update_by_you">You upgraded this room.</string>
 
     <string name="notice_requested_voip_conference">%1$s requested a VoIP conference</string>
+    <string name="notice_requested_voip_conference_by_you">You requested a VoIP conference</string>
     <string name="notice_voip_started">VoIP conference started</string>
     <string name="notice_voip_finished">VoIP conference finished</string>
 
     <string name="notice_avatar_changed_too">(avatar was changed too)</string>
     <string name="notice_room_name_removed">%1$s removed the room name</string>
+    <string name="notice_room_name_removed_by_you">You removed the room name</string>
     <string name="notice_room_topic_removed">%1$s removed the room topic</string>
+    <string name="notice_room_topic_removed_by_you">You removed the room topic</string>
     <string name="notice_event_redacted">Message removed</string>
     <string name="notice_event_redacted_by">Message removed by %1$s</string>
     <string name="notice_event_redacted_with_reason">Message removed [reason: %1$s]</string>
     <string name="notice_event_redacted_by_with_reason">Message removed by %1$s [reason: %2$s]</string>
     <string name="notice_profile_change_redacted">%1$s updated their profile %2$s</string>
+    <string name="notice_profile_change_redacted_by_you">You updated your profile %2$s</string>
     <string name="notice_room_third_party_invite">%1$s sent an invitation to %2$s to join the room</string>
+    <string name="notice_room_third_party_invite_by_you">You sent an invitation to %1$s to join the room</string>
     <string name="notice_room_third_party_revoked_invite">%1$s revoked the invitation for %2$s to join the room</string>
+    <string name="notice_room_third_party_revoked_invite_by_you">You revoked the invitation for %1$s to join the room</string>
     <string name="notice_room_third_party_registered_invite">%1$s accepted the invitation for %2$s</string>
+    <string name="notice_room_third_party_registered_invite_by_you">You accepted the invitation for %1$s</string>
 
     <string name="notice_crypto_unable_to_decrypt">** Unable to decrypt: %s **</string>
     <string name="notice_crypto_error_unkwown_inbound_session_id">The sender\'s device has not sent us the keys for this message.</string>
@@ -245,22 +277,39 @@
     <string name="clear_timeline_send_queue">Clear sending queue</string>
 
     <string name="notice_room_invite_no_invitee_with_reason">%1$s\'s invitation. Reason: %2$s</string>
+    <string name="notice_room_invite_no_invitee_with_reason_by_you">Your invitation. Reason: %2$s</string>
     <string name="notice_room_invite_with_reason">%1$s invited %2$s. Reason: %3$s</string>
+    <string name="notice_room_invite_with_reason_by_you">You invited %1$s. Reason: %2$s</string>
     <string name="notice_room_invite_you_with_reason">%1$s invited you. Reason: %2$s</string>
     <string name="notice_room_join_with_reason">%1$s joined the room. Reason: %2$s</string>
+    <string name="notice_room_join_with_reason_by_you">You joined the room. Reason: %1$s</string>
     <string name="notice_room_leave_with_reason">%1$s left the room. Reason: %2$s</string>
+    <string name="notice_room_leave_with_reason_by_you">You left the room. Reason: %1$s</string>
     <string name="notice_room_reject_with_reason">%1$s rejected the invitation. Reason: %2$s</string>
+    <string name="notice_room_reject_with_reason_by_you">You rejected the invitation. Reason: %1$s</string>
     <string name="notice_room_kick_with_reason">%1$s kicked %2$s. Reason: %3$s</string>
+    <string name="notice_room_kick_with_reason_by_you">You kicked %1$s. Reason: %2$s</string>
     <string name="notice_room_unban_with_reason">%1$s unbanned %2$s. Reason: %3$s</string>
+    <string name="notice_room_unban_with_reason_by_you">You unbanned %1$s. Reason: %2$s</string>
     <string name="notice_room_ban_with_reason">%1$s banned %2$s. Reason: %3$s</string>
+    <string name="notice_room_ban_with_reason_by_you">You banned %1$s. Reason: %2$s</string>
     <string name="notice_room_third_party_invite_with_reason">%1$s sent an invitation to %2$s to join the room. Reason: %3$s</string>
+    <string name="notice_room_third_party_invite_with_reason_by_you">You sent an invitation to %1$s to join the room. Reason: %2$s</string>
     <string name="notice_room_third_party_revoked_invite_with_reason">%1$s revoked the invitation for %2$s to join the room. Reason: %3$s</string>
+    <string name="notice_room_third_party_revoked_invite_with_reason_by_you">You revoked the invitation for %1$s to join the room. Reason: %2$s</string>
     <string name="notice_room_third_party_registered_invite_with_reason">%1$s accepted the invitation for %2$s. Reason: %3$s</string>
+    <string name="notice_room_third_party_registered_invite_with_reason_by_you">You accepted the invitation for %1$s. Reason: %2$s</string>
     <string name="notice_room_withdraw_with_reason">%1$s withdrew %2$s\'s invitation. Reason: %3$s</string>
+    <string name="notice_room_withdraw_with_reason_by_you">You withdrew %1$s\'s invitation. Reason: %2$s</string>
 
     <plurals name="notice_room_aliases_added">
         <item quantity="one">%1$s added %2$s as an address for this room.</item>
         <item quantity="other">%1$s added %2$s as addresses for this room.</item>
+    </plurals>
+
+    <plurals name="notice_room_aliases_added_by_you">
+        <item quantity="one">You added %1$s as an address for this room.</item>
+        <item quantity="other">You added %1$s as addresses for this room.</item>
     </plurals>
 
     <plurals name="notice_room_aliases_removed">
@@ -268,16 +317,28 @@
         <item quantity="other">%1$s removed %3$s as addresses for this room.</item>
     </plurals>
 
+    <plurals name="notice_room_aliases_removed_by_you">
+        <item quantity="one">You removed %1$s as an address for this room.</item>
+        <item quantity="other">You removed %2$s as addresses for this room.</item>
+    </plurals>
+
     <string name="notice_room_aliases_added_and_removed">%1$s added %2$s and removed %3$s as addresses for this room.</string>
+    <string name="notice_room_aliases_added_and_removed_by_you">You added %1$s and removed %2$s as addresses for this room.</string>
 
     <string name="notice_room_canonical_alias_set">"%1$s set the main address for this room to %2$s."</string>
+    <string name="notice_room_canonical_alias_set_by_you">"You set the main address for this room to %1$s."</string>
     <string name="notice_room_canonical_alias_unset">"%1$s removed the main address for this room."</string>
+    <string name="notice_room_canonical_alias_unset_by_you">"You removed the main address for this room."</string>
 
     <string name="notice_room_guest_access_can_join">"%1$s has allowed guests to join the room."</string>
+    <string name="notice_room_guest_access_can_join_by_you">"You have allowed guests to join the room."</string>
     <string name="notice_room_guest_access_forbidden">"%1$s has prevented guests from joining the room."</string>
+    <string name="notice_room_guest_access_forbidden_by_you">"You have prevented guests from joining the room."</string>
 
     <string name="notice_end_to_end_ok">%1$s turned on end-to-end encryption.</string>
+    <string name="notice_end_to_end_ok_by_you">You turned on end-to-end encryption.</string>
     <string name="notice_end_to_end_unknown_algorithm">%1$s turned on end-to-end encryption (unrecognised algorithm %2$s).</string>
+    <string name="notice_end_to_end_unknown_algorithm_by_you">You turned on end-to-end encryption (unrecognised algorithm %1$s).</string>
 
     <string name="key_verification_request_fallback_message">%s is requesting to verify your key, but your client does not support in-chat key verification. You will need to use legacy key verification to verify keys.</string>
 

--- a/vector/src/main/java/im/vector/riotx/features/home/room/detail/timeline/factory/MergedHeaderItemFactory.kt
+++ b/vector/src/main/java/im/vector/riotx/features/home/room/detail/timeline/factory/MergedHeaderItemFactory.kt
@@ -22,6 +22,7 @@ import im.vector.matrix.android.api.session.room.model.create.RoomCreateContent
 import im.vector.matrix.android.api.session.room.timeline.TimelineEvent
 import im.vector.matrix.android.internal.crypto.MXCRYPTO_ALGORITHM_MEGOLM
 import im.vector.matrix.android.internal.crypto.model.event.EncryptionEventContent
+import im.vector.riotx.core.di.ActiveSessionHolder
 import im.vector.riotx.core.extensions.prevOrNull
 import im.vector.riotx.features.home.AvatarRenderer
 import im.vector.riotx.features.home.room.detail.timeline.TimelineEventController
@@ -38,7 +39,8 @@ import im.vector.riotx.features.home.room.detail.timeline.item.MergedRoomCreatio
 import javax.inject.Inject
 
 class MergedHeaderItemFactory @Inject constructor(private val avatarRenderer: AvatarRenderer,
-                                                  private val avatarSizeProvider: AvatarSizeProvider) {
+                                                  private val avatarSizeProvider: AvatarSizeProvider,
+                                                  private val activeSessionHolder: ActiveSessionHolder) {
 
     private val collapsedEventIds = linkedSetOf<Long>()
     private val mergeItemCollapseStates = HashMap<Long, Boolean>()
@@ -188,7 +190,8 @@ class MergedHeaderItemFactory @Inject constructor(private val avatarRenderer: Av
                     },
                     hasEncryptionEvent = hasEncryption,
                     isEncryptionAlgorithmSecure = encryptionAlgorithm == MXCRYPTO_ALGORITHM_MEGOLM,
-                    readReceiptsCallback = callback
+                    readReceiptsCallback = callback,
+                    currentUserId = activeSessionHolder.getSafeActiveSession()?.myUserId ?: ""
             )
             MergedRoomCreationItem_()
                     .id(mergeId)

--- a/vector/src/main/java/im/vector/riotx/features/home/room/detail/timeline/format/NoticeEventFormatter.kt
+++ b/vector/src/main/java/im/vector/riotx/features/home/room/detail/timeline/format/NoticeEventFormatter.kt
@@ -191,16 +191,18 @@ class NoticeEventFormatter @Inject constructor(private val sessionHolder: Active
                     }
                 }
             }
-            EventType.CALL_ANSWER -> if (event.isSentByCurrentUser()) {
-                sp.getString(R.string.notice_answered_call_by_you)
-            } else {
-                sp.getString(R.string.notice_answered_call, senderName)
-            }
-            EventType.CALL_HANGUP -> if (event.isSentByCurrentUser()) {
-                sp.getString(R.string.notice_ended_call_by_you)
-            } else {
-                sp.getString(R.string.notice_ended_call, senderName)
-            }
+            EventType.CALL_ANSWER ->
+                if (event.isSentByCurrentUser()) {
+                    sp.getString(R.string.notice_answered_call_by_you)
+                } else {
+                    sp.getString(R.string.notice_answered_call, senderName)
+                }
+            EventType.CALL_HANGUP ->
+                if (event.isSentByCurrentUser()) {
+                    sp.getString(R.string.notice_ended_call_by_you)
+                } else {
+                    sp.getString(R.string.notice_ended_call, senderName)
+                }
             else                  -> null
         }
     }
@@ -223,27 +225,29 @@ class NoticeEventFormatter @Inject constructor(private val sessionHolder: Active
         val addedAliases = eventContent?.aliases.orEmpty() - prevEventContent?.aliases.orEmpty()
         val removedAliases = prevEventContent?.aliases.orEmpty() - eventContent?.aliases.orEmpty()
 
-        return if (addedAliases.isNotEmpty() && removedAliases.isNotEmpty()) {
-            if (event.isSentByCurrentUser()) {
-                sp.getString(R.string.notice_room_aliases_added_and_removed_by_you, addedAliases.joinToString(), removedAliases.joinToString())
-            } else {
-                sp.getString(R.string.notice_room_aliases_added_and_removed, senderName, addedAliases.joinToString(), removedAliases.joinToString())
+        return when {
+            addedAliases.isNotEmpty() && removedAliases.isNotEmpty() ->
+                if (event.isSentByCurrentUser()) {
+                    sp.getString(R.string.notice_room_aliases_added_and_removed_by_you, addedAliases.joinToString(), removedAliases.joinToString())
+                } else {
+                    sp.getString(R.string.notice_room_aliases_added_and_removed, senderName, addedAliases.joinToString(), removedAliases.joinToString())
+                }
+            addedAliases.isNotEmpty()                                ->
+                if (event.isSentByCurrentUser()) {
+                    sp.getQuantityString(R.plurals.notice_room_aliases_added_by_you, addedAliases.size, addedAliases.joinToString())
+                } else {
+                    sp.getQuantityString(R.plurals.notice_room_aliases_added, addedAliases.size, senderName, addedAliases.joinToString())
+                }
+            removedAliases.isNotEmpty()                              ->
+                if (event.isSentByCurrentUser()) {
+                    sp.getQuantityString(R.plurals.notice_room_aliases_removed_by_you, removedAliases.size, removedAliases.joinToString())
+                } else {
+                    sp.getQuantityString(R.plurals.notice_room_aliases_removed, removedAliases.size, senderName, removedAliases.joinToString())
+                }
+            else                                                     -> {
+                Timber.w("Alias event without any change...")
+                null
             }
-        } else if (addedAliases.isNotEmpty()) {
-            if (event.isSentByCurrentUser()) {
-                sp.getQuantityString(R.plurals.notice_room_aliases_added_by_you, addedAliases.size, addedAliases.joinToString())
-            } else {
-                sp.getQuantityString(R.plurals.notice_room_aliases_added, addedAliases.size, senderName, addedAliases.joinToString())
-            }
-        } else if (removedAliases.isNotEmpty()) {
-            if (event.isSentByCurrentUser()) {
-                sp.getQuantityString(R.plurals.notice_room_aliases_removed_by_you, removedAliases.size, removedAliases.joinToString())
-            } else {
-                sp.getQuantityString(R.plurals.notice_room_aliases_removed, removedAliases.size, senderName, removedAliases.joinToString())
-            }
-        } else {
-            Timber.w("Alias event without any change...")
-            null
         }
     }
 
@@ -269,34 +273,37 @@ class NoticeEventFormatter @Inject constructor(private val sessionHolder: Active
     private fun formatRoomGuestAccessEvent(event: Event, senderName: String?): String? {
         val eventContent: RoomGuestAccessContent? = event.getClearContent().toModel()
         return when (eventContent?.guestAccess) {
-            GuestAccess.CanJoin   -> if (event.isSentByCurrentUser()) {
-                sp.getString(R.string.notice_room_guest_access_can_join_by_you)
-            } else {
-                sp.getString(R.string.notice_room_guest_access_can_join, senderName)
-            }
-            GuestAccess.Forbidden -> if (event.isSentByCurrentUser()) {
-                sp.getString(R.string.notice_room_guest_access_forbidden_by_you)
-            } else {
-                sp.getString(R.string.notice_room_guest_access_forbidden, senderName)
-            }
+            GuestAccess.CanJoin   ->
+                if (event.isSentByCurrentUser()) {
+                    sp.getString(R.string.notice_room_guest_access_can_join_by_you)
+                } else {
+                    sp.getString(R.string.notice_room_guest_access_can_join, senderName)
+                }
+            GuestAccess.Forbidden ->
+                if (event.isSentByCurrentUser()) {
+                    sp.getString(R.string.notice_room_guest_access_forbidden_by_you)
+                } else {
+                    sp.getString(R.string.notice_room_guest_access_forbidden, senderName)
+                }
             else                  -> null
         }
     }
 
     private fun formatRoomEncryptionEvent(event: Event, senderName: String?): CharSequence? {
         val content = event.content.toModel<EncryptionEventContent>() ?: return null
-        return if (content.algorithm == MXCRYPTO_ALGORITHM_MEGOLM) {
-            if (event.isSentByCurrentUser()) {
-                sp.getString(R.string.notice_end_to_end_ok_by_you)
-            } else {
-                sp.getString(R.string.notice_end_to_end_ok, senderName)
-            }
-        } else {
-            if (event.isSentByCurrentUser()) {
-                sp.getString(R.string.notice_end_to_end_unknown_algorithm_by_you, content.algorithm)
-            } else {
-                sp.getString(R.string.notice_end_to_end_unknown_algorithm, senderName, content.algorithm)
-            }
+        return when (content.algorithm) {
+            MXCRYPTO_ALGORITHM_MEGOLM ->
+                if (event.isSentByCurrentUser()) {
+                    sp.getString(R.string.notice_end_to_end_ok_by_you)
+                } else {
+                    sp.getString(R.string.notice_end_to_end_ok, senderName)
+                }
+            else                      ->
+                if (event.isSentByCurrentUser()) {
+                    sp.getString(R.string.notice_end_to_end_unknown_algorithm_by_you, content.algorithm)
+                } else {
+                    sp.getString(R.string.notice_end_to_end_unknown_algorithm, senderName, content.algorithm)
+                }
         }
     }
 
@@ -413,59 +420,62 @@ class NoticeEventFormatter @Inject constructor(private val sessionHolder: Active
             Membership.LEAVE  ->
                 // 2 cases here: this member may have left voluntarily or they may have been "left" by someone else ie. kicked
                 if (event.senderId == event.stateKey) {
-                    if (prevEventContent?.membership == Membership.INVITE) {
-                        if (event.isSentByCurrentUser()) {
-                            eventContent.safeReason?.let { reason ->
-                                sp.getString(R.string.notice_room_reject_with_reason_by_you, reason)
-                            } ?: sp.getString(R.string.notice_room_reject_by_you)
-                        } else {
-                            eventContent.safeReason?.let { reason ->
-                                sp.getString(R.string.notice_room_reject_with_reason, senderDisplayName, reason)
-                            } ?: sp.getString(R.string.notice_room_reject, senderDisplayName)
-                        }
-                    } else {
-                        if (event.isSentByCurrentUser()) {
-                            eventContent.safeReason?.let { reason ->
-                                sp.getString(R.string.notice_room_leave_with_reason_by_you, reason)
-                            } ?: sp.getString(R.string.notice_room_leave_by_you)
-                        } else {
-                            eventContent.safeReason?.let { reason ->
-                                sp.getString(R.string.notice_room_leave_with_reason, senderDisplayName, reason)
-                            } ?: sp.getString(R.string.notice_room_leave, senderDisplayName)
-                        }
-                    }
-                } else if (prevEventContent?.membership == Membership.INVITE) {
-                    if (event.isSentByCurrentUser()) {
-                        eventContent.safeReason?.let { reason ->
-                            sp.getString(R.string.notice_room_withdraw_with_reason_by_you, targetDisplayName, reason)
-                        } ?: sp.getString(R.string.notice_room_withdraw_by_you, targetDisplayName)
-                    } else {
-                        eventContent.safeReason?.let { reason ->
-                            sp.getString(R.string.notice_room_withdraw_with_reason, senderDisplayName, targetDisplayName, reason)
-                        } ?: sp.getString(R.string.notice_room_withdraw, senderDisplayName, targetDisplayName)
-                    }
-                } else if (prevEventContent?.membership == Membership.JOIN) {
-                    if (event.isSentByCurrentUser()) {
-                        eventContent.safeReason?.let { reason ->
-                            sp.getString(R.string.notice_room_kick_with_reason_by_you, targetDisplayName, reason)
-                        } ?: sp.getString(R.string.notice_room_kick_by_you, targetDisplayName)
-                    } else {
-                        eventContent.safeReason?.let { reason ->
-                            sp.getString(R.string.notice_room_kick_with_reason, senderDisplayName, targetDisplayName, reason)
-                        } ?: sp.getString(R.string.notice_room_kick, senderDisplayName, targetDisplayName)
-                    }
-                } else if (prevEventContent?.membership == Membership.BAN) {
-                    if (event.isSentByCurrentUser()) {
-                        eventContent.safeReason?.let { reason ->
-                            sp.getString(R.string.notice_room_unban_with_reason_by_you, targetDisplayName, reason)
-                        } ?: sp.getString(R.string.notice_room_unban_by_you, targetDisplayName)
-                    } else {
-                        eventContent.safeReason?.let { reason ->
-                            sp.getString(R.string.notice_room_unban_with_reason, senderDisplayName, targetDisplayName, reason)
-                        } ?: sp.getString(R.string.notice_room_unban, senderDisplayName, targetDisplayName)
+                    when (prevEventContent?.membership) {
+                        Membership.INVITE ->
+                            if (event.isSentByCurrentUser()) {
+                                eventContent.safeReason?.let { reason ->
+                                    sp.getString(R.string.notice_room_reject_with_reason_by_you, reason)
+                                } ?: sp.getString(R.string.notice_room_reject_by_you)
+                            } else {
+                                eventContent.safeReason?.let { reason ->
+                                    sp.getString(R.string.notice_room_reject_with_reason, senderDisplayName, reason)
+                                } ?: sp.getString(R.string.notice_room_reject, senderDisplayName)
+                            }
+                        else              ->
+                            if (event.isSentByCurrentUser()) {
+                                eventContent.safeReason?.let { reason ->
+                                    sp.getString(R.string.notice_room_leave_with_reason_by_you, reason)
+                                } ?: sp.getString(R.string.notice_room_leave_by_you)
+                            } else {
+                                eventContent.safeReason?.let { reason ->
+                                    sp.getString(R.string.notice_room_leave_with_reason, senderDisplayName, reason)
+                                } ?: sp.getString(R.string.notice_room_leave, senderDisplayName)
+                            }
                     }
                 } else {
-                    null
+                    when (prevEventContent?.membership) {
+                        Membership.INVITE ->
+                            if (event.isSentByCurrentUser()) {
+                                eventContent.safeReason?.let { reason ->
+                                    sp.getString(R.string.notice_room_withdraw_with_reason_by_you, targetDisplayName, reason)
+                                } ?: sp.getString(R.string.notice_room_withdraw_by_you, targetDisplayName)
+                            } else {
+                                eventContent.safeReason?.let { reason ->
+                                    sp.getString(R.string.notice_room_withdraw_with_reason, senderDisplayName, targetDisplayName, reason)
+                                } ?: sp.getString(R.string.notice_room_withdraw, senderDisplayName, targetDisplayName)
+                            }
+                        Membership.JOIN   ->
+                            if (event.isSentByCurrentUser()) {
+                                eventContent.safeReason?.let { reason ->
+                                    sp.getString(R.string.notice_room_kick_with_reason_by_you, targetDisplayName, reason)
+                                } ?: sp.getString(R.string.notice_room_kick_by_you, targetDisplayName)
+                            } else {
+                                eventContent.safeReason?.let { reason ->
+                                    sp.getString(R.string.notice_room_kick_with_reason, senderDisplayName, targetDisplayName, reason)
+                                } ?: sp.getString(R.string.notice_room_kick, senderDisplayName, targetDisplayName)
+                            }
+                        Membership.BAN    ->
+                            if (event.isSentByCurrentUser()) {
+                                eventContent.safeReason?.let { reason ->
+                                    sp.getString(R.string.notice_room_unban_with_reason_by_you, targetDisplayName, reason)
+                                } ?: sp.getString(R.string.notice_room_unban_by_you, targetDisplayName)
+                            } else {
+                                eventContent.safeReason?.let { reason ->
+                                    sp.getString(R.string.notice_room_unban_with_reason, senderDisplayName, targetDisplayName, reason)
+                                } ?: sp.getString(R.string.notice_room_unban, senderDisplayName, targetDisplayName)
+                            }
+                        else              -> null
+                    }
                 }
             Membership.BAN    ->
                 if (event.isSentByCurrentUser()) {
@@ -494,16 +504,18 @@ class NoticeEventFormatter @Inject constructor(private val sessionHolder: Active
     private fun formatJoinRulesEvent(event: Event, senderName: String?): CharSequence? {
         val content = event.getClearContent().toModel<RoomJoinRulesContent>() ?: return null
         return when (content.joinRules) {
-            RoomJoinRules.INVITE -> if (event.isSentByCurrentUser()) {
-                sp.getString(R.string.room_join_rules_invite_by_you)
-            } else {
-                sp.getString(R.string.room_join_rules_invite, senderName)
-            }
-            RoomJoinRules.PUBLIC -> if (event.isSentByCurrentUser()) {
-                sp.getString(R.string.room_join_rules_public_by_you)
-            } else {
-                sp.getString(R.string.room_join_rules_public, senderName)
-            }
+            RoomJoinRules.INVITE ->
+                if (event.isSentByCurrentUser()) {
+                    sp.getString(R.string.room_join_rules_invite_by_you)
+                } else {
+                    sp.getString(R.string.room_join_rules_invite, senderName)
+                }
+            RoomJoinRules.PUBLIC ->
+                if (event.isSentByCurrentUser()) {
+                    sp.getString(R.string.room_join_rules_public_by_you)
+                } else {
+                    sp.getString(R.string.room_join_rules_public, senderName)
+                }
             else                 -> null
         }
     }

--- a/vector/src/main/java/im/vector/riotx/features/home/room/detail/timeline/item/MergedRoomCreationItem.kt
+++ b/vector/src/main/java/im/vector/riotx/features/home/room/detail/timeline/item/MergedRoomCreationItem.kt
@@ -46,8 +46,12 @@ abstract class MergedRoomCreationItem : BasedMergedItem<MergedRoomCreationItem.H
             // Take the oldest data
             val data = distinctMergeData.lastOrNull()
 
-            val summary = holder.expandView.resources.getString(R.string.room_created_summary_item,
-                    data?.memberName ?: data?.userId ?: "")
+            val createdFromCurrentUser = data?.userId == attributes.currentUserId
+            val summary = if (createdFromCurrentUser) {
+                holder.expandView.resources.getString(R.string.room_created_summary_item_by_you)
+            } else {
+                holder.expandView.resources.getString(R.string.room_created_summary_item, data?.memberName ?: data?.userId ?: "")
+            }
             holder.summaryView.text = summary
             holder.summaryView.visibility = View.VISIBLE
             holder.avatarView.visibility = View.VISIBLE
@@ -110,7 +114,8 @@ abstract class MergedRoomCreationItem : BasedMergedItem<MergedRoomCreationItem.H
             override val avatarRenderer: AvatarRenderer,
             override val readReceiptsCallback: TimelineEventController.ReadReceiptsCallback? = null,
             override val onCollapsedStateChanged: (Boolean) -> Unit,
-            val hasEncryptionEvent : Boolean,
+            val currentUserId: String,
+            val hasEncryptionEvent: Boolean,
             val isEncryptionAlgorithmSecure: Boolean
     ) : BasedMergedItem.Attributes
 }

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -1823,6 +1823,7 @@ Not all features in Riot are implemented in RiotX yet. Main missing (and coming 
     <string name="room_list_quick_actions_settings">"Settings"</string>
     <string name="room_list_quick_actions_leave">"Leave the room"</string>
     <string name="notice_member_no_changes">"%1$s made no changes"</string>
+    <string name="notice_member_no_changes_by_you">"You made no changes"</string>
     <string name="command_description_spoiler">Sends the given message as a spoiler</string>
     <string name="spoiler">Spoiler</string>
     <string name="reaction_search_type_hint">Type keywords to find a reaction.</string>
@@ -1833,7 +1834,9 @@ Not all features in Riot are implemented in RiotX yet. Main missing (and coming 
 
 
     <string name="room_join_rules_public">%1$s made the room public to whoever knows the link.</string>
+    <string name="room_join_rules_public_by_you">You made the room public to whoever knows the link.</string>
     <string name="room_join_rules_invite">%1$s made the room invite only.</string>
+    <string name="room_join_rules_invite_by_you">You made the room invite only.</string>
     <string name="timeline_unread_messages">Unread messages</string>
 
     <string name="login_splash_title">Liberate your communication</string>
@@ -2302,6 +2305,7 @@ Not all features in Riot are implemented in RiotX yet. Main missing (and coming 
     <string name="encryption_unknown_algorithm_tile_description">The encryption used by this room is not supported</string>
 
     <string name="room_created_summary_item">%s created and configured the room.</string>
+    <string name="room_created_summary_item_by_you">You created and configured the room.</string>
 
     <string name="qr_code_scanned_self_verif_notice">Almost there! Is the other device showing the same shield?</string>
     <string name="qr_code_scanned_verif_waiting_notice">Almost there! Waiting for confirmation…</string>


### PR DESCRIPTION
It's worth noting that historically notice string were located in the SDK. Now a few of them are in the app.
This PR does not change anything about this, but maybe on day we should clarify this point.