### PR TITLE
Use retrofit2.Call.awaitResponse extension provided by Retrofit 2.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,7 @@ Build 🧱:
  - SDK is now API level 21 minimum, and so RiotX (#405)
 
 Other changes:
+ - Use `retrofit2.Call.awaitResponse` extension provided by Retrofit 2. (#1526)
  - Fix minor typo in contribution guide (#1512)
  - Fix self-assignment of callback in `DefaultRoomPushRuleService#setRoomNotificationState` (#1520)
  - Random housekeeping clean-ups indicated by Lint (#1520)

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/network/Request.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/network/Request.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 New Vector Ltd
+ * Copyright 2020 New Vector Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,12 +22,13 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
 import org.greenrobot.eventbus.EventBus
 import retrofit2.Call
+import retrofit2.awaitResponse
 import java.io.IOException
 
-internal suspend inline fun <DATA> executeRequest(eventBus: EventBus?,
+internal suspend inline fun <DATA : Any> executeRequest(eventBus: EventBus?,
                                                   block: Request<DATA>.() -> Unit) = Request<DATA>(eventBus).apply(block).execute()
 
-internal class Request<DATA>(private val eventBus: EventBus?) {
+internal class Request<DATA : Any>(private val eventBus: EventBus?) {
 
     var isRetryable = false
     var initialDelay: Long = 100L

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/network/RetrofitExtensions.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/network/RetrofitExtensions.kt
@@ -1,6 +1,6 @@
 /*
  *
- *  * Copyright 2019 New Vector Ltd
+ *  * Copyright 2020 New Vector Ltd
  *  *
  *  * Licensed under the Apache License, Version 2.0 (the "License");
  *  * you may not use this file except in compliance with the License.
@@ -26,31 +26,12 @@ import im.vector.matrix.android.internal.di.MoshiProvider
 import kotlinx.coroutines.suspendCancellableCoroutine
 import okhttp3.ResponseBody
 import org.greenrobot.eventbus.EventBus
-import retrofit2.Call
-import retrofit2.Callback
 import retrofit2.Response
 import timber.log.Timber
 import java.io.IOException
 import java.net.HttpURLConnection
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
-
-internal suspend fun <T> Call<T>.awaitResponse(): Response<T> {
-    return suspendCancellableCoroutine { continuation ->
-        continuation.invokeOnCancellation {
-            cancel()
-        }
-        enqueue(object : Callback<T> {
-            override fun onResponse(call: Call<T>, response: Response<T>) {
-                continuation.resume(response)
-            }
-
-            override fun onFailure(call: Call<T>, t: Throwable) {
-                continuation.resumeWithException(t)
-            }
-        })
-    }
-}
 
 internal suspend fun okhttp3.Call.awaitResponse(): okhttp3.Response {
     return suspendCancellableCoroutine { continuation ->


### PR DESCRIPTION
+ This extension is identical to the one used in this project and is available since Retrofit 2.6.0.
  See https://github.com/square/retrofit/commit/b761518aa174c7b0512b73f2fe70e2e908f24081.

Signed-off-by: Tobias Preuss <tobias.preuss@googlemail.com>