### PR TITLE
Fix / reply ux stays too long

### DIFF
--- a/vector/src/main/java/im/vector/riotx/features/home/room/detail/RoomDetailFragment.kt
+++ b/vector/src/main/java/im/vector/riotx/features/home/room/detail/RoomDetailFragment.kt
@@ -622,6 +622,8 @@ class RoomDetailFragment @Inject constructor(
                     return
                 }
                 if (text.isNotBlank()) {
+                    // We collapse ASAP, if not there will be a slight anoying delay
+                    composerLayout.collapse(true)
                     lockSendButton = true
                     roomDetailViewModel.handle(RoomDetailAction.SendMessage(text, vectorPreferences.isMarkdownEnabled()))
                 }


### PR DESCRIPTION
Fixes 1169
https://github.com/vector-im/riotX-android/issues/1169

The Reply UX in composer stays too long after send.
The issue is that the action is dispatched to MvRx thread, then the update is posted back.
It can take quite long before the composer ux is collapsed (enough to tap on close, send again)

As there is no real reason to keep it, we can discard asap, a bit like we are disabling the send button