### PR TITLE
Minor dev setup improvement for Linux/Windows.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,11 @@ An Android Studio template has been added to the project to help creating all fi
 
 To install the template (to be done only once):
 - Go to folder `./tools/template`.
-- Run the script `./configure.sh`.
+- Mac OSX: Run the script `./configure.sh`.
+
+   Linux: Run `ANDROID_STUDIO=/path/to/android-studio ./configure`
+    - e.g. `ANDROID_STUDIO=/usr/local/android-studio ./configure`
+
 - Restart Android Studio.
 
 To create a new screen:

--- a/tools/templates/configure.sh
+++ b/tools/templates/configure.sh
@@ -17,8 +17,9 @@
 #
 
 echo "Configure RiotX Template..."
+if [ -z ${ANDROID_STUDIO+x} ]; then ANDROID_STUDIO="/Applications/Android Studio.app/Contents"; fi
 {
-ln -s $(pwd)/RiotXFeature /Applications/Android\ Studio.app/Contents/plugins/android/lib/templates/other
+ln -s $(pwd)/RiotXFeature "${ANDROID_STUDIO%/}/plugins/android/lib/templates/other"
 } && {
   echo "Please restart Android Studio."
 }


### PR DESCRIPTION
tools/templates/configure only worked for Mac OSX. I added an optional variable to set the location for Android Studio when using other OSes.

Signed-off-by: Fabian Ulbricht <fabianu@student.ethz.ch>

#648 # Pull Request Checklist

<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/riotX-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->

- [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
