### PR TITLE
Fix bad color contrast for navigation and status bar

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ Bugfix 🐛:
  - Switch theme is not fully taken into account without restarting the app
  - Temporary fix to show error when user is creating an account on matrix.org with userId containing only digits (#1410)
  - Reply composer overlay stays on screen too long after send (#1169)
+ - Fix navigation bar icon contrast on API in [21,27[ (#1342)
 
 Translations 🗣:
  -

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ Bugfix 🐛:
  - Temporary fix to show error when user is creating an account on matrix.org with userId containing only digits (#1410)
  - Reply composer overlay stays on screen too long after send (#1169)
  - Fix navigation bar icon contrast on API in [21,27[ (#1342)
+ - Fix status bar icon contrast on API in [21,23[
 
 Translations 🗣:
  -

--- a/vector/src/main/res/values-v21/theme_light.xml
+++ b/vector/src/main/res/values-v21/theme_light.xml
@@ -3,7 +3,8 @@
 
     <style name="AppTheme.Light.v21" parent="AppTheme.Base.Light">
         <item name="android:statusBarColor">@color/riotx_header_panel_background_light</item>
-        <item name="android:navigationBarColor">@color/riotx_header_panel_background_light</item>
+        <!-- Use dark color, to have enough contrast with icons color. windowLightNavigationBar is only available in API 27+ -->
+        <item name="android:navigationBarColor">@color/riotx_header_panel_background_dark</item>
 
         <!-- enable window content transitions -->
         <item name="android:windowContentTransitions">true</item>

--- a/vector/src/main/res/values-v21/theme_light.xml
+++ b/vector/src/main/res/values-v21/theme_light.xml
@@ -2,7 +2,8 @@
 <resources>
 
     <style name="AppTheme.Light.v21" parent="AppTheme.Base.Light">
-        <item name="android:statusBarColor">@color/riotx_header_panel_background_light</item>
+        <!-- Use dark color, to have enough contrast with icons color. windowLightStatusBar is only available in API 23+ -->
+        <item name="android:statusBarColor">@color/riotx_header_panel_background_dark</item>
         <!-- Use dark color, to have enough contrast with icons color. windowLightNavigationBar is only available in API 27+ -->
         <item name="android:navigationBarColor">@color/riotx_header_panel_background_dark</item>
 

--- a/vector/src/main/res/values-v21/theme_status.xml
+++ b/vector/src/main/res/values-v21/theme_status.xml
@@ -2,7 +2,8 @@
 <resources>
 
     <style name="AppTheme.Status.v21" parent="AppTheme.Base.Status">
-        <item name="android:statusBarColor">@color/riotx_header_panel_background_light</item>
+        <!-- Use dark color, to have enough contrast with icons color. windowLightStatusBar is only available in API 23+ -->
+        <item name="android:statusBarColor">@color/riotx_header_panel_background_dark</item>
         <!-- Use dark color, to have enough contrast with icons color. windowLightNavigationBar is only available in API 27+ -->
         <item name="android:navigationBarColor">@color/riotx_header_panel_background_dark</item>
 

--- a/vector/src/main/res/values-v21/theme_status.xml
+++ b/vector/src/main/res/values-v21/theme_status.xml
@@ -3,7 +3,8 @@
 
     <style name="AppTheme.Status.v21" parent="AppTheme.Base.Status">
         <item name="android:statusBarColor">@color/riotx_header_panel_background_light</item>
-        <item name="android:navigationBarColor">@color/riotx_header_panel_background_light</item>
+        <!-- Use dark color, to have enough contrast with icons color. windowLightNavigationBar is only available in API 27+ -->
+        <item name="android:navigationBarColor">@color/riotx_header_panel_background_dark</item>
 
         <!-- enable window content transitions -->
         <item name="android:windowContentTransitions">true</item>

--- a/vector/src/main/res/values-v23/theme_light.xml
+++ b/vector/src/main/res/values-v23/theme_light.xml
@@ -2,6 +2,7 @@
 <resources>
 
     <style name="AppTheme.Light.v23" parent="AppTheme.Light.v21">
+        <item name="android:statusBarColor">@color/riotx_header_panel_background_light</item>
         <item name="android:windowLightStatusBar">true</item>
     </style>
 

--- a/vector/src/main/res/values-v23/theme_status.xml
+++ b/vector/src/main/res/values-v23/theme_status.xml
@@ -2,7 +2,8 @@
 <resources>
 
     <style name="AppTheme.Status.v23" parent="AppTheme.Status.v21">
-        <item name="android:windowLightStatusBar">false</item>
+        <item name="android:statusBarColor">@color/riotx_header_panel_background_light</item>
+        <item name="android:windowLightStatusBar">true</item>
     </style>
 
     <style name="AppTheme.Status" parent="AppTheme.Status.v23"/>

--- a/vector/src/main/res/values-v27/theme_light.xml
+++ b/vector/src/main/res/values-v27/theme_light.xml
@@ -2,6 +2,7 @@
 <resources>
 
     <style name="AppTheme.Light.v27" parent="AppTheme.Light.v23">
+        <item name="android:navigationBarColor">@color/riotx_header_panel_background_light</item>
         <item name="android:windowLightNavigationBar">true</item>
     </style>
 

--- a/vector/src/main/res/values-v27/theme_status.xml
+++ b/vector/src/main/res/values-v27/theme_status.xml
@@ -2,6 +2,7 @@
 <resources>
 
     <style name="AppTheme.Status.v27" parent="AppTheme.Status.v23">
+        <item name="android:navigationBarColor">@color/riotx_header_panel_background_light</item>
         <item name="android:windowLightNavigationBar">true</item>
     </style>
 


### PR DESCRIPTION
Fixes #1342

## On API 21

### Before

(Note, this is an old version with old filter icon)

<img width="362" alt="image" src="https://user-images.githubusercontent.com/3940906/83748868-1f943080-a663-11ea-963b-5e809377e18e.png">

### After

<img width="369" alt="image" src="https://user-images.githubusercontent.com/3940906/83748964-48b4c100-a663-11ea-8e47-e49d1a5682cf.png">

## On API 23

### Before

<img width="393" alt="image" src="https://user-images.githubusercontent.com/3940906/83749385-ee683000-a663-11ea-99d8-4c2c44959e6a.png">

### After

<img width="393" alt="image" src="https://user-images.githubusercontent.com/3940906/83749098-7568d880-a663-11ea-8539-5e014cdb9ac2.png">

### On API 29 (no change then)

<img width="382" alt="image" src="https://user-images.githubusercontent.com/3940906/83749772-8b2acd80-a664-11ea-9b54-7e0d9a38b961.png">

<img width="383" alt="image" src="https://user-images.githubusercontent.com/3940906/83749786-9120ae80-a664-11ea-9fa6-b87f761888a4.png">



