### PR TITLE
Hide left rooms in breadcrumbs (#766)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ Features ✨:
 Improvements 🙌:
  - New wording for notice when current user is the sender
  - Hide "X made no changes" event by default in timeline (#1430)
+ - Hide left rooms in breadcrumbs (#766)
 
 Bugfix 🐛:
  - Switch theme is not fully taken into account without restarting the app

--- a/matrix-sdk-android-rx/src/main/java/im/vector/matrix/rx/RxSession.kt
+++ b/matrix-sdk-android-rx/src/main/java/im/vector/matrix/rx/RxSession.kt
@@ -29,6 +29,7 @@ import im.vector.matrix.android.api.session.room.model.RoomSummary
 import im.vector.matrix.android.api.session.room.model.create.CreateRoomParams
 import im.vector.matrix.android.api.session.sync.SyncState
 import im.vector.matrix.android.api.session.user.model.User
+import im.vector.matrix.android.api.session.widgets.model.Widget
 import im.vector.matrix.android.api.util.JsonDict
 import im.vector.matrix.android.api.util.Optional
 import im.vector.matrix.android.api.util.toOptional
@@ -36,7 +37,6 @@ import im.vector.matrix.android.internal.crypto.model.CryptoDeviceInfo
 import im.vector.matrix.android.internal.crypto.model.rest.DeviceInfo
 import im.vector.matrix.android.internal.crypto.store.PrivateKeysInfo
 import im.vector.matrix.android.internal.session.sync.model.accountdata.UserAccountDataEvent
-import im.vector.matrix.android.api.session.widgets.model.Widget
 import io.reactivex.Observable
 import io.reactivex.Single
 
@@ -56,10 +56,10 @@ class RxSession(private val session: Session) {
                 }
     }
 
-    fun liveBreadcrumbs(): Observable<List<RoomSummary>> {
-        return session.getBreadcrumbsLive().asObservable()
+    fun liveBreadcrumbs(onlyJoinedRooms: Boolean): Observable<List<RoomSummary>> {
+        return session.getBreadcrumbsLive(onlyJoinedRooms).asObservable()
                 .startWithCallable {
-                    session.getBreadcrumbs()
+                    session.getBreadcrumbs(onlyJoinedRooms)
                 }
     }
 

--- a/matrix-sdk-android-rx/src/main/java/im/vector/matrix/rx/RxSession.kt
+++ b/matrix-sdk-android-rx/src/main/java/im/vector/matrix/rx/RxSession.kt
@@ -56,10 +56,10 @@ class RxSession(private val session: Session) {
                 }
     }
 
-    fun liveBreadcrumbs(onlyJoinedRooms: Boolean): Observable<List<RoomSummary>> {
-        return session.getBreadcrumbsLive(onlyJoinedRooms).asObservable()
+    fun liveBreadcrumbs(queryParams: RoomSummaryQueryParams): Observable<List<RoomSummary>> {
+        return session.getBreadcrumbsLive(queryParams).asObservable()
                 .startWithCallable {
-                    session.getBreadcrumbs(onlyJoinedRooms)
+                    session.getBreadcrumbs(queryParams)
                 }
     }
 

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/RoomService.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/RoomService.kt
@@ -73,15 +73,17 @@ interface RoomService {
 
     /**
      * Get a snapshot list of Breadcrumbs
+     * @param onlyJoinedRooms set to true to keep only joined rooms, and filter out left rooms
      * @return the immutable list of [RoomSummary]
      */
-    fun getBreadcrumbs(): List<RoomSummary>
+    fun getBreadcrumbs(onlyJoinedRooms: Boolean): List<RoomSummary>
 
     /**
      * Get a live list of Breadcrumbs
+     * @param onlyJoinedRooms set to true to keep only joined rooms, and filter out left rooms
      * @return the [LiveData] of [RoomSummary]
      */
-    fun getBreadcrumbsLive(): LiveData<List<RoomSummary>>
+    fun getBreadcrumbsLive(onlyJoinedRooms: Boolean): LiveData<List<RoomSummary>>
 
     /**
      * Inform the Matrix SDK that a room is displayed.

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/RoomService.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/RoomService.kt
@@ -73,17 +73,17 @@ interface RoomService {
 
     /**
      * Get a snapshot list of Breadcrumbs
-     * @param onlyJoinedRooms set to true to keep only joined rooms, and filter out left rooms
+     * @param queryParams parameters to query the room summaries. It can be use to keep only joined rooms, for instance.
      * @return the immutable list of [RoomSummary]
      */
-    fun getBreadcrumbs(onlyJoinedRooms: Boolean): List<RoomSummary>
+    fun getBreadcrumbs(queryParams: RoomSummaryQueryParams): List<RoomSummary>
 
     /**
      * Get a live list of Breadcrumbs
-     * @param onlyJoinedRooms set to true to keep only joined rooms, and filter out left rooms
+     * @param queryParams parameters to query the room summaries. It can be use to keep only joined rooms, for instance.
      * @return the [LiveData] of [RoomSummary]
      */
-    fun getBreadcrumbsLive(onlyJoinedRooms: Boolean): LiveData<List<RoomSummary>>
+    fun getBreadcrumbsLive(queryParams: RoomSummaryQueryParams): LiveData<List<RoomSummary>>
 
     /**
      * Inform the Matrix SDK that a room is displayed.

--- a/vector/src/main/java/im/vector/riotx/features/home/room/breadcrumbs/BreadcrumbsViewModel.kt
+++ b/vector/src/main/java/im/vector/riotx/features/home/room/breadcrumbs/BreadcrumbsViewModel.kt
@@ -21,7 +21,10 @@ import com.airbnb.mvrx.MvRxViewModelFactory
 import com.airbnb.mvrx.ViewModelContext
 import com.squareup.inject.assisted.Assisted
 import com.squareup.inject.assisted.AssistedInject
+import im.vector.matrix.android.api.query.QueryStringValue
 import im.vector.matrix.android.api.session.Session
+import im.vector.matrix.android.api.session.room.model.Membership
+import im.vector.matrix.android.api.session.room.roomSummaryQueryParams
 import im.vector.matrix.rx.rx
 import im.vector.riotx.core.platform.EmptyAction
 import im.vector.riotx.core.platform.EmptyViewEvents
@@ -58,7 +61,10 @@ class BreadcrumbsViewModel @AssistedInject constructor(@Assisted initialState: B
 
     private fun observeBreadcrumbs() {
         session.rx()
-                .liveBreadcrumbs(true)
+                .liveBreadcrumbs(roomSummaryQueryParams {
+                    displayName = QueryStringValue.NoCondition
+                    memberships = listOf(Membership.JOIN)
+                })
                 .observeOn(Schedulers.computation())
                 .execute { asyncBreadcrumbs ->
                     copy(asyncBreadcrumbs = asyncBreadcrumbs)

--- a/vector/src/main/java/im/vector/riotx/features/home/room/breadcrumbs/BreadcrumbsViewModel.kt
+++ b/vector/src/main/java/im/vector/riotx/features/home/room/breadcrumbs/BreadcrumbsViewModel.kt
@@ -58,7 +58,7 @@ class BreadcrumbsViewModel @AssistedInject constructor(@Assisted initialState: B
 
     private fun observeBreadcrumbs() {
         session.rx()
-                .liveBreadcrumbs()
+                .liveBreadcrumbs(true)
                 .observeOn(Schedulers.computation())
                 .execute { asyncBreadcrumbs ->
                     copy(asyncBreadcrumbs = asyncBreadcrumbs)


### PR DESCRIPTION
User get confused to see left rooms in the breadcrumbs.
I decided to filter them out.
Note that they are still present in the breadcrumbs account data, but should naturally be excluded once the user has navigated to any 20 other rooms.
If the user joins the room again, it may appear in its current breadcrumb index, which is OK I think.