### PR TITLE
Min SDK level set to 21 (#405)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@ SDK API changes ⚠️:
 
 Build 🧱:
  - Enable code optimization (Proguard)
+ - SDK is now API level 21 minimum, and so RiotX (#405)
 
 Other changes:
  -

--- a/matrix-sdk-android-rx/build.gradle
+++ b/matrix-sdk-android-rx/build.gradle
@@ -6,7 +6,7 @@ android {
     compileSdkVersion 29
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 21
         targetSdkVersion 29
         versionCode 1
         versionName "1.0"

--- a/matrix-sdk-android/build.gradle
+++ b/matrix-sdk-android/build.gradle
@@ -23,7 +23,7 @@ android {
     testOptions.unitTests.includeAndroidResources = true
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 21
         targetSdkVersion 29
         versionCode 1
         versionName "0.0.1"

--- a/vector/build.gradle
+++ b/vector/build.gradle
@@ -107,9 +107,8 @@ android {
     compileSdkVersion 29
     defaultConfig {
         applicationId "im.vector.riotx"
-        // Set to API 19 because motionLayout is min API 18.
-        // In the future we may consider using an alternative of MotionLayout to support API 16. But for security reason, maybe not.
-        minSdkVersion 19
+        // Set to API 21: see #405
+        minSdkVersion 21
         targetSdkVersion 29
         multiDexEnabled true
 


### PR DESCRIPTION
Fixes #405 

The decision has been taken to set min level API to 21. Several reasons for that have been provided in #405.

It's still possible for anyone to create a fork to support previous versions of Android OS if they want to.
