### PR TITLE
Wrong /query request (#1444)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ Bugfix 🐛:
  - Switch theme is not fully taken into account without restarting the app
  - Temporary fix to show error when user is creating an account on matrix.org with userId containing only digits (#1410)
  - Reply composer overlay stays on screen too long after send (#1169)
+ - Wrong /query request (#1444)
 
 Translations 🗣:
  -

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/model/rest/KeysQueryBody.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/model/rest/KeysQueryBody.kt
@@ -36,7 +36,7 @@ internal data class KeysQueryBody(
          * A map from user ID, to a list of device IDs, or to an empty list to indicate all devices for the corresponding user.
          */
         @Json(name = "device_keys")
-        val deviceKeys: Map<String, Any>,
+        val deviceKeys: Map<String, List<String>>,
 
         /**
          * If the client is fetching keys as a result of a device update received in a sync request, this should be the 'since' token

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/tasks/DownloadKeysForUsersTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/tasks/DownloadKeysForUsersTask.kt
@@ -27,7 +27,7 @@ import javax.inject.Inject
 internal interface DownloadKeysForUsersTask : Task<DownloadKeysForUsersTask.Params, KeysQueryResponse> {
     data class Params(
             // the list of users to get keys for.
-            val userIds: List<String>?,
+            val userIds: List<String>,
             // the up-to token
             val token: String?
     )
@@ -39,7 +39,7 @@ internal class DefaultDownloadKeysForUsers @Inject constructor(
 ) : DownloadKeysForUsersTask {
 
     override suspend fun execute(params: DownloadKeysForUsersTask.Params): KeysQueryResponse {
-        val downloadQuery = params.userIds?.associateWith { emptyMap<String, Any>() }.orEmpty()
+        val downloadQuery = params.userIds.associateWith { emptyList<String>() }
 
         val body = KeysQueryBody(
                 deviceKeys = downloadQuery,


### PR DESCRIPTION
Fixes #1444 

RiotX now sends empty lists instead of empty JsonObjects (= maps)