### PR TITLE
Improove file download

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ Improvements 🙌:
  - Room Settings: Name, Topic, Photo, Aliases, History Visibility (#1455)
  - Update user avatar (#1054)
  - Allow self-signed certificate (#1564)
+ - Improve file download and open in timeline
 
 Bugfix 🐛:
  - Fix dark theme issue on login screen (#1097)

--- a/matrix-sdk-android/src/main/AndroidManifest.xml
+++ b/matrix-sdk-android/src/main/AndroidManifest.xml
@@ -13,8 +13,20 @@
             android:authorities="${applicationId}.workmanager-init"
             android:exported="false"
             tools:node="remove" />
-
+        <!--
+         The SDK offers a secured File provider to access downloaded files.
+         Access to these file will be given via the FileService, with a temporary
+         read access permission
+        -->
+        <provider
+            android:name="im.vector.matrix.android.api.session.file.MatrixSDKFileProvider"
+            android:authorities="${applicationId}.mx-sdk.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/sdk_provider_paths" />
+        </provider>
     </application>
-
 
 </manifest>

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/Session.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/Session.kt
@@ -47,6 +47,7 @@ import im.vector.matrix.android.api.session.typing.TypingUsersTracker
 import im.vector.matrix.android.api.session.user.UserService
 import im.vector.matrix.android.api.session.widgets.WidgetService
 import im.vector.matrix.android.internal.session.download.ContentDownloadStateTracker
+import java.io.File
 
 /**
  * This interface defines interactions with a session.
@@ -60,7 +61,6 @@ interface Session :
         CacheService,
         SignOutService,
         FilterService,
-        FileService,
         TermsService,
         ProfileService,
         PushRuleService,
@@ -182,6 +182,11 @@ interface Session :
      * Returns the call signaling service associated with the session
      */
     fun callSignalingService(): CallSignalingService
+
+    /**
+     * Returns the file download service associated with the session
+     */
+    fun fileService(): FileService
 
     /**
      * Add a listener to the session.

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/Session.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/Session.kt
@@ -47,7 +47,6 @@ import im.vector.matrix.android.api.session.typing.TypingUsersTracker
 import im.vector.matrix.android.api.session.user.UserService
 import im.vector.matrix.android.api.session.widgets.WidgetService
 import im.vector.matrix.android.internal.session.download.ContentDownloadStateTracker
-import java.io.File
 
 /**
  * This interface defines interactions with a session.

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/Session.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/Session.kt
@@ -46,6 +46,7 @@ import im.vector.matrix.android.api.session.terms.TermsService
 import im.vector.matrix.android.api.session.typing.TypingUsersTracker
 import im.vector.matrix.android.api.session.user.UserService
 import im.vector.matrix.android.api.session.widgets.WidgetService
+import im.vector.matrix.android.internal.session.download.ContentDownloadStateTracker
 
 /**
  * This interface defines interactions with a session.
@@ -151,6 +152,11 @@ interface Session :
      * Returns the TypingUsersTracker associated with the session
      */
     fun typingUsersTracker(): TypingUsersTracker
+
+    /**
+     * Returns the ContentDownloadStateTracker associated with the session
+     */
+    fun contentDownloadProgressTracker(): ContentDownloadStateTracker
 
     /**
      * Returns the cryptoService associated with the session

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/Session.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/Session.kt
@@ -28,6 +28,7 @@ import im.vector.matrix.android.api.session.call.CallSignalingService
 import im.vector.matrix.android.api.session.content.ContentUploadStateTracker
 import im.vector.matrix.android.api.session.content.ContentUrlResolver
 import im.vector.matrix.android.api.session.crypto.CryptoService
+import im.vector.matrix.android.api.session.file.ContentDownloadStateTracker
 import im.vector.matrix.android.api.session.file.FileService
 import im.vector.matrix.android.api.session.group.GroupService
 import im.vector.matrix.android.api.session.homeserver.HomeServerCapabilitiesService
@@ -46,7 +47,6 @@ import im.vector.matrix.android.api.session.terms.TermsService
 import im.vector.matrix.android.api.session.typing.TypingUsersTracker
 import im.vector.matrix.android.api.session.user.UserService
 import im.vector.matrix.android.api.session.widgets.WidgetService
-import im.vector.matrix.android.internal.session.download.ContentDownloadStateTracker
 
 /**
  * This interface defines interactions with a session.

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/events/model/Event.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/events/model/Event.kt
@@ -235,3 +235,11 @@ fun Event.isVideoMessage(): Boolean {
         else                      -> false
     }
 }
+
+fun Event.isFileMessage(): Boolean {
+    return getClearType() == EventType.MESSAGE
+            && when (getClearContent()?.toModel<MessageContent>()?.msgType) {
+        MessageType.MSGTYPE_FILE -> true
+        else                      -> false
+    }
+}

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/file/ContentDownloadStateTracker.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/file/ContentDownloadStateTracker.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package im.vector.matrix.android.internal.session.download
+package im.vector.matrix.android.api.session.file
 
 interface ContentDownloadStateTracker {
     fun track(key: String, updateListener: UpdateListener)

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/file/FileService.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/file/FileService.kt
@@ -50,8 +50,7 @@ interface FileService {
 
     /**
      * Download a file.
-     * Result will be a decrypted file, stored in the cache folder. id parameter will be used to create a sub folder to avoid name collision.
-     * You can pass the eventId
+     * Result will be a decrypted file, stored in the cache folder. url parameter will be used to create unique filename to avoid name collision.
      */
     fun downloadFile(
             downloadMode: DownloadMode,
@@ -70,9 +69,19 @@ interface FileService {
      */
     fun getTemporarySharableURI(mxcUrl: String, mimeType: String?): Uri?
 
+    /**
+     * Get information on the given file.
+     * Mimetype should be the same one as passed to downloadFile (limitation for now)
+     */
     fun fileState(mxcUrl: String, mimeType: String?) : FileState
 
+    /**
+     * Clears all the files downloaded  by the service
+     */
     fun clearCache()
 
+    /**
+     * Get size of cached files
+     */
     fun getCacheSize() : Int
 }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/file/FileService.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/file/FileService.kt
@@ -16,6 +16,7 @@
 
 package im.vector.matrix.android.api.session.file
 
+import android.net.Uri
 import im.vector.matrix.android.api.MatrixCallback
 import im.vector.matrix.android.api.util.Cancelable
 import im.vector.matrix.android.internal.crypto.attachments.ElementToDecrypt
@@ -50,7 +51,16 @@ interface FileService {
             downloadMode: DownloadMode,
             id: String,
             fileName: String,
+            mimeType: String?,
             url: String?,
             elementToDecrypt: ElementToDecrypt?,
             callback: MatrixCallback<File>): Cancelable
+
+    fun isFileInCache(mxcUrl: String, mimeType: String?): Boolean
+
+    /**
+     * Use this URI and pass it to intent using flag Intent.FLAG_GRANT_READ_URI_PERMISSION
+     * (if not other app won't be able to access it)
+     */
+    fun getTemporarySharableURI(mxcUrl: String, mimeType: String?): Uri?
 }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/file/FileService.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/file/FileService.kt
@@ -42,6 +42,12 @@ interface FileService {
         FOR_EXTERNAL_SHARE
     }
 
+    enum class FileState {
+        IN_CACHE,
+        DOWNLOADING,
+        UNKNOWN
+    }
+
     /**
      * Download a file.
      * Result will be a decrypted file, stored in the cache folder. id parameter will be used to create a sub folder to avoid name collision.
@@ -63,4 +69,6 @@ interface FileService {
      * (if not other app won't be able to access it)
      */
     fun getTemporarySharableURI(mxcUrl: String, mimeType: String?): Uri?
+
+    fun fileState(mxcUrl: String, mimeType: String?) : FileState
 }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/file/FileService.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/file/FileService.kt
@@ -71,4 +71,8 @@ interface FileService {
     fun getTemporarySharableURI(mxcUrl: String, mimeType: String?): Uri?
 
     fun fileState(mxcUrl: String, mimeType: String?) : FileState
+
+    fun clearCache()
+
+    fun getCacheSize() : Int
 }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/file/FileService.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/file/FileService.kt
@@ -32,10 +32,12 @@ interface FileService {
          * Download file in external storage
          */
         TO_EXPORT,
+
         /**
          * Download file in cache
          */
         FOR_INTERNAL_USE,
+
         /**
          * Download file in file provider path
          */
@@ -73,15 +75,15 @@ interface FileService {
      * Get information on the given file.
      * Mimetype should be the same one as passed to downloadFile (limitation for now)
      */
-    fun fileState(mxcUrl: String, mimeType: String?) : FileState
+    fun fileState(mxcUrl: String, mimeType: String?): FileState
 
     /**
-     * Clears all the files downloaded  by the service
+     * Clears all the files downloaded by the service
      */
     fun clearCache()
 
     /**
      * Get size of cached files
      */
-    fun getCacheSize() : Int
+    fun getCacheSize(): Int
 }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/file/MatrixSDKFileProvider.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/file/MatrixSDKFileProvider.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2020 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.matrix.android.api.session.file
+
+import android.net.Uri
+import androidx.core.content.FileProvider
+
+/**
+ * We have to declare our own file provider to avoid collision with apps using the sdk
+ * and having their own
+ */
+class MatrixSDKFileProvider : FileProvider() {
+    override fun getType(uri: Uri): String? {
+        return super.getType(uri) ?: "plain/text"
+    }
+}

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/model/message/MessageAudioContent.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/model/message/MessageAudioContent.kt
@@ -51,4 +51,8 @@ data class MessageAudioContent(
          * Required if the file is encrypted. Information on the encrypted file, as specified in End-to-end encryption.
          */
         @Json(name = "file") override val encryptedFileInfo: EncryptedFileInfo? = null
-) : MessageWithAttachmentContent
+) : MessageWithAttachmentContent {
+
+        override val mimeType: String?
+                get() =  encryptedFileInfo?.mimetype ?: audioInfo?.mimeType
+}

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/model/message/MessageFileContent.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/model/message/MessageFileContent.kt
@@ -16,7 +16,7 @@
 
 package im.vector.matrix.android.api.session.room.model.message
 
-import android.content.ClipDescription
+import android.webkit.MimeTypeMap
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import im.vector.matrix.android.api.session.events.model.Content
@@ -59,12 +59,12 @@ data class MessageFileContent(
         @Json(name = "file") override val encryptedFileInfo: EncryptedFileInfo? = null
 ) : MessageWithAttachmentContent {
 
-    fun getMimeType(): String {
-        // Mimetype default to plain text, should not be used
-        return encryptedFileInfo?.mimetype
+    override val mimeType: String?
+        get() = encryptedFileInfo?.mimetype
                 ?: info?.mimeType
-                ?: ClipDescription.MIMETYPE_TEXT_PLAIN
-    }
+                ?: MimeTypeMap.getFileExtensionFromUrl(filename ?: body)?.let { extension ->
+                    MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension)
+                }
 
     fun getFileName(): String {
         return filename ?: body

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/model/message/MessageImageContent.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/model/message/MessageImageContent.kt
@@ -52,4 +52,7 @@ data class MessageImageContent(
          * Required if the file is encrypted. Information on the encrypted file, as specified in End-to-end encryption.
          */
         @Json(name = "file") override val encryptedFileInfo: EncryptedFileInfo? = null
-) : MessageImageInfoContent
+) : MessageImageInfoContent {
+        override val mimeType: String?
+                get() = encryptedFileInfo?.mimetype ?: info?.mimeType ?: "image/*"
+}

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/model/message/MessageStickerContent.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/model/message/MessageStickerContent.kt
@@ -52,4 +52,7 @@ data class MessageStickerContent(
          * Required if the file is encrypted. Information on the encrypted file, as specified in End-to-end encryption.
          */
         @Json(name = "file") override val encryptedFileInfo: EncryptedFileInfo? = null
-) : MessageImageInfoContent
+) : MessageImageInfoContent {
+        override val mimeType: String?
+                get() = encryptedFileInfo?.mimetype ?: info?.mimeType
+}

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/model/message/MessageVideoContent.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/model/message/MessageVideoContent.kt
@@ -51,4 +51,7 @@ data class MessageVideoContent(
          * Required if the file is encrypted. Information on the encrypted file, as specified in End-to-end encryption.
          */
         @Json(name = "file") override val encryptedFileInfo: EncryptedFileInfo? = null
-) : MessageWithAttachmentContent
+) : MessageWithAttachmentContent {
+        override val mimeType: String?
+                get() = encryptedFileInfo?.mimetype ?: videoInfo?.mimeType
+}

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/model/message/MessageWithAttachmentContent.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/model/message/MessageWithAttachmentContent.kt
@@ -31,9 +31,13 @@ interface MessageWithAttachmentContent : MessageContent {
      * Required if the file is encrypted. Information on the encrypted file, as specified in End-to-end encryption.
      */
     val encryptedFileInfo: EncryptedFileInfo?
+
+    val mimeType: String?
 }
 
 /**
  * Get the url of the encrypted file or of the file
  */
 fun MessageWithAttachmentContent.getFileUrl() = encryptedFileInfo?.url ?: url
+
+fun MessageWithAttachmentContent.getFileName() = (this as? MessageFileContent)?.getFileName() ?: body

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/di/AuthQualifiers.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/di/AuthQualifiers.kt
@@ -36,4 +36,4 @@ internal annotation class UnauthenticatedWithCertificate
 
 @Qualifier
 @Retention(AnnotationRetention.RUNTIME)
-internal annotation class WithProgress
+internal annotation class UnauthenticatedWithCertificateWithProgress

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/di/AuthQualifiers.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/di/AuthQualifiers.kt
@@ -33,3 +33,7 @@ internal annotation class Unauthenticated
 @Qualifier
 @Retention(AnnotationRetention.RUNTIME)
 internal annotation class UnauthenticatedWithCertificate
+
+@Qualifier
+@Retention(AnnotationRetention.RUNTIME)
+internal annotation class WithProgress

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/di/FileQualifiers.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/di/FileQualifiers.kt
@@ -24,7 +24,7 @@ internal annotation class SessionFilesDirectory
 
 @Qualifier
 @Retention(AnnotationRetention.RUNTIME)
-internal annotation class SessionCacheDirectory
+internal annotation class SessionDownloadsDirectory
 
 @Qualifier
 @Retention(AnnotationRetention.RUNTIME)

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/DefaultFileService.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/DefaultFileService.kt
@@ -238,4 +238,17 @@ internal class DefaultFileService @Inject constructor(
                 file
         }
     }
+
+    override fun getCacheSize(): Int {
+        return downloadFolder.walkTopDown()
+                .onEnter {
+                    Timber.v("Get size of ${it.absolutePath}")
+                    true
+                }
+                .sumBy { it.length().toInt() }
+    }
+
+    override fun clearCache() {
+        downloadFolder.deleteRecursively()
+    }
 }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/DefaultFileService.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/DefaultFileService.kt
@@ -32,7 +32,8 @@ import im.vector.matrix.android.internal.crypto.attachments.MXEncryptedAttachmen
 import im.vector.matrix.android.internal.di.CacheDirectory
 import im.vector.matrix.android.internal.di.ExternalFilesDirectory
 import im.vector.matrix.android.internal.di.SessionDownloadsDirectory
-import im.vector.matrix.android.internal.di.WithProgress
+import im.vector.matrix.android.internal.di.UnauthenticatedWithCertificateWithProgress
+import im.vector.matrix.android.internal.session.download.DownloadProgressInterceptor.Companion.DOWNLOAD_PROGRESS_INTERCEPTOR_HEADER
 import im.vector.matrix.android.internal.task.TaskExecutor
 import im.vector.matrix.android.internal.util.MatrixCoroutineDispatchers
 import im.vector.matrix.android.internal.util.toCancelable
@@ -60,7 +61,7 @@ internal class DefaultFileService @Inject constructor(
         @SessionDownloadsDirectory
         private val sessionCacheDirectory: File,
         private val contentUrlResolver: ContentUrlResolver,
-        @WithProgress
+        @UnauthenticatedWithCertificateWithProgress
         private val okHttpClient: OkHttpClient,
         private val coroutineDispatchers: MatrixCoroutineDispatchers,
         private val taskExecutor: TaskExecutor
@@ -122,7 +123,7 @@ internal class DefaultFileService @Inject constructor(
 
                         val request = Request.Builder()
                                 .url(resolvedUrl)
-                                .header("matrix-sdk:mxc_URL", url)
+                                .header(DOWNLOAD_PROGRESS_INTERCEPTOR_HEADER, url)
                                 .build()
 
                         val response = try {

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/DefaultFileService.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/DefaultFileService.kt
@@ -16,6 +16,10 @@
 
 package im.vector.matrix.android.internal.session
 
+import android.content.Context
+import android.net.Uri
+import android.webkit.MimeTypeMap
+import androidx.core.content.FileProvider
 import arrow.core.Try
 import im.vector.matrix.android.api.MatrixCallback
 import im.vector.matrix.android.api.session.content.ContentUrlResolver
@@ -25,8 +29,8 @@ import im.vector.matrix.android.internal.crypto.attachments.ElementToDecrypt
 import im.vector.matrix.android.internal.crypto.attachments.MXEncryptedAttachments
 import im.vector.matrix.android.internal.di.CacheDirectory
 import im.vector.matrix.android.internal.di.ExternalFilesDirectory
-import im.vector.matrix.android.internal.di.SessionCacheDirectory
-import im.vector.matrix.android.internal.di.UnauthenticatedWithCertificate
+import im.vector.matrix.android.internal.di.SessionDownloadsDirectory
+import im.vector.matrix.android.internal.di.WithProgress
 import im.vector.matrix.android.internal.extensions.foldToCallback
 import im.vector.matrix.android.internal.task.TaskExecutor
 import im.vector.matrix.android.internal.util.MatrixCoroutineDispatchers
@@ -39,21 +43,27 @@ import okhttp3.Request
 import timber.log.Timber
 import java.io.File
 import java.io.IOException
+import java.net.URLEncoder
 import javax.inject.Inject
 
 internal class DefaultFileService @Inject constructor(
+        private val context: Context,
         @CacheDirectory
         private val cacheDirectory: File,
         @ExternalFilesDirectory
         private val externalFilesDirectory: File?,
-        @SessionCacheDirectory
+        @SessionDownloadsDirectory
         private val sessionCacheDirectory: File,
         private val contentUrlResolver: ContentUrlResolver,
-        @UnauthenticatedWithCertificate
+        @WithProgress
         private val okHttpClient: OkHttpClient,
         private val coroutineDispatchers: MatrixCoroutineDispatchers,
         private val taskExecutor: TaskExecutor
 ) : FileService {
+
+    private fun String.safeFileName() = URLEncoder.encode(this, Charsets.US_ASCII.displayName())
+
+    private val downloadFolder = File(sessionCacheDirectory, "MF")
 
     /**
      * Download file in the cache folder, and eventually decrypt it
@@ -63,23 +73,28 @@ internal class DefaultFileService @Inject constructor(
     override fun downloadFile(downloadMode: FileService.DownloadMode,
                               id: String,
                               fileName: String,
+                              mimeType: String?,
                               url: String?,
                               elementToDecrypt: ElementToDecrypt?,
                               callback: MatrixCallback<File>): Cancelable {
         return taskExecutor.executorScope.launch(coroutineDispatchers.main) {
             withContext(coroutineDispatchers.io) {
                 Try {
-                    val folder = File(sessionCacheDirectory, "MF")
-                    if (!folder.exists()) {
-                        folder.mkdirs()
+                    val unwrappedUrl = url ?: throw IllegalArgumentException("url is null")
+                    if (!downloadFolder.exists()) {
+                        downloadFolder.mkdirs()
                     }
-                    File(folder, fileName)
+                    // ensure we use unique file name by using URL (mapped to suitable file name)
+                    // Also we need to add extension for the FileProvider, if not it lot's of app that it's
+                    // shared with will not function well (even if mime type is passed in the intent)
+                    File(downloadFolder, fileForUrl(unwrappedUrl, mimeType))
                 }.flatMap { destFile ->
                     if (!destFile.exists()) {
                         val resolvedUrl = contentUrlResolver.resolveFullSize(url) ?: return@flatMap Try.Failure(IllegalArgumentException("url is null"))
 
                         val request = Request.Builder()
                                 .url(resolvedUrl)
+                                .header("matrix-sdk:mxc_URL", url ?: "")
                                 .build()
 
                         val response = try {
@@ -119,6 +134,27 @@ internal class DefaultFileService @Inject constructor(
             }
                     .foldToCallback(callback)
         }.toCancelable()
+    }
+
+    private fun fileForUrl(url: String, mimeType: String?): String {
+        val extension = mimeType?.let { MimeTypeMap.getSingleton().getExtensionFromMimeType(mimeType) }
+        return if (extension != null) "${url.safeFileName()}.$extension" else url.safeFileName()
+    }
+
+    override fun isFileInCache(mxcUrl: String, mimeType: String?): Boolean {
+        return File(downloadFolder,  fileForUrl(mxcUrl, mimeType)).exists()
+    }
+
+    /**
+     * Use this URI and pass it to intent using flag Intent.FLAG_GRANT_READ_URI_PERMISSION
+     * (if not other app won't be able to access it)
+     */
+    override fun getTemporarySharableURI(mxcUrl: String, mimeType: String?): Uri? {
+        // this string could be extracted no?
+        val authority = "${context.packageName}.mx-sdk.fileprovider"
+        val targetFile = File(downloadFolder, fileForUrl(mxcUrl, mimeType))
+        if (!targetFile.exists()) return null
+        return FileProvider.getUriForFile(context, authority, targetFile)
     }
 
     private fun copyFile(file: File, downloadMode: FileService.DownloadMode): File {

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/DefaultSession.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/DefaultSession.kt
@@ -53,6 +53,7 @@ import im.vector.matrix.android.internal.auth.SessionParamsStore
 import im.vector.matrix.android.internal.crypto.DefaultCryptoService
 import im.vector.matrix.android.internal.di.SessionId
 import im.vector.matrix.android.internal.di.WorkManagerProvider
+import im.vector.matrix.android.internal.session.download.ContentDownloadStateTracker
 import im.vector.matrix.android.internal.session.identity.DefaultIdentityService
 import im.vector.matrix.android.internal.session.room.timeline.TimelineEventDecryptor
 import im.vector.matrix.android.internal.session.sync.SyncTokenStore
@@ -100,6 +101,7 @@ internal class DefaultSession @Inject constructor(
         private val sessionParamsStore: SessionParamsStore,
         private val contentUploadProgressTracker: ContentUploadStateTracker,
         private val typingUsersTracker: TypingUsersTracker,
+        private val contentDownloadStateTracker: ContentDownloadStateTracker,
         private val initialSyncProgressService: Lazy<InitialSyncProgressService>,
         private val homeServerCapabilitiesService: Lazy<HomeServerCapabilitiesService>,
         private val accountDataService: Lazy<AccountDataService>,
@@ -238,6 +240,8 @@ internal class DefaultSession @Inject constructor(
     override fun contentUploadProgressTracker() = contentUploadProgressTracker
 
     override fun typingUsersTracker() = typingUsersTracker
+
+    override fun contentDownloadProgressTracker(): ContentDownloadStateTracker = contentDownloadStateTracker
 
     override fun cryptoService(): CryptoService = cryptoService.get()
 

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/DefaultSession.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/DefaultSession.kt
@@ -32,6 +32,7 @@ import im.vector.matrix.android.api.session.call.CallSignalingService
 import im.vector.matrix.android.api.session.content.ContentUploadStateTracker
 import im.vector.matrix.android.api.session.content.ContentUrlResolver
 import im.vector.matrix.android.api.session.crypto.CryptoService
+import im.vector.matrix.android.api.session.file.ContentDownloadStateTracker
 import im.vector.matrix.android.api.session.file.FileService
 import im.vector.matrix.android.api.session.group.GroupService
 import im.vector.matrix.android.api.session.homeserver.HomeServerCapabilitiesService
@@ -53,7 +54,6 @@ import im.vector.matrix.android.internal.auth.SessionParamsStore
 import im.vector.matrix.android.internal.crypto.DefaultCryptoService
 import im.vector.matrix.android.internal.di.SessionId
 import im.vector.matrix.android.internal.di.WorkManagerProvider
-import im.vector.matrix.android.internal.session.download.ContentDownloadStateTracker
 import im.vector.matrix.android.internal.session.identity.DefaultIdentityService
 import im.vector.matrix.android.internal.session.room.timeline.TimelineEventDecryptor
 import im.vector.matrix.android.internal.session.sync.SyncTokenStore

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/DefaultSession.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/DefaultSession.kt
@@ -91,7 +91,7 @@ internal class DefaultSession @Inject constructor(
         private val pushersService: Lazy<PushersService>,
         private val termsService: Lazy<TermsService>,
         private val cryptoService: Lazy<DefaultCryptoService>,
-        private val fileService: Lazy<FileService>,
+        private val defaultFileService: Lazy<FileService>,
         private val secureStorageService: Lazy<SecureStorageService>,
         private val profileService: Lazy<ProfileService>,
         private val widgetService: Lazy<WidgetService>,
@@ -122,7 +122,6 @@ internal class DefaultSession @Inject constructor(
         FilterService by filterService.get(),
         PushRuleService by pushRuleService.get(),
         PushersService by pushersService.get(),
-        FileService by fileService.get(),
         TermsService by termsService.get(),
         InitialSyncProgressService by initialSyncProgressService.get(),
         SecureStorageService by secureStorageService.get(),
@@ -246,6 +245,8 @@ internal class DefaultSession @Inject constructor(
     override fun cryptoService(): CryptoService = cryptoService.get()
 
     override fun identityService() = defaultIdentityService
+
+    override fun fileService(): FileService = defaultFileService.get()
 
     override fun widgetService(): WidgetService = widgetService.get()
 

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/SessionModule.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/SessionModule.kt
@@ -49,9 +49,9 @@ import im.vector.matrix.android.internal.di.SessionFilesDirectory
 import im.vector.matrix.android.internal.di.SessionId
 import im.vector.matrix.android.internal.di.Unauthenticated
 import im.vector.matrix.android.internal.di.UnauthenticatedWithCertificate
+import im.vector.matrix.android.internal.di.UnauthenticatedWithCertificateWithProgress
 import im.vector.matrix.android.internal.di.UserId
 import im.vector.matrix.android.internal.di.UserMd5
-import im.vector.matrix.android.internal.di.WithProgress
 import im.vector.matrix.android.internal.eventbus.EventBusTimberLogger
 import im.vector.matrix.android.internal.network.DefaultNetworkConnectivityChecker
 import im.vector.matrix.android.internal.network.FallbackNetworkCallbackStrategy
@@ -222,7 +222,7 @@ internal abstract class SessionModule {
         @JvmStatic
         @Provides
         @SessionScope
-        @WithProgress
+        @UnauthenticatedWithCertificateWithProgress
         fun providesProgressOkHttpClient(@UnauthenticatedWithCertificate okHttpClient: OkHttpClient,
                                          downloadProgressInterceptor: DownloadProgressInterceptor): OkHttpClient {
             return okHttpClient.newBuilder()

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/cleanup/CleanupSession.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/cleanup/CleanupSession.kt
@@ -22,7 +22,7 @@ import im.vector.matrix.android.internal.auth.SessionParamsStore
 import im.vector.matrix.android.internal.crypto.CryptoModule
 import im.vector.matrix.android.internal.database.RealmKeysUtils
 import im.vector.matrix.android.internal.di.CryptoDatabase
-import im.vector.matrix.android.internal.di.SessionCacheDirectory
+import im.vector.matrix.android.internal.di.SessionDownloadsDirectory
 import im.vector.matrix.android.internal.di.SessionDatabase
 import im.vector.matrix.android.internal.di.SessionFilesDirectory
 import im.vector.matrix.android.internal.di.SessionId
@@ -44,7 +44,7 @@ internal class CleanupSession @Inject constructor(
         @SessionDatabase private val clearSessionDataTask: ClearCacheTask,
         @CryptoDatabase private val clearCryptoDataTask: ClearCacheTask,
         @SessionFilesDirectory private val sessionFiles: File,
-        @SessionCacheDirectory private val sessionCache: File,
+        @SessionDownloadsDirectory private val sessionCache: File,
         private val realmKeysUtils: RealmKeysUtils,
         @SessionDatabase private val realmSessionConfiguration: RealmConfiguration,
         @CryptoDatabase private val realmCryptoConfiguration: RealmConfiguration,

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/content/ContentModule.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/content/ContentModule.kt
@@ -20,12 +20,17 @@ import dagger.Binds
 import dagger.Module
 import im.vector.matrix.android.api.session.content.ContentUploadStateTracker
 import im.vector.matrix.android.api.session.content.ContentUrlResolver
+import im.vector.matrix.android.internal.session.download.ContentDownloadStateTracker
+import im.vector.matrix.android.internal.session.download.DefaultContentDownloadStateTracker
 
 @Module
 internal abstract class ContentModule {
 
     @Binds
     abstract fun bindContentUploadStateTracker(tracker: DefaultContentUploadStateTracker): ContentUploadStateTracker
+
+    @Binds
+    abstract fun bindContentDownloadStateTracker(tracker: DefaultContentDownloadStateTracker): ContentDownloadStateTracker
 
     @Binds
     abstract fun bindContentUrlResolver(resolver: DefaultContentUrlResolver): ContentUrlResolver

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/content/ContentModule.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/content/ContentModule.kt
@@ -20,7 +20,7 @@ import dagger.Binds
 import dagger.Module
 import im.vector.matrix.android.api.session.content.ContentUploadStateTracker
 import im.vector.matrix.android.api.session.content.ContentUrlResolver
-import im.vector.matrix.android.internal.session.download.ContentDownloadStateTracker
+import im.vector.matrix.android.api.session.file.ContentDownloadStateTracker
 import im.vector.matrix.android.internal.session.download.DefaultContentDownloadStateTracker
 
 @Module

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/content/UploadContentWorker.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/content/UploadContentWorker.kt
@@ -35,6 +35,7 @@ import im.vector.matrix.android.api.session.room.model.message.MessageVideoConte
 import im.vector.matrix.android.internal.crypto.attachments.MXEncryptedAttachments
 import im.vector.matrix.android.internal.crypto.model.rest.EncryptedFileInfo
 import im.vector.matrix.android.internal.network.ProgressRequestBody
+import im.vector.matrix.android.internal.session.DefaultFileService
 import im.vector.matrix.android.internal.session.room.send.MultipleEventSendingDispatcherWorker
 import im.vector.matrix.android.internal.worker.SessionWorkerParams
 import im.vector.matrix.android.internal.worker.WorkerParamsFactory
@@ -71,6 +72,7 @@ internal class UploadContentWorker(val context: Context, params: WorkerParameter
 
     @Inject lateinit var fileUploader: FileUploader
     @Inject lateinit var contentUploadStateTracker: DefaultContentUploadStateTracker
+    @Inject lateinit var fileService: DefaultFileService
 
     override suspend fun doWork(): Result {
         val params = WorkerParamsFactory.fromData<Params>(inputData)
@@ -208,6 +210,13 @@ internal class UploadContentWorker(val context: Context, params: WorkerParameter
                     } else {
                         fileUploader
                                 .uploadFile(cacheFile, attachment.name, attachment.getSafeMimeType(), progressListener)
+                    }
+
+                    // If it's a file update the file service so that it does not redownload?
+                    if (params.attachment.type == ContentAttachmentData.Type.FILE) {
+                        context.contentResolver.openInputStream(attachment.queryUri)?.let {
+                            fileService.storeDataFor(contentUploadResponse.contentUri, params.attachment.getSafeMimeType(), it)
+                        }
                     }
 
                     handleSuccess(params,

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/download/ContentDownloadStateTracker.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/download/ContentDownloadStateTracker.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2020 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.matrix.android.internal.session.download
+
+interface ContentDownloadStateTracker {
+    fun track(key: String, updateListener: UpdateListener)
+    fun unTrack(key: String, updateListener: UpdateListener)
+    fun clear()
+
+    sealed class State {
+        object Idle : State()
+        data class Downloading(val current: Long, val total: Long, val indeterminate: Boolean) : State()
+        object Decrypting : State()
+        object Success : State()
+        data class Failure(val errorCode: Int) : State()
+    }
+
+    interface UpdateListener {
+        fun onDownloadStateUpdate(state: State)
+    }
+}

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/download/DefaultContentDownloadStateTracker.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/download/DefaultContentDownloadStateTracker.kt
@@ -27,8 +27,6 @@ import javax.inject.Inject
 class DefaultContentDownloadStateTracker @Inject constructor() : ProgressListener, ContentDownloadStateTracker {
 
     private val mainHandler = Handler(Looper.getMainLooper())
-
-    // TODO this will grow undefinitly..
     private val states = mutableMapOf<String, ContentDownloadStateTracker.State>()
     private val listeners = mutableMapOf<String, MutableList<ContentDownloadStateTracker.UpdateListener>>()
 
@@ -54,6 +52,7 @@ class DefaultContentDownloadStateTracker @Inject constructor() : ProgressListene
     }
 
     override fun clear() {
+        states.clear()
         listeners.clear()
     }
 

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/download/DefaultContentDownloadStateTracker.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/download/DefaultContentDownloadStateTracker.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2020 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.matrix.android.internal.session.download
+
+import android.os.Handler
+import android.os.Looper
+import im.vector.matrix.android.api.extensions.tryThis
+import im.vector.matrix.android.internal.session.SessionScope
+import timber.log.Timber
+import javax.inject.Inject
+
+@SessionScope
+class DefaultContentDownloadStateTracker @Inject constructor() : ProgressListener, ContentDownloadStateTracker {
+
+    private val mainHandler = Handler(Looper.getMainLooper())
+    private val states = mutableMapOf<String, ContentDownloadStateTracker.State>()
+    private val listeners = mutableMapOf<String, MutableList<ContentDownloadStateTracker.UpdateListener>>()
+
+    override fun track(key: String, updateListener: ContentDownloadStateTracker.UpdateListener) {
+        val listeners = listeners.getOrPut(key) { ArrayList() }
+        if (!listeners.contains(updateListener)) {
+            listeners.add(updateListener)
+        }
+    }
+
+    override fun unTrack(key: String, updateListener: ContentDownloadStateTracker.UpdateListener) {
+        listeners[key]?.apply {
+            remove(updateListener)
+        }
+    }
+
+    override fun clear() {
+        listeners.clear()
+    }
+
+//    private fun URL.toKey() = toString()
+
+    override fun update(url: String, bytesRead: Long, contentLength: Long, done: Boolean) {
+        Timber.v("## DL Progress url:$url read:$bytesRead total:$contentLength done:$done")
+        listeners[url]?.forEach {
+            tryThis {
+                if (done) {
+                    it.onDownloadStateUpdate(ContentDownloadStateTracker.State.Success)
+                } else {
+                    it.onDownloadStateUpdate(ContentDownloadStateTracker.State.Downloading(bytesRead, contentLength, contentLength == -1L))
+                }
+            }
+        }
+    }
+
+    override fun error(url: String, errorCode: Int) {
+        Timber.v("## DL Progress Error code:$errorCode")
+        listeners[url]?.forEach {
+            tryThis { it.onDownloadStateUpdate(ContentDownloadStateTracker.State.Failure(errorCode)) }
+        }
+    }
+}

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/download/DefaultContentDownloadStateTracker.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/download/DefaultContentDownloadStateTracker.kt
@@ -19,12 +19,13 @@ package im.vector.matrix.android.internal.session.download
 import android.os.Handler
 import android.os.Looper
 import im.vector.matrix.android.api.extensions.tryThis
+import im.vector.matrix.android.api.session.file.ContentDownloadStateTracker
 import im.vector.matrix.android.internal.session.SessionScope
 import timber.log.Timber
 import javax.inject.Inject
 
 @SessionScope
-class DefaultContentDownloadStateTracker @Inject constructor() : ProgressListener, ContentDownloadStateTracker {
+internal class DefaultContentDownloadStateTracker @Inject constructor() : ProgressListener, ContentDownloadStateTracker {
 
     private val mainHandler = Handler(Looper.getMainLooper())
     private val states = mutableMapOf<String, ContentDownloadStateTracker.State>()

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/download/DownloadProgressInterceptor.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/download/DownloadProgressInterceptor.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2020 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.matrix.android.internal.session.download
+
+import okhttp3.Interceptor
+import okhttp3.Response
+import javax.inject.Inject
+
+class DownloadProgressInterceptor @Inject constructor(
+        private val downloadStateTracker: DefaultContentDownloadStateTracker
+) : Interceptor {
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val url = chain.request().url.toUrl()
+        val mxcURl = chain.request().header("matrix-sdk:mxc_URL")
+
+        val request = chain.request().newBuilder()
+                .removeHeader("matrix-sdk:mxc_URL")
+                .build()
+
+        val originalResponse = chain.proceed(request)
+        if (!originalResponse.isSuccessful) {
+            downloadStateTracker.error(mxcURl ?: url.toExternalForm(), originalResponse.code)
+            return originalResponse
+        }
+        val responseBody = originalResponse.body ?: return originalResponse
+        return originalResponse.newBuilder()
+                .body(ProgressResponseBody(responseBody, mxcURl ?: url.toExternalForm(), downloadStateTracker))
+                .build()
+    }
+}

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/download/DownloadProgressInterceptor.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/download/DownloadProgressInterceptor.kt
@@ -20,16 +20,20 @@ import okhttp3.Interceptor
 import okhttp3.Response
 import javax.inject.Inject
 
-class DownloadProgressInterceptor @Inject constructor(
+internal class DownloadProgressInterceptor @Inject constructor(
         private val downloadStateTracker: DefaultContentDownloadStateTracker
 ) : Interceptor {
 
+    companion object {
+        const val DOWNLOAD_PROGRESS_INTERCEPTOR_HEADER = "matrix-sdk:mxc_URL"
+    }
+
     override fun intercept(chain: Interceptor.Chain): Response {
         val url = chain.request().url.toUrl()
-        val mxcURl = chain.request().header("matrix-sdk:mxc_URL")
+        val mxcURl = chain.request().header(DOWNLOAD_PROGRESS_INTERCEPTOR_HEADER)
 
         val request = chain.request().newBuilder()
-                .removeHeader("matrix-sdk:mxc_URL")
+                .removeHeader(DOWNLOAD_PROGRESS_INTERCEPTOR_HEADER)
                 .build()
 
         val originalResponse = chain.proceed(request)

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/download/ProgressResponseBody.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/download/ProgressResponseBody.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2020 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.matrix.android.internal.session.download
+
+import okhttp3.MediaType
+import okhttp3.ResponseBody
+import okio.Buffer
+import okio.BufferedSource
+import okio.ForwardingSource
+import okio.Source
+import okio.buffer
+
+class ProgressResponseBody(
+        private val responseBody: ResponseBody,
+        private val chainUrl: String,
+        private val progressListener: ProgressListener) : ResponseBody() {
+
+    private var bufferedSource: BufferedSource? = null
+
+    override fun contentType(): MediaType? = responseBody.contentType()
+    override fun contentLength(): Long = responseBody.contentLength()
+
+    override fun source(): BufferedSource {
+        if (bufferedSource == null) {
+            bufferedSource = source(responseBody.source()).buffer()
+        }
+        return bufferedSource!!
+    }
+
+    fun source(source: Source): Source {
+        return object : ForwardingSource(source) {
+            var totalBytesRead = 0L
+
+            override fun read(sink: Buffer, byteCount: Long): Long {
+                val bytesRead = super.read(sink, byteCount)
+                // read() returns the number of bytes read, or -1 if this source is exhausted.
+                totalBytesRead += if (bytesRead != -1L) bytesRead else 0L
+                progressListener.update(chainUrl, totalBytesRead, responseBody.contentLength(), bytesRead == -1L)
+                return bytesRead
+            }
+        }
+    }
+}
+
+interface ProgressListener {
+    fun update(url: String, bytesRead: Long, contentLength: Long, done: Boolean)
+    fun error(url: String, errorCode: Int)
+}

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/util/FileSaver.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/util/FileSaver.kt
@@ -17,10 +17,8 @@
 package im.vector.matrix.android.internal.util
 
 import androidx.annotation.WorkerThread
-import okio.buffer
-import okio.sink
-import okio.source
 import java.io.File
+import java.io.FileOutputStream
 import java.io.InputStream
 
 /**
@@ -28,9 +26,7 @@ import java.io.InputStream
  */
 @WorkerThread
 fun writeToFile(inputStream: InputStream, outputFile: File) {
-    inputStream.source().buffer().use { input ->
-        outputFile.sink().buffer().use { output ->
-            output.writeAll(input)
-        }
+    FileOutputStream(outputFile).use {
+        inputStream.copyTo(it)
     }
 }

--- a/matrix-sdk-android/src/main/res/xml/sdk_provider_paths.xml
+++ b/matrix-sdk-android/src/main/res/xml/sdk_provider_paths.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <cache-path
+        name="downloads"
+        path="/" />
+</paths>

--- a/tools/check/forbidden_strings_in_code.txt
+++ b/tools/check/forbidden_strings_in_code.txt
@@ -164,7 +164,7 @@ Formatter\.formatShortFileSize===1
 # android\.text\.TextUtils
 
 ### This is not a rule, but a warning: the number of "enum class" has changed. For Json classes, it is mandatory that they have `@JsonClass(generateAdapter = false)`. If it is ok, change the value in file forbidden_strings_in_code.txt
-enum class===73
+enum class===74
 
 ### Do not import temporary legacy classes
 import im.vector.matrix.android.internal.legacy.riot===3

--- a/vector/src/main/AndroidManifest.xml
+++ b/vector/src/main/AndroidManifest.xml
@@ -204,7 +204,7 @@
 
         <service
             android:name=".core.services.CallService"
-            android:exported="false" >
+            android:exported="false">
             <!-- in order to get headset button events -->
             <intent-filter>
                 <action android:name="android.intent.action.MEDIA_BUTTON" />
@@ -239,7 +239,7 @@
         A media button receiver receives and helps translate hardware media playback buttons,
         such as those found on wired and wireless headsets, into the appropriate callbacks in your app.
            -->
-        <receiver android:name="androidx.media.session.MediaButtonReceiver" >
+        <receiver android:name="androidx.media.session.MediaButtonReceiver">
             <intent-filter>
                 <action android:name="android.intent.action.MEDIA_BUTTON" />
             </intent-filter>
@@ -254,7 +254,7 @@
             android:grantUriPermissions="true">
             <meta-data
                 android:name="android.support.FILE_PROVIDER_PATHS"
-                android:resource="@xml/riotx_provider_paths" />
+                android:resource="@xml/sdk_provider_paths" />
         </provider>
     </application>
 

--- a/vector/src/main/java/im/vector/riotx/features/home/room/detail/RoomDetailAction.kt
+++ b/vector/src/main/java/im/vector/riotx/features/home/room/detail/RoomDetailAction.kt
@@ -18,8 +18,8 @@ package im.vector.riotx.features.home.room.detail
 
 import im.vector.matrix.android.api.session.content.ContentAttachmentData
 import im.vector.matrix.android.api.session.events.model.Event
-import im.vector.matrix.android.api.session.room.model.message.MessageFileContent
 import im.vector.matrix.android.api.session.room.model.message.MessageStickerContent
+import im.vector.matrix.android.api.session.room.model.message.MessageWithAttachmentContent
 import im.vector.matrix.android.api.session.room.timeline.Timeline
 import im.vector.matrix.android.api.session.room.timeline.TimelineEvent
 import im.vector.riotx.core.platform.VectorViewModelAction
@@ -39,7 +39,7 @@ sealed class RoomDetailAction : VectorViewModelAction {
     data class UpdateQuickReactAction(val targetEventId: String, val selectedReaction: String, val add: Boolean) : RoomDetailAction()
     data class NavigateToEvent(val eventId: String, val highlight: Boolean) : RoomDetailAction()
     object MarkAllAsRead : RoomDetailAction()
-    data class DownloadFile(val eventId: String, val messageFileContent: MessageFileContent) : RoomDetailAction()
+    data class DownloadOrOpen(val eventId: String, val messageFileContent: MessageWithAttachmentContent) : RoomDetailAction()
     data class HandleTombstoneEvent(val event: Event) : RoomDetailAction()
     object AcceptInvite : RoomDetailAction()
     object RejectInvite : RoomDetailAction()

--- a/vector/src/main/java/im/vector/riotx/features/home/room/detail/RoomDetailFragment.kt
+++ b/vector/src/main/java/im/vector/riotx/features/home/room/detail/RoomDetailFragment.kt
@@ -68,15 +68,14 @@ import im.vector.matrix.android.api.session.events.model.Event
 import im.vector.matrix.android.api.session.events.model.toModel
 import im.vector.matrix.android.api.session.file.FileService
 import im.vector.matrix.android.api.session.room.model.Membership
-import im.vector.matrix.android.api.session.room.model.message.MessageAudioContent
 import im.vector.matrix.android.api.session.room.model.message.MessageContent
-import im.vector.matrix.android.api.session.room.model.message.MessageFileContent
 import im.vector.matrix.android.api.session.room.model.message.MessageFormat
 import im.vector.matrix.android.api.session.room.model.message.MessageImageInfoContent
 import im.vector.matrix.android.api.session.room.model.message.MessageStickerContent
 import im.vector.matrix.android.api.session.room.model.message.MessageTextContent
 import im.vector.matrix.android.api.session.room.model.message.MessageVerificationRequestContent
 import im.vector.matrix.android.api.session.room.model.message.MessageVideoContent
+import im.vector.matrix.android.api.session.room.model.message.MessageWithAttachmentContent
 import im.vector.matrix.android.api.session.room.model.message.getFileUrl
 import im.vector.matrix.android.api.session.room.send.SendState
 import im.vector.matrix.android.api.session.room.timeline.Timeline
@@ -98,7 +97,6 @@ import im.vector.riotx.core.extensions.hideKeyboard
 import im.vector.riotx.core.extensions.setTextOrHide
 import im.vector.riotx.core.extensions.showKeyboard
 import im.vector.riotx.core.extensions.trackItemsVisibilityChange
-import im.vector.riotx.core.files.addEntryToDownloadManager
 import im.vector.riotx.core.glide.GlideApp
 import im.vector.riotx.core.intent.getMimeTypeFromUri
 import im.vector.riotx.core.platform.VectorBaseFragment
@@ -112,7 +110,6 @@ import im.vector.riotx.core.utils.KeyboardStateUtils
 import im.vector.riotx.core.utils.PERMISSIONS_FOR_AUDIO_IP_CALL
 import im.vector.riotx.core.utils.PERMISSIONS_FOR_VIDEO_IP_CALL
 import im.vector.riotx.core.utils.PERMISSIONS_FOR_WRITING_FILES
-import im.vector.riotx.core.utils.PERMISSION_REQUEST_CODE_DOWNLOAD_FILE
 import im.vector.riotx.core.utils.PERMISSION_REQUEST_CODE_INCOMING_URI
 import im.vector.riotx.core.utils.PERMISSION_REQUEST_CODE_PICK_ATTACHMENT
 import im.vector.riotx.core.utils.TextUtils
@@ -344,7 +341,7 @@ class RoomDetailFragment @Inject constructor(
                 is RoomDetailViewEvents.DownloadFileState                -> handleDownloadFileState(it)
                 is RoomDetailViewEvents.JoinRoomCommandSuccess           -> handleJoinedToAnotherRoom(it)
                 is RoomDetailViewEvents.SendMessageResult                -> renderSendMessageResult(it)
-                is RoomDetailViewEvents.ShowE2EErrorMessage    -> displayE2eError(it.withHeldCode)
+                is RoomDetailViewEvents.ShowE2EErrorMessage              -> displayE2eError(it.withHeldCode)
                 RoomDetailViewEvents.DisplayPromptForIntegrationManager  -> displayPromptForIntegrationManager()
                 is RoomDetailViewEvents.OpenStickerPicker                -> openStickerPicker(it)
                 is RoomDetailViewEvents.DisplayEnableIntegrationsWarning -> displayDisabledIntegrationDialog()
@@ -368,6 +365,21 @@ class RoomDetailFragment @Inject constructor(
 
     private fun openStickerPicker(event: RoomDetailViewEvents.OpenStickerPicker) {
         navigator.openStickerPicker(this, roomDetailArgs.roomId, event.widget)
+    }
+
+    private fun startOpenFileIntent(action: RoomDetailViewEvents.OpenFile) {
+        if (action.uri != null) {
+            val intent = Intent(Intent.ACTION_VIEW).apply {
+                setDataAndTypeAndNormalize(action.uri, action.mimeType)
+                addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_ACTIVITY_NEW_TASK)
+            }
+
+            if (intent.resolveActivity(requireActivity().packageManager) != null) {
+                requireActivity().startActivity(intent)
+            } else {
+                requireActivity().toast(R.string.error_no_external_application_found)
+            }
+        }
     }
 
     private fun displayPromptForIntegrationManager() {
@@ -487,21 +499,22 @@ class RoomDetailFragment @Inject constructor(
         val activity = requireActivity()
         if (action.throwable != null) {
             activity.toast(errorFormatter.toHumanReadable(action.throwable))
-        } else if (action.file != null) {
-            addEntryToDownloadManager(activity, action.file, action.mimeType)?.let {
-                // This is a temporary solution to help users find downloaded files
-                // there is a better way to do that
-                // On android Q+ this method returns the file URI, on older
-                // it returns null, and the download manager handles the notification
-                notificationUtils.buildDownloadFileNotification(
-                        it,
-                        action.file.name ?: "file",
-                        action.mimeType
-                ).let { notification ->
-                    notificationUtils.showNotificationMessage("DL", action.file.absolutePath.hashCode(), notification)
-                }
-            }
         }
+//        else if (action.file != null) {
+//            addEntryToDownloadManager(activity, action.file, action.mimeType ?: "application/octet-stream")?.let {
+//                // This is a temporary solution to help users find downloaded files
+//                // there is a better way to do that
+//                // On android Q+ this method returns the file URI, on older
+//                // it returns null, and the download manager handles the notification
+//                notificationUtils.buildDownloadFileNotification(
+//                        it,
+//                        action.file.name ?: "file",
+//                        action.mimeType ?: "application/octet-stream"
+//                ).let { notification ->
+//                    notificationUtils.showNotificationMessage("DL", action.file.absolutePath.hashCode(), notification)
+//                }
+//            }
+//        }
     }
 
     private fun setupNotificationView() {
@@ -680,6 +693,8 @@ class RoomDetailFragment @Inject constructor(
                 }
             }
         }
+        // TODO why don't we call super here?
+        // super.onActivityResult(requestCode, resultCode, data)
     }
 
 // PRIVATE METHODS *****************************************************************************
@@ -1163,31 +1178,32 @@ class RoomDetailFragment @Inject constructor(
         navigator.openVideoViewer(requireActivity(), mediaData)
     }
 
-    override fun onFileMessageClicked(eventId: String, messageFileContent: MessageFileContent) {
-        val action = RoomDetailAction.DownloadFile(eventId, messageFileContent)
-        // We need WRITE_EXTERNAL permission
-        if (checkPermissions(PERMISSIONS_FOR_WRITING_FILES, this, PERMISSION_REQUEST_CODE_DOWNLOAD_FILE)) {
-            showSnackWithMessage(getString(R.string.downloading_file, messageFileContent.getFileName()))
-            roomDetailViewModel.handle(action)
-        } else {
-            roomDetailViewModel.pendingAction = action
-        }
-    }
+//    override fun onFileMessageClicked(eventId: String, messageFileContent: MessageFileContent) {
+//        val isEncrypted = messageFileContent.encryptedFileInfo != null
+//        val action = RoomDetailAction.DownloadOrOpen(eventId, messageFileContent, isEncrypted)
+//        // We need WRITE_EXTERNAL permission
+// //        if (!isEncrypted || checkPermissions(PERMISSIONS_FOR_WRITING_FILES, this, PERMISSION_REQUEST_CODE_DOWNLOAD_FILE)) {
+//            showSnackWithMessage(getString(R.string.downloading_file, messageFileContent.getFileName()))
+//            roomDetailViewModel.handle(action)
+// //        } else {
+// //            roomDetailViewModel.pendingAction = action
+// //        }
+//    }
 
     override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>, grantResults: IntArray) {
         if (allGranted(grantResults)) {
             when (requestCode) {
-                PERMISSION_REQUEST_CODE_DOWNLOAD_FILE   -> {
-                    val action = roomDetailViewModel.pendingAction
-                    if (action != null) {
-                        (action as? RoomDetailAction.DownloadFile)
-                                ?.messageFileContent
-                                ?.getFileName()
-                                ?.let { showSnackWithMessage(getString(R.string.downloading_file, it)) }
-                        roomDetailViewModel.pendingAction = null
-                        roomDetailViewModel.handle(action)
-                    }
-                }
+//                PERMISSION_REQUEST_CODE_DOWNLOAD_FILE   -> {
+//                    val action = roomDetailViewModel.pendingAction
+//                    if (action != null) {
+//                        (action as? RoomDetailAction.DownloadFile)
+//                                ?.messageFileContent
+//                                ?.getFileName()
+//                                ?.let { showSnackWithMessage(getString(R.string.downloading_file, it)) }
+//                        roomDetailViewModel.pendingAction = null
+//                        roomDetailViewModel.handle(action)
+//                    }
+//                }
                 PERMISSION_REQUEST_CODE_INCOMING_URI    -> {
                     val pendingUri = roomDetailViewModel.pendingUri
                     if (pendingUri != null) {
@@ -1227,9 +1243,9 @@ class RoomDetailFragment @Inject constructor(
         }
     }
 
-    override fun onAudioMessageClicked(messageAudioContent: MessageAudioContent) {
-        vectorBaseActivity.notImplemented("open audio file")
-    }
+//    override fun onAudioMessageClicked(messageAudioContent: MessageAudioContent) {
+//        vectorBaseActivity.notImplemented("open audio file")
+//    }
 
     override fun onLoadMore(direction: Timeline.Direction) {
         roomDetailViewModel.handle(RoomDetailAction.LoadMoreTimelineEvents(direction))
@@ -1239,6 +1255,10 @@ class RoomDetailFragment @Inject constructor(
         when (messageContent) {
             is MessageVerificationRequestContent -> {
                 roomDetailViewModel.handle(RoomDetailAction.ResumeVerification(informationData.eventId, null))
+            }
+            is MessageWithAttachmentContent      -> {
+                val action = RoomDetailAction.DownloadOrOpen(informationData.eventId, messageContent)
+                roomDetailViewModel.handle(action)
             }
             is EncryptedEventContent             -> {
                 roomDetailViewModel.handle(RoomDetailAction.TapOnFailedToDecrypt(informationData.eventId))
@@ -1323,6 +1343,7 @@ class RoomDetailFragment @Inject constructor(
                 action.eventId,
                 action.messageContent.body,
                 action.messageContent.getFileUrl(),
+                action.messageContent.mimeType,
                 action.messageContent.encryptedFileInfo?.toElementToDecrypt(),
                 object : MatrixCallback<File> {
                     override fun onSuccess(data: File) {
@@ -1336,12 +1357,13 @@ class RoomDetailFragment @Inject constructor(
 
     private fun onSaveActionClicked(action: EventSharedAction.Save) {
         session.downloadFile(
-                FileService.DownloadMode.FOR_EXTERNAL_SHARE,
-                action.eventId,
-                action.messageContent.body,
-                action.messageContent.getFileUrl(),
-                action.messageContent.encryptedFileInfo?.toElementToDecrypt(),
-                object : MatrixCallback<File> {
+                downloadMode = FileService.DownloadMode.FOR_EXTERNAL_SHARE,
+                id = action.eventId,
+                fileName = action.messageContent.body,
+                mimeType = action.messageContent.mimeType,
+                url = action.messageContent.getFileUrl(),
+                elementToDecrypt = action.messageContent.encryptedFileInfo?.toElementToDecrypt(),
+                callback = object : MatrixCallback<File> {
                     override fun onSuccess(data: File) {
                         if (isAdded) {
                             val saved = saveMedia(

--- a/vector/src/main/java/im/vector/riotx/features/home/room/detail/RoomDetailFragment.kt
+++ b/vector/src/main/java/im/vector/riotx/features/home/room/detail/RoomDetailFragment.kt
@@ -1339,7 +1339,7 @@ class RoomDetailFragment @Inject constructor(
     }
 
     private fun onShareActionClicked(action: EventSharedAction.Share) {
-        session.downloadFile(
+        session.fileService().downloadFile(
                 FileService.DownloadMode.FOR_EXTERNAL_SHARE,
                 action.eventId,
                 action.messageContent.body,
@@ -1357,7 +1357,7 @@ class RoomDetailFragment @Inject constructor(
     }
 
     private fun onSaveActionClicked(action: EventSharedAction.Save) {
-        session.downloadFile(
+        session.fileService().downloadFile(
                 downloadMode = FileService.DownloadMode.FOR_EXTERNAL_SHARE,
                 id = action.eventId,
                 fileName = action.messageContent.body,

--- a/vector/src/main/java/im/vector/riotx/features/home/room/detail/RoomDetailFragment.kt
+++ b/vector/src/main/java/im/vector/riotx/features/home/room/detail/RoomDetailFragment.kt
@@ -346,6 +346,7 @@ class RoomDetailFragment @Inject constructor(
                 is RoomDetailViewEvents.OpenStickerPicker                -> openStickerPicker(it)
                 is RoomDetailViewEvents.DisplayEnableIntegrationsWarning -> displayDisabledIntegrationDialog()
                 is RoomDetailViewEvents.OpenIntegrationManager           -> openIntegrationManager()
+                is RoomDetailViewEvents.OpenFile                         -> startOpenFileIntent(it)
             }.exhaustive
         }
     }

--- a/vector/src/main/java/im/vector/riotx/features/home/room/detail/RoomDetailFragment.kt
+++ b/vector/src/main/java/im/vector/riotx/features/home/room/detail/RoomDetailFragment.kt
@@ -1366,17 +1366,13 @@ class RoomDetailFragment @Inject constructor(
                 callback = object : MatrixCallback<File> {
                     override fun onSuccess(data: File) {
                         if (isAdded) {
-                            val saved = saveMedia(
+                            saveMedia(
                                     context = requireContext(),
                                     file = data,
                                     title = action.messageContent.body,
-                                    mediaMimeType = getMimeTypeFromUri(requireContext(), data.toUri())
+                                    mediaMimeType = action.messageContent.mimeType ?: getMimeTypeFromUri(requireContext(), data.toUri()),
+                                    notificationUtils = notificationUtils
                             )
-                            if (saved) {
-                                Toast.makeText(requireContext(), R.string.media_file_added_to_gallery, Toast.LENGTH_LONG).show()
-                            } else {
-                                Toast.makeText(requireContext(), R.string.error_adding_media_file_to_gallery, Toast.LENGTH_LONG).show()
-                            }
                         }
                     }
                 }

--- a/vector/src/main/java/im/vector/riotx/features/home/room/detail/RoomDetailViewEvents.kt
+++ b/vector/src/main/java/im/vector/riotx/features/home/room/detail/RoomDetailViewEvents.kt
@@ -16,6 +16,7 @@
 
 package im.vector.riotx.features.home.room.detail
 
+import android.net.Uri
 import androidx.annotation.StringRes
 import im.vector.matrix.android.api.session.widgets.model.Widget
 import im.vector.matrix.android.internal.crypto.model.event.WithHeldCode
@@ -45,8 +46,14 @@ sealed class RoomDetailViewEvents : VectorViewEvents {
     ) : RoomDetailViewEvents()
 
     data class DownloadFileState(
-            val mimeType: String,
+            val mimeType: String?,
             val file: File?,
+            val throwable: Throwable?
+    ) : RoomDetailViewEvents()
+
+    data class OpenFile(
+            val mimeType: String?,
+            val uri: Uri?,
             val throwable: Throwable?
     ) : RoomDetailViewEvents()
 

--- a/vector/src/main/java/im/vector/riotx/features/home/room/detail/RoomDetailViewModel.kt
+++ b/vector/src/main/java/im/vector/riotx/features/home/room/detail/RoomDetailViewModel.kt
@@ -861,10 +861,10 @@ class RoomDetailViewModel @AssistedInject constructor(
 
     private fun handleOpenOrDownloadFile(action: RoomDetailAction.DownloadOrOpen) {
         val mxcUrl = action.messageFileContent.getFileUrl()
-        val isDownloaded = mxcUrl?.let { session.isFileInCache(it, action.messageFileContent.mimeType) } ?: false
+        val isDownloaded = mxcUrl?.let { session.fileService().isFileInCache(it, action.messageFileContent.mimeType) } ?: false
         if (isDownloaded) {
             // we can open it
-            session.getTemporarySharableURI(mxcUrl!!, action.messageFileContent.mimeType)?.let { uri ->
+            session.fileService().getTemporarySharableURI(mxcUrl!!, action.messageFileContent.mimeType)?.let { uri ->
                 _viewEvents.post(RoomDetailViewEvents.OpenFile(
                         action.messageFileContent.mimeType,
                         uri,
@@ -872,7 +872,7 @@ class RoomDetailViewModel @AssistedInject constructor(
                 ))
             }
         } else {
-            session.downloadFile(
+            session.fileService().downloadFile(
                     FileService.DownloadMode.FOR_INTERNAL_USE,
                     action.eventId,
                     action.messageFileContent.getFileName(),

--- a/vector/src/main/java/im/vector/riotx/features/home/room/detail/RoomDetailViewModel.kt
+++ b/vector/src/main/java/im/vector/riotx/features/home/room/detail/RoomDetailViewModel.kt
@@ -48,6 +48,7 @@ import im.vector.matrix.android.api.session.room.model.RoomSummary
 import im.vector.matrix.android.api.session.room.model.message.MessageContent
 import im.vector.matrix.android.api.session.room.model.message.MessageType
 import im.vector.matrix.android.api.session.room.model.message.OptionItem
+import im.vector.matrix.android.api.session.room.model.message.getFileName
 import im.vector.matrix.android.api.session.room.model.message.getFileUrl
 import im.vector.matrix.android.api.session.room.model.tombstone.RoomTombstoneContent
 import im.vector.matrix.android.api.session.room.powerlevels.PowerLevelsHelper
@@ -243,7 +244,7 @@ class RoomDetailViewModel @AssistedInject constructor(
             is RoomDetailAction.EnterEditMode                    -> handleEditAction(action)
             is RoomDetailAction.EnterQuoteMode                   -> handleQuoteAction(action)
             is RoomDetailAction.EnterReplyMode                   -> handleReplyAction(action)
-            is RoomDetailAction.DownloadFile                     -> handleDownloadFile(action)
+            is RoomDetailAction.DownloadOrOpen                   -> handleOpenOrDownloadFile(action)
             is RoomDetailAction.NavigateToEvent                  -> handleNavigateToEvent(action)
             is RoomDetailAction.HandleTombstoneEvent             -> handleTombstoneEvent(action)
             is RoomDetailAction.ResendMessage                    -> handleResendEvent(action)
@@ -858,30 +859,44 @@ class RoomDetailViewModel @AssistedInject constructor(
         }
     }
 
-    private fun handleDownloadFile(action: RoomDetailAction.DownloadFile) {
-        session.downloadFile(
-                FileService.DownloadMode.TO_EXPORT,
-                action.eventId,
-                action.messageFileContent.getFileName(),
-                action.messageFileContent.getFileUrl(),
-                action.messageFileContent.encryptedFileInfo?.toElementToDecrypt(),
-                object : MatrixCallback<File> {
-                    override fun onSuccess(data: File) {
-                        _viewEvents.post(RoomDetailViewEvents.DownloadFileState(
-                                action.messageFileContent.getMimeType(),
-                                data,
-                                null
-                        ))
-                    }
+    private fun handleOpenOrDownloadFile(action: RoomDetailAction.DownloadOrOpen) {
+        val mxcUrl = action.messageFileContent.getFileUrl()
+        val isDownloaded = mxcUrl?.let { session.isFileInCache(it, action.messageFileContent.mimeType) } ?: false
+        if (isDownloaded) {
+            // we can open it
+            session.getTemporarySharableURI(mxcUrl!!, action.messageFileContent.mimeType)?.let { uri ->
+                _viewEvents.post(RoomDetailViewEvents.OpenFile(
+                        action.messageFileContent.mimeType,
+                        uri,
+                        null
+                ))
+            }
+        } else {
+            session.downloadFile(
+                    FileService.DownloadMode.FOR_INTERNAL_USE,
+                    action.eventId,
+                    action.messageFileContent.getFileName(),
+                    action.messageFileContent.mimeType,
+                    mxcUrl,
+                    action.messageFileContent.encryptedFileInfo?.toElementToDecrypt(),
+                    object : MatrixCallback<File> {
+                        override fun onSuccess(data: File) {
+                            _viewEvents.post(RoomDetailViewEvents.DownloadFileState(
+                                    action.messageFileContent.mimeType,
+                                    data,
+                                    null
+                            ))
+                        }
 
-                    override fun onFailure(failure: Throwable) {
-                        _viewEvents.post(RoomDetailViewEvents.DownloadFileState(
-                                action.messageFileContent.getMimeType(),
-                                null,
-                                failure
-                        ))
-                    }
-                })
+                        override fun onFailure(failure: Throwable) {
+                            _viewEvents.post(RoomDetailViewEvents.DownloadFileState(
+                                    action.messageFileContent.mimeType,
+                                    null,
+                                    failure
+                            ))
+                        }
+                    })
+        }
     }
 
     private fun handleNavigateToEvent(action: RoomDetailAction.NavigateToEvent) {

--- a/vector/src/main/java/im/vector/riotx/features/home/room/detail/timeline/TimelineEventController.kt
+++ b/vector/src/main/java/im/vector/riotx/features/home/room/detail/timeline/TimelineEventController.kt
@@ -41,6 +41,7 @@ import im.vector.riotx.features.home.room.detail.RoomDetailViewState
 import im.vector.riotx.features.home.room.detail.UnreadState
 import im.vector.riotx.features.home.room.detail.timeline.factory.MergedHeaderItemFactory
 import im.vector.riotx.features.home.room.detail.timeline.factory.TimelineItemFactory
+import im.vector.riotx.features.home.room.detail.timeline.helper.ContentDownloadStateTrackerBinder
 import im.vector.riotx.features.home.room.detail.timeline.helper.ContentUploadStateTrackerBinder
 import im.vector.riotx.features.home.room.detail.timeline.helper.ReadMarkerVisibilityStateChangedListener
 import im.vector.riotx.features.home.room.detail.timeline.helper.TimelineEventDiffUtilCallback
@@ -60,6 +61,7 @@ import javax.inject.Inject
 
 class TimelineEventController @Inject constructor(private val dateFormatter: VectorDateFormatter,
                                                   private val contentUploadStateTrackerBinder: ContentUploadStateTrackerBinder,
+                                                  private val contentDownloadStateTrackerBinder: ContentDownloadStateTrackerBinder,
                                                   private val timelineItemFactory: TimelineItemFactory,
                                                   private val timelineMediaSizeProvider: TimelineMediaSizeProvider,
                                                   private val mergedHeaderItemFactory: MergedHeaderItemFactory,
@@ -227,6 +229,7 @@ class TimelineEventController @Inject constructor(private val dateFormatter: Vec
     override fun onDetachedFromRecyclerView(recyclerView: RecyclerView) {
         timelineMediaSizeProvider.recyclerView = null
         contentUploadStateTrackerBinder.clear()
+        contentDownloadStateTrackerBinder.clear()
         timeline?.removeListener(this)
         super.onDetachedFromRecyclerView(recyclerView)
     }

--- a/vector/src/main/java/im/vector/riotx/features/home/room/detail/timeline/TimelineEventController.kt
+++ b/vector/src/main/java/im/vector/riotx/features/home/room/detail/timeline/TimelineEventController.kt
@@ -27,6 +27,7 @@ import com.airbnb.epoxy.EpoxyModel
 import com.airbnb.epoxy.VisibilityState
 import im.vector.matrix.android.api.session.room.model.message.MessageAudioContent
 import im.vector.matrix.android.api.session.room.model.message.MessageFileContent
+import im.vector.matrix.android.api.session.room.model.message.MessageContent
 import im.vector.matrix.android.api.session.room.model.message.MessageImageInfoContent
 import im.vector.matrix.android.api.session.room.model.message.MessageVideoContent
 import im.vector.matrix.android.api.session.room.timeline.Timeline
@@ -74,8 +75,8 @@ class TimelineEventController @Inject constructor(private val dateFormatter: Vec
         fun onEncryptedMessageClicked(informationData: MessageInformationData, view: View)
         fun onImageMessageClicked(messageImageContent: MessageImageInfoContent, mediaData: ImageContentRenderer.Data, view: View)
         fun onVideoMessageClicked(messageVideoContent: MessageVideoContent, mediaData: VideoContentRenderer.Data, view: View)
-        fun onFileMessageClicked(eventId: String, messageFileContent: MessageFileContent)
-        fun onAudioMessageClicked(messageAudioContent: MessageAudioContent)
+//        fun onFileMessageClicked(eventId: String, messageFileContent: MessageFileContent)
+//        fun onAudioMessageClicked(messageAudioContent: MessageAudioContent)
         fun onEditedDecorationClicked(informationData: MessageInformationData)
 
         // TODO move all callbacks to this?

--- a/vector/src/main/java/im/vector/riotx/features/home/room/detail/timeline/TimelineEventController.kt
+++ b/vector/src/main/java/im/vector/riotx/features/home/room/detail/timeline/TimelineEventController.kt
@@ -25,9 +25,6 @@ import androidx.recyclerview.widget.RecyclerView
 import com.airbnb.epoxy.EpoxyController
 import com.airbnb.epoxy.EpoxyModel
 import com.airbnb.epoxy.VisibilityState
-import im.vector.matrix.android.api.session.room.model.message.MessageAudioContent
-import im.vector.matrix.android.api.session.room.model.message.MessageFileContent
-import im.vector.matrix.android.api.session.room.model.message.MessageContent
 import im.vector.matrix.android.api.session.room.model.message.MessageImageInfoContent
 import im.vector.matrix.android.api.session.room.model.message.MessageVideoContent
 import im.vector.matrix.android.api.session.room.timeline.Timeline

--- a/vector/src/main/java/im/vector/riotx/features/home/room/detail/timeline/factory/MessageItemFactory.kt
+++ b/vector/src/main/java/im/vector/riotx/features/home/room/detail/timeline/factory/MessageItemFactory.kt
@@ -186,7 +186,6 @@ class MessageItemFactory @Inject constructor(
                                       @Suppress("UNUSED_PARAMETER")
                                       informationData: MessageInformationData,
                                       highlight: Boolean,
-//                                      callback: TimelineEventController.Callback?,
                                       attributes: AbsMessageItem.Attributes): MessageFileItem? {
         return MessageFileItem_()
                 .attributes(attributes)
@@ -197,11 +196,7 @@ class MessageItemFactory @Inject constructor(
                 .highlighted(highlight)
                 .leftGuideline(avatarSizeProvider.leftGuideline)
                 .filename(messageContent.body)
-                .iconRes(R.drawable.ic_paperclip)
-//                .clickListener(
-//                        DebouncedClickListener(View.OnClickListener {
-//                            callback?.onAudioMessageClicked(messageContent)
-//                        }))
+                .iconRes(R.drawable.ic_headphones)
     }
 
     private fun buildVerificationRequestMessageItem(messageContent: MessageVerificationRequestContent,
@@ -236,16 +231,8 @@ class MessageItemFactory @Inject constructor(
                         )
                 )
                 .callback(callback)
-//                .izLocalFile(messageContent.getFileUrl().isLocalFile())
-//                .contentUploadStateTrackerBinder(contentUploadStateTrackerBinder)
                 .highlighted(highlight)
                 .leftGuideline(avatarSizeProvider.leftGuideline)
-//                .filename(messageContent.body)
-//                .iconRes(R.drawable.filetype_audio)
-//                .clickListener(
-//                        DebouncedClickListener(View.OnClickListener {
-//                            callback?.onAudioMessageClicked(messageContent)
-//                        }))
     }
 
     private fun buildFileMessageItem(messageContent: MessageFileContent,
@@ -253,20 +240,18 @@ class MessageItemFactory @Inject constructor(
                                      highlight: Boolean,
 //                                     callback: TimelineEventController.Callback?,
                                      attributes: AbsMessageItem.Attributes): MessageFileItem? {
+        val mxcUrl = messageContent.getFileUrl() ?: ""
         return MessageFileItem_()
                 .attributes(attributes)
                 .leftGuideline(avatarSizeProvider.leftGuideline)
                 .izLocalFile(messageContent.getFileUrl().isLocalFile())
-                .mxcUrl(messageContent.getFileUrl() ?: "")
+                .izDownloaded(session.isFileInCache(mxcUrl, messageContent.mimeType))
+                .mxcUrl(mxcUrl)
                 .contentUploadStateTrackerBinder(contentUploadStateTrackerBinder)
                 .contentDownloadStateTrackerBinder(contentDownloadStateTrackerBinder)
                 .highlighted(highlight)
                 .filename(messageContent.body)
                 .iconRes(R.drawable.ic_paperclip)
-//                .clickListener(
-//                        DebouncedClickListener(View.OnClickListener {
-//                            callback?.onFileMessageClicked(informationData.eventId, messageContent)
-//                        }))
     }
 
     private fun buildNotHandledMessageItem(messageContent: MessageContent,

--- a/vector/src/main/java/im/vector/riotx/features/home/room/detail/timeline/factory/MessageItemFactory.kt
+++ b/vector/src/main/java/im/vector/riotx/features/home/room/detail/timeline/factory/MessageItemFactory.kt
@@ -245,7 +245,7 @@ class MessageItemFactory @Inject constructor(
                 .attributes(attributes)
                 .leftGuideline(avatarSizeProvider.leftGuideline)
                 .izLocalFile(messageContent.getFileUrl().isLocalFile())
-                .izDownloaded(session.isFileInCache(mxcUrl, messageContent.mimeType))
+                .izDownloaded(session.fileService().isFileInCache(mxcUrl, messageContent.mimeType))
                 .mxcUrl(mxcUrl)
                 .contentUploadStateTrackerBinder(contentUploadStateTrackerBinder)
                 .contentDownloadStateTrackerBinder(contentDownloadStateTrackerBinder)

--- a/vector/src/main/java/im/vector/riotx/features/home/room/detail/timeline/helper/ContentDownloadStateTrackerBinder.kt
+++ b/vector/src/main/java/im/vector/riotx/features/home/room/detail/timeline/helper/ContentDownloadStateTrackerBinder.kt
@@ -57,7 +57,7 @@ class ContentDownloadStateTrackerBinder @Inject constructor(private val activeSe
 
     fun clear() {
         activeSessionHolder.getSafeActiveSession()?.also {
-            it.contentUploadProgressTracker().clear()
+            it.contentDownloadProgressTracker().clear()
         }
     }
 }
@@ -76,7 +76,7 @@ private class ContentDownloadUpdater(private val holder: MessageFileItem.Holder,
         }
     }
 
-    private var animatedDrawable:  AnimatedVectorDrawableCompat? = null
+    private var animatedDrawable: AnimatedVectorDrawableCompat? = null
     private var animationLoopCallback = object : Animatable2Compat.AnimationCallback() {
         override fun onAnimationEnd(drawable: Drawable?) {
             animatedDrawable?.start()

--- a/vector/src/main/java/im/vector/riotx/features/home/room/detail/timeline/helper/ContentDownloadStateTrackerBinder.kt
+++ b/vector/src/main/java/im/vector/riotx/features/home/room/detail/timeline/helper/ContentDownloadStateTrackerBinder.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2019 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.riotx.features.home.room.detail.timeline.helper
+
+import im.vector.matrix.android.internal.session.download.ContentDownloadStateTracker
+import im.vector.riotx.R
+import im.vector.riotx.core.di.ActiveSessionHolder
+import im.vector.riotx.core.di.ScreenScope
+import im.vector.riotx.core.error.ErrorFormatter
+import im.vector.riotx.features.home.room.detail.timeline.MessageColorProvider
+import im.vector.riotx.features.home.room.detail.timeline.item.MessageFileItem
+import javax.inject.Inject
+
+@ScreenScope
+class ContentDownloadStateTrackerBinder @Inject constructor(private val activeSessionHolder: ActiveSessionHolder,
+                                                            private val messageColorProvider: MessageColorProvider,
+                                                            private val errorFormatter: ErrorFormatter) {
+
+    private val updateListeners = mutableMapOf<String, ContentDownloadStateTracker.UpdateListener>()
+
+    fun bind(mxcUrl: String,
+             holder: MessageFileItem.Holder) {
+        activeSessionHolder.getSafeActiveSession()?.also { session ->
+            val downloadStateTracker = session.contentDownloadProgressTracker()
+            val updateListener = ContentDownloadUpdater(holder, messageColorProvider, errorFormatter)
+            updateListeners[mxcUrl] = updateListener
+            downloadStateTracker.track(mxcUrl, updateListener)
+        }
+    }
+
+    fun unbind(mxcUrl: String) {
+        activeSessionHolder.getSafeActiveSession()?.also { session ->
+            val downloadStateTracker = session.contentDownloadProgressTracker()
+            updateListeners[mxcUrl]?.also {
+                downloadStateTracker.unTrack(mxcUrl, it)
+            }
+        }
+    }
+
+    fun clear() {
+        activeSessionHolder.getSafeActiveSession()?.also {
+            it.contentUploadProgressTracker().clear()
+        }
+    }
+}
+
+private class ContentDownloadUpdater(private val holder: MessageFileItem.Holder,
+                                     private val messageColorProvider: MessageColorProvider,
+                                     private val errorFormatter: ErrorFormatter) : ContentDownloadStateTracker.UpdateListener {
+
+    override fun onDownloadStateUpdate(state: ContentDownloadStateTracker.State) {
+        when (state) {
+            ContentDownloadStateTracker.State.Idle           -> handleIdle()
+            is ContentDownloadStateTracker.State.Downloading -> handleProgress(state)
+            ContentDownloadStateTracker.State.Decrypting     -> handleDecrypting()
+            ContentDownloadStateTracker.State.Success        -> handleSuccess()
+            is ContentDownloadStateTracker.State.Failure     -> handleFailure()
+        }
+    }
+
+    // avoid blink effect when setting icon
+    private var hasDLResource = false
+
+    private fun handleIdle() {
+        holder.fileDownloadProgress.progress = 0
+        holder.fileDownloadProgress.isIndeterminate = false
+    }
+
+    private fun handleDecrypting() {
+        holder.fileDownloadProgress.isIndeterminate = true
+    }
+
+    private fun handleProgress(state: ContentDownloadStateTracker.State.Downloading) {
+        doHandleProgress(state.current, state.total)
+    }
+
+    private fun doHandleProgress(current: Long, total: Long) {
+        val percent = 100L * (current.toFloat() / total.toFloat())
+        holder.fileDownloadProgress.isIndeterminate = false
+        holder.fileDownloadProgress.progress = percent.toInt()
+        if (!hasDLResource) {
+            holder.fileImageView.setImageResource(R.drawable.ic_download)
+            hasDLResource = true
+        }
+    }
+
+    private fun handleFailure() {
+        holder.fileDownloadProgress.isIndeterminate = false
+        holder.fileDownloadProgress.progress = 0
+        holder.fileImageView.setImageResource(R.drawable.ic_close_round)
+    }
+
+    private fun handleSuccess() {
+        holder.fileDownloadProgress.isIndeterminate = false
+        holder.fileDownloadProgress.progress = 100
+        holder.fileImageView.setImageResource(R.drawable.ic_paperclip)
+    }
+}

--- a/vector/src/main/java/im/vector/riotx/features/home/room/detail/timeline/helper/ContentDownloadStateTrackerBinder.kt
+++ b/vector/src/main/java/im/vector/riotx/features/home/room/detail/timeline/helper/ContentDownloadStateTrackerBinder.kt
@@ -19,7 +19,7 @@ package im.vector.riotx.features.home.room.detail.timeline.helper
 import android.graphics.drawable.Drawable
 import androidx.vectordrawable.graphics.drawable.Animatable2Compat
 import androidx.vectordrawable.graphics.drawable.AnimatedVectorDrawableCompat
-import im.vector.matrix.android.internal.session.download.ContentDownloadStateTracker
+import im.vector.matrix.android.api.session.file.ContentDownloadStateTracker
 import im.vector.riotx.R
 import im.vector.riotx.core.di.ActiveSessionHolder
 import im.vector.riotx.core.di.ScreenScope

--- a/vector/src/main/java/im/vector/riotx/features/home/room/detail/timeline/helper/MessageInformationDataFactory.kt
+++ b/vector/src/main/java/im/vector/riotx/features/home/room/detail/timeline/helper/MessageInformationDataFactory.kt
@@ -21,9 +21,13 @@ package im.vector.riotx.features.home.room.detail.timeline.helper
 import im.vector.matrix.android.api.extensions.orFalse
 import im.vector.matrix.android.api.session.Session
 import im.vector.matrix.android.api.session.events.model.EventType
+import im.vector.matrix.android.api.session.events.model.isFileMessage
 import im.vector.matrix.android.api.session.events.model.toModel
 import im.vector.matrix.android.api.session.room.model.ReferencesAggregatedContent
+import im.vector.matrix.android.api.session.room.model.message.MessageContent
 import im.vector.matrix.android.api.session.room.model.message.MessageVerificationRequestContent
+import im.vector.matrix.android.api.session.room.model.message.MessageWithAttachmentContent
+import im.vector.matrix.android.api.session.room.model.message.getFileUrl
 import im.vector.matrix.android.api.session.room.send.SendState
 import im.vector.matrix.android.api.session.room.timeline.TimelineEvent
 import im.vector.matrix.android.api.session.room.timeline.getLastMessageContent
@@ -111,7 +115,8 @@ class MessageInformationDataFactory @Inject constructor(private val session: Ses
                     ReferencesInfoData(verificationState)
                 },
                 sentByMe = event.root.senderId == session.myUserId,
-                e2eDecoration = e2eDecoration
+                e2eDecoration = e2eDecoration,
+                isDowloaded = isDownloaded
         )
     }
 

--- a/vector/src/main/java/im/vector/riotx/features/home/room/detail/timeline/helper/MessageInformationDataFactory.kt
+++ b/vector/src/main/java/im/vector/riotx/features/home/room/detail/timeline/helper/MessageInformationDataFactory.kt
@@ -21,13 +21,9 @@ package im.vector.riotx.features.home.room.detail.timeline.helper
 import im.vector.matrix.android.api.extensions.orFalse
 import im.vector.matrix.android.api.session.Session
 import im.vector.matrix.android.api.session.events.model.EventType
-import im.vector.matrix.android.api.session.events.model.isFileMessage
 import im.vector.matrix.android.api.session.events.model.toModel
 import im.vector.matrix.android.api.session.room.model.ReferencesAggregatedContent
-import im.vector.matrix.android.api.session.room.model.message.MessageContent
 import im.vector.matrix.android.api.session.room.model.message.MessageVerificationRequestContent
-import im.vector.matrix.android.api.session.room.model.message.MessageWithAttachmentContent
-import im.vector.matrix.android.api.session.room.model.message.getFileUrl
 import im.vector.matrix.android.api.session.room.send.SendState
 import im.vector.matrix.android.api.session.room.timeline.TimelineEvent
 import im.vector.matrix.android.api.session.room.timeline.getLastMessageContent
@@ -115,8 +111,7 @@ class MessageInformationDataFactory @Inject constructor(private val session: Ses
                     ReferencesInfoData(verificationState)
                 },
                 sentByMe = event.root.senderId == session.myUserId,
-                e2eDecoration = e2eDecoration,
-                isDowloaded = isDownloaded
+                e2eDecoration = e2eDecoration
         )
     }
 

--- a/vector/src/main/java/im/vector/riotx/features/home/room/detail/timeline/item/MessageFileItem.kt
+++ b/vector/src/main/java/im/vector/riotx/features/home/room/detail/timeline/item/MessageFileItem.kt
@@ -49,6 +49,9 @@ abstract class MessageFileItem : AbsMessageItem<MessageFileItem.Holder>() {
     var izLocalFile = false
 
     @EpoxyAttribute
+    var izDownloaded = false
+
+    @EpoxyAttribute
     lateinit var contentUploadStateTrackerBinder: ContentUploadStateTrackerBinder
 
     @EpoxyAttribute
@@ -60,18 +63,21 @@ abstract class MessageFileItem : AbsMessageItem<MessageFileItem.Holder>() {
         if (!attributes.informationData.sendState.hasFailed()) {
             contentUploadStateTrackerBinder.bind(attributes.informationData.eventId, izLocalFile, holder.progressLayout)
         } else {
+            holder.fileImageView.setImageResource(R.drawable.ic_cross)
             holder.progressLayout.isVisible = false
         }
-        if (!attributes.informationData.isDowloaded) {
-            contentDownloadStateTrackerBinder.bind(mxcUrl, holder)
-        }
         holder.filenameView.text = filename
-        if (attributes.informationData.isDowloaded) {
+        if (attributes.informationData.sendState.isSending()) {
             holder.fileImageView.setImageResource(iconRes)
-            holder.fileDownloadProgress.progress = 100
         } else {
-            holder.fileImageView.setImageResource(R.drawable.ic_download)
-            holder.fileDownloadProgress.progress = 0
+            if (izDownloaded) {
+                holder.fileImageView.setImageResource(iconRes)
+                holder.fileDownloadProgress.progress = 100
+            } else {
+                contentDownloadStateTrackerBinder.bind(mxcUrl, holder)
+                holder.fileImageView.setImageResource(R.drawable.ic_download)
+                holder.fileDownloadProgress.progress = 0
+            }
         }
 //        holder.view.setOnClickListener(clickListener)
 

--- a/vector/src/main/java/im/vector/riotx/features/home/room/detail/timeline/item/MessageFileItem.kt
+++ b/vector/src/main/java/im/vector/riotx/features/home/room/detail/timeline/item/MessageFileItem.kt
@@ -17,15 +17,16 @@
 package im.vector.riotx.features.home.room.detail.timeline.item
 
 import android.graphics.Paint
-import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
+import android.widget.ProgressBar
 import android.widget.TextView
 import androidx.annotation.DrawableRes
 import androidx.core.view.isVisible
 import com.airbnb.epoxy.EpoxyAttribute
 import com.airbnb.epoxy.EpoxyModelClass
 import im.vector.riotx.R
+import im.vector.riotx.features.home.room.detail.timeline.helper.ContentDownloadStateTrackerBinder
 import im.vector.riotx.features.home.room.detail.timeline.helper.ContentUploadStateTrackerBinder
 
 @EpoxyModelClass(layout = R.layout.item_timeline_event_base)
@@ -33,15 +34,25 @@ abstract class MessageFileItem : AbsMessageItem<MessageFileItem.Holder>() {
 
     @EpoxyAttribute
     var filename: CharSequence = ""
+
+    @EpoxyAttribute
+    var mxcUrl: String = ""
+
     @EpoxyAttribute
     @DrawableRes
     var iconRes: Int = 0
-    @EpoxyAttribute(EpoxyAttribute.Option.DoNotHash)
-    var clickListener: View.OnClickListener? = null
+
+//    @EpoxyAttribute(EpoxyAttribute.Option.DoNotHash)
+//    var clickListener: View.OnClickListener? = null
+
     @EpoxyAttribute
     var izLocalFile = false
+
     @EpoxyAttribute
     lateinit var contentUploadStateTrackerBinder: ContentUploadStateTrackerBinder
+
+    @EpoxyAttribute
+    lateinit var contentDownloadStateTrackerBinder: ContentDownloadStateTrackerBinder
 
     override fun bind(holder: Holder) {
         super.bind(holder)
@@ -51,15 +62,30 @@ abstract class MessageFileItem : AbsMessageItem<MessageFileItem.Holder>() {
         } else {
             holder.progressLayout.isVisible = false
         }
+        if (!attributes.informationData.isDowloaded) {
+            contentDownloadStateTrackerBinder.bind(mxcUrl, holder)
+        }
         holder.filenameView.text = filename
-        holder.fileImageView.setImageResource(iconRes)
-        holder.filenameView.setOnClickListener(clickListener)
+        if (attributes.informationData.isDowloaded) {
+            holder.fileImageView.setImageResource(iconRes)
+            holder.fileDownloadProgress.progress = 100
+        } else {
+            holder.fileImageView.setImageResource(R.drawable.ic_download)
+            holder.fileDownloadProgress.progress = 0
+        }
+//        holder.view.setOnClickListener(clickListener)
+
+        holder.filenameView.setOnClickListener(attributes.itemClickListener)
+        holder.filenameView.setOnLongClickListener(attributes.itemLongClickListener)
+        holder.fileImageWrapper.setOnClickListener(attributes.itemClickListener)
+        holder.fileImageWrapper.setOnLongClickListener(attributes.itemLongClickListener)
         holder.filenameView.paintFlags = (holder.filenameView.paintFlags or Paint.UNDERLINE_TEXT_FLAG)
     }
 
     override fun unbind(holder: Holder) {
         super.unbind(holder)
         contentUploadStateTrackerBinder.unbind(attributes.informationData.eventId)
+        contentDownloadStateTrackerBinder.unbind(mxcUrl)
     }
 
     override fun getViewType() = STUB_ID
@@ -67,7 +93,9 @@ abstract class MessageFileItem : AbsMessageItem<MessageFileItem.Holder>() {
     class Holder : AbsMessageItem.Holder(STUB_ID) {
         val progressLayout by bind<ViewGroup>(R.id.messageFileUploadProgressLayout)
         val fileLayout by bind<ViewGroup>(R.id.messageFileLayout)
-        val fileImageView by bind<ImageView>(R.id.messageFileImageView)
+        val fileImageView by bind<ImageView>(R.id.messageFileIconView)
+        val fileImageWrapper by bind<ViewGroup>(R.id.messageFileImageView)
+        val fileDownloadProgress by bind<ProgressBar>(R.id.messageFileProgressbar)
         val filenameView by bind<TextView>(R.id.messageFilenameView)
     }
 

--- a/vector/src/main/java/im/vector/riotx/features/home/room/detail/timeline/item/MessageInformationData.kt
+++ b/vector/src/main/java/im/vector/riotx/features/home/room/detail/timeline/item/MessageInformationData.kt
@@ -41,9 +41,7 @@ data class MessageInformationData(
         val readReceipts: List<ReadReceiptData> = emptyList(),
         val referencesInfoData: ReferencesInfoData? = null,
         val sentByMe : Boolean,
-        val e2eDecoration: E2EDecoration = E2EDecoration.NONE,
-        // used for file messages
-        val isDowloaded: Boolean = true
+        val e2eDecoration: E2EDecoration = E2EDecoration.NONE
 ) : Parcelable {
 
     val matrixItem: MatrixItem

--- a/vector/src/main/java/im/vector/riotx/features/home/room/detail/timeline/item/MessageInformationData.kt
+++ b/vector/src/main/java/im/vector/riotx/features/home/room/detail/timeline/item/MessageInformationData.kt
@@ -41,7 +41,9 @@ data class MessageInformationData(
         val readReceipts: List<ReadReceiptData> = emptyList(),
         val referencesInfoData: ReferencesInfoData? = null,
         val sentByMe : Boolean,
-        val e2eDecoration: E2EDecoration = E2EDecoration.NONE
+        val e2eDecoration: E2EDecoration = E2EDecoration.NONE,
+        // used for file messages
+        val isDowloaded: Boolean = true
 ) : Parcelable {
 
     val matrixItem: MatrixItem

--- a/vector/src/main/java/im/vector/riotx/features/media/ImageContentRenderer.kt
+++ b/vector/src/main/java/im/vector/riotx/features/media/ImageContentRenderer.kt
@@ -49,6 +49,7 @@ class ImageContentRenderer @Inject constructor(private val activeSessionHolder: 
     data class Data(
             val eventId: String,
             val filename: String,
+            val mimeType: String?,
             val url: String?,
             val elementToDecrypt: ElementToDecrypt?,
             val height: Int?,

--- a/vector/src/main/java/im/vector/riotx/features/media/ImageMediaViewerActivity.kt
+++ b/vector/src/main/java/im/vector/riotx/features/media/ImageMediaViewerActivity.kt
@@ -133,7 +133,7 @@ class ImageMediaViewerActivity : VectorBaseActivity() {
     }
 
     private fun onShareActionClicked() {
-        session.downloadFile(
+        session.fileService().downloadFile(
                 FileService.DownloadMode.FOR_EXTERNAL_SHARE,
                 mediaData.eventId,
                 mediaData.filename,

--- a/vector/src/main/java/im/vector/riotx/features/media/ImageMediaViewerActivity.kt
+++ b/vector/src/main/java/im/vector/riotx/features/media/ImageMediaViewerActivity.kt
@@ -137,6 +137,7 @@ class ImageMediaViewerActivity : VectorBaseActivity() {
                 FileService.DownloadMode.FOR_EXTERNAL_SHARE,
                 mediaData.eventId,
                 mediaData.filename,
+                mediaData.mimeType,
                 mediaData.url,
                 mediaData.elementToDecrypt,
                 object : MatrixCallback<File> {

--- a/vector/src/main/java/im/vector/riotx/features/media/VideoContentRenderer.kt
+++ b/vector/src/main/java/im/vector/riotx/features/media/VideoContentRenderer.kt
@@ -40,6 +40,7 @@ class VideoContentRenderer @Inject constructor(private val activeSessionHolder: 
     data class Data(
             val eventId: String,
             val filename: String,
+            val mimeType: String?,
             val url: String?,
             val elementToDecrypt: ElementToDecrypt?,
             val thumbnailMediaData: ImageContentRenderer.Data
@@ -66,12 +67,13 @@ class VideoContentRenderer @Inject constructor(private val activeSessionHolder: 
 
                 activeSessionHolder.getActiveSession()
                         .downloadFile(
-                                FileService.DownloadMode.FOR_INTERNAL_USE,
-                                data.eventId,
-                                data.filename,
-                                data.url,
-                                data.elementToDecrypt,
-                                object : MatrixCallback<File> {
+                                downloadMode = FileService.DownloadMode.FOR_INTERNAL_USE,
+                                id = data.eventId,
+                                fileName = data.filename,
+                                mimeType = null,
+                                url = data.url,
+                                elementToDecrypt = data.elementToDecrypt,
+                                callback = object : MatrixCallback<File> {
                                     override fun onSuccess(data: File) {
                                         thumbnailView.isVisible = false
                                         loadingView.isVisible = false
@@ -104,12 +106,13 @@ class VideoContentRenderer @Inject constructor(private val activeSessionHolder: 
 
                 activeSessionHolder.getActiveSession()
                         .downloadFile(
-                                FileService.DownloadMode.FOR_INTERNAL_USE,
-                                data.eventId,
-                                data.filename,
-                                data.url,
-                                null,
-                                object : MatrixCallback<File> {
+                                downloadMode = FileService.DownloadMode.FOR_INTERNAL_USE,
+                                id = data.eventId,
+                                fileName = data.filename,
+                                mimeType = data.mimeType,
+                                url = data.url,
+                                elementToDecrypt = null,
+                                callback = object : MatrixCallback<File> {
                                     override fun onSuccess(data: File) {
                                         thumbnailView.isVisible = false
                                         loadingView.isVisible = false

--- a/vector/src/main/java/im/vector/riotx/features/media/VideoContentRenderer.kt
+++ b/vector/src/main/java/im/vector/riotx/features/media/VideoContentRenderer.kt
@@ -65,7 +65,7 @@ class VideoContentRenderer @Inject constructor(private val activeSessionHolder: 
                 thumbnailView.isVisible = true
                 loadingView.isVisible = true
 
-                activeSessionHolder.getActiveSession()
+                activeSessionHolder.getActiveSession().fileService()
                         .downloadFile(
                                 downloadMode = FileService.DownloadMode.FOR_INTERNAL_USE,
                                 id = data.eventId,
@@ -104,7 +104,7 @@ class VideoContentRenderer @Inject constructor(private val activeSessionHolder: 
                 thumbnailView.isVisible = true
                 loadingView.isVisible = true
 
-                activeSessionHolder.getActiveSession()
+                activeSessionHolder.getActiveSession().fileService()
                         .downloadFile(
                                 downloadMode = FileService.DownloadMode.FOR_INTERNAL_USE,
                                 id = data.eventId,

--- a/vector/src/main/java/im/vector/riotx/features/media/VideoMediaViewerActivity.kt
+++ b/vector/src/main/java/im/vector/riotx/features/media/VideoMediaViewerActivity.kt
@@ -82,6 +82,7 @@ class VideoMediaViewerActivity : VectorBaseActivity() {
                 FileService.DownloadMode.FOR_EXTERNAL_SHARE,
                 mediaData.eventId,
                 mediaData.filename,
+                mediaData.mimeType,
                 mediaData.url,
                 mediaData.elementToDecrypt,
                 object : MatrixCallback<File> {

--- a/vector/src/main/java/im/vector/riotx/features/media/VideoMediaViewerActivity.kt
+++ b/vector/src/main/java/im/vector/riotx/features/media/VideoMediaViewerActivity.kt
@@ -78,7 +78,7 @@ class VideoMediaViewerActivity : VectorBaseActivity() {
     }
 
     private fun onShareActionClicked() {
-        session.downloadFile(
+        session.fileService().downloadFile(
                 FileService.DownloadMode.FOR_EXTERNAL_SHARE,
                 mediaData.eventId,
                 mediaData.filename,

--- a/vector/src/main/java/im/vector/riotx/features/notifications/NotificationUtils.kt
+++ b/vector/src/main/java/im/vector/riotx/features/notifications/NotificationUtils.kt
@@ -480,6 +480,26 @@ class NotificationUtils @Inject constructor(private val context: Context,
                 .build()
     }
 
+    fun buildDownloadFileNotification(uri: Uri, fileName: String, mimeType: String): Notification {
+        return NotificationCompat.Builder(context, SILENT_NOTIFICATION_CHANNEL_ID)
+                .setGroup(stringProvider.getString(R.string.app_name))
+                .setSmallIcon(R.drawable.ic_download)
+                .setContentText(stringProvider.getString(R.string.downloaded_file, fileName))
+                .setAutoCancel(true)
+                .apply {
+                    val intent = Intent(Intent.ACTION_VIEW).apply {
+                        setDataAndType(uri, mimeType)
+                        addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                    }
+                    PendingIntent.getActivity(
+                            context, System.currentTimeMillis().toInt(), intent, PendingIntent.FLAG_UPDATE_CURRENT
+                    ).let {
+                        setContentIntent(it)
+                    }
+                }
+                .build()
+    }
+
     /**
      * Build a notification for a Room
      */

--- a/vector/src/main/java/im/vector/riotx/features/roomprofile/uploads/RoomUploadsFragment.kt
+++ b/vector/src/main/java/im/vector/riotx/features/roomprofile/uploads/RoomUploadsFragment.kt
@@ -22,7 +22,6 @@ import androidx.core.net.toUri
 import com.airbnb.mvrx.args
 import com.airbnb.mvrx.fragmentViewModel
 import com.airbnb.mvrx.withState
-import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.tabs.TabLayoutMediator
 import im.vector.matrix.android.api.util.toMatrixItem
 import im.vector.riotx.R
@@ -33,6 +32,7 @@ import im.vector.riotx.core.resources.StringProvider
 import im.vector.riotx.core.utils.saveMedia
 import im.vector.riotx.core.utils.shareMedia
 import im.vector.riotx.features.home.AvatarRenderer
+import im.vector.riotx.features.notifications.NotificationUtils
 import im.vector.riotx.features.roomprofile.RoomProfileArgs
 import kotlinx.android.synthetic.main.fragment_room_uploads.*
 import javax.inject.Inject
@@ -40,7 +40,8 @@ import javax.inject.Inject
 class RoomUploadsFragment @Inject constructor(
         private val viewModelFactory: RoomUploadsViewModel.Factory,
         private val stringProvider: StringProvider,
-        private val avatarRenderer: AvatarRenderer
+        private val avatarRenderer: AvatarRenderer,
+        private val notificationUtils: NotificationUtils
 ) : VectorBaseFragment(), RoomUploadsViewModel.Factory by viewModelFactory {
 
     private val roomProfileArgs: RoomProfileArgs by args()
@@ -70,17 +71,13 @@ class RoomUploadsFragment @Inject constructor(
                     shareMedia(requireContext(), it.file, getMimeTypeFromUri(requireContext(), it.file.toUri()))
                 }
                 is RoomUploadsViewEvents.FileReadyForSaving  -> {
-                    val saved = saveMedia(
+                    saveMedia(
                             context = requireContext(),
                             file = it.file,
                             title = it.title,
-                            mediaMimeType = getMimeTypeFromUri(requireContext(), it.file.toUri())
+                            mediaMimeType = getMimeTypeFromUri(requireContext(), it.file.toUri()),
+                            notificationUtils = notificationUtils
                     )
-                    if (saved) {
-                        Snackbar.make(roomUploadsCoordinator, R.string.media_file_added_to_gallery, Snackbar.LENGTH_LONG).show()
-                    } else {
-                        Snackbar.make(roomUploadsCoordinator, R.string.error_adding_media_file_to_gallery, Snackbar.LENGTH_LONG).show()
-                    }
                 }
                 is RoomUploadsViewEvents.Failure             -> showFailure(it.throwable)
             }.exhaustive

--- a/vector/src/main/java/im/vector/riotx/features/roomprofile/uploads/RoomUploadsViewModel.kt
+++ b/vector/src/main/java/im/vector/riotx/features/roomprofile/uploads/RoomUploadsViewModel.kt
@@ -136,7 +136,7 @@ class RoomUploadsViewModel @AssistedInject constructor(
         viewModelScope.launch {
             try {
                 val file = awaitCallback<File> {
-                    session.downloadFile(
+                    session.fileService().downloadFile(
                             downloadMode = FileService.DownloadMode.FOR_EXTERNAL_SHARE,
                             id = action.uploadEvent.eventId,
                             fileName = action.uploadEvent.contentWithAttachmentContent.body,
@@ -157,7 +157,7 @@ class RoomUploadsViewModel @AssistedInject constructor(
         viewModelScope.launch {
             try {
                 val file = awaitCallback<File> {
-                    session.downloadFile(
+                    session.fileService().downloadFile(
                             FileService.DownloadMode.FOR_EXTERNAL_SHARE,
                             action.uploadEvent.eventId,
                             action.uploadEvent.contentWithAttachmentContent.body,

--- a/vector/src/main/java/im/vector/riotx/features/roomprofile/uploads/RoomUploadsViewModel.kt
+++ b/vector/src/main/java/im/vector/riotx/features/roomprofile/uploads/RoomUploadsViewModel.kt
@@ -137,12 +137,13 @@ class RoomUploadsViewModel @AssistedInject constructor(
             try {
                 val file = awaitCallback<File> {
                     session.downloadFile(
-                            FileService.DownloadMode.FOR_EXTERNAL_SHARE,
-                            action.uploadEvent.eventId,
-                            action.uploadEvent.contentWithAttachmentContent.body,
-                            action.uploadEvent.contentWithAttachmentContent.getFileUrl(),
-                            action.uploadEvent.contentWithAttachmentContent.encryptedFileInfo?.toElementToDecrypt(),
-                            it
+                            downloadMode = FileService.DownloadMode.FOR_EXTERNAL_SHARE,
+                            id = action.uploadEvent.eventId,
+                            fileName = action.uploadEvent.contentWithAttachmentContent.body,
+                            url = action.uploadEvent.contentWithAttachmentContent.getFileUrl(),
+                            mimeType = action.uploadEvent.contentWithAttachmentContent.mimeType,
+                            elementToDecrypt = action.uploadEvent.contentWithAttachmentContent.encryptedFileInfo?.toElementToDecrypt(),
+                            callback = it
                     )
                 }
                 _viewEvents.post(RoomUploadsViewEvents.FileReadyForSharing(file))
@@ -161,6 +162,7 @@ class RoomUploadsViewModel @AssistedInject constructor(
                             action.uploadEvent.eventId,
                             action.uploadEvent.contentWithAttachmentContent.body,
                             action.uploadEvent.contentWithAttachmentContent.getFileUrl(),
+                            action.uploadEvent.contentWithAttachmentContent.mimeType,
                             action.uploadEvent.contentWithAttachmentContent.encryptedFileInfo?.toElementToDecrypt(),
                             it)
                 }

--- a/vector/src/main/java/im/vector/riotx/features/roomprofile/uploads/media/UploadsMediaController.kt
+++ b/vector/src/main/java/im/vector/riotx/features/roomprofile/uploads/media/UploadsMediaController.kt
@@ -115,6 +115,7 @@ class UploadsMediaController @Inject constructor(
                 eventId = eventId,
                 filename = messageContent.body,
                 url = messageContent.getFileUrl(),
+                mimeType = messageContent.mimeType,
                 elementToDecrypt = messageContent.encryptedFileInfo?.toElementToDecrypt(),
                 height = messageContent.info?.height,
                 maxHeight = itemSize,
@@ -129,6 +130,7 @@ class UploadsMediaController @Inject constructor(
         val thumbnailData = ImageContentRenderer.Data(
                 eventId = eventId,
                 filename = messageContent.body,
+                mimeType = messageContent.mimeType,
                 url = messageContent.videoInfo?.thumbnailFile?.url ?: messageContent.videoInfo?.thumbnailUrl,
                 elementToDecrypt = messageContent.videoInfo?.thumbnailFile?.toElementToDecrypt(),
                 height = messageContent.videoInfo?.height,
@@ -140,6 +142,7 @@ class UploadsMediaController @Inject constructor(
         return VideoContentRenderer.Data(
                 eventId = eventId,
                 filename = messageContent.body,
+                mimeType = messageContent.mimeType,
                 url = messageContent.getFileUrl(),
                 elementToDecrypt = messageContent.encryptedFileInfo?.toElementToDecrypt(),
                 thumbnailMediaData = thumbnailData

--- a/vector/src/main/java/im/vector/riotx/features/settings/VectorSettingsGeneralFragment.kt
+++ b/vector/src/main/java/im/vector/riotx/features/settings/VectorSettingsGeneralFragment.kt
@@ -237,7 +237,7 @@ class VectorSettingsGeneralFragment : VectorSettingsBaseFragment() {
 
         // clear medias cache
         findPreference<VectorPreference>(VectorPreferences.SETTINGS_CLEAR_MEDIA_CACHE_PREFERENCE_KEY)!!.let {
-            val size = getSizeOfFiles(File(requireContext().cacheDir, DiskCache.Factory.DEFAULT_DISK_CACHE_DIR)) + session.getCacheSize()
+            val size = getSizeOfFiles(File(requireContext().cacheDir, DiskCache.Factory.DEFAULT_DISK_CACHE_DIR)) + session.fileService().getCacheSize()
 
             it.summary = TextUtils.formatFileSize(requireContext(), size.toLong())
 
@@ -247,7 +247,7 @@ class VectorSettingsGeneralFragment : VectorSettingsBaseFragment() {
                     displayLoadingView()
 
                     Glide.get(requireContext()).clearMemory()
-                    session.clearCache()
+                    session.fileService().clearCache()
 
                     var newSize = 0
 
@@ -256,7 +256,7 @@ class VectorSettingsGeneralFragment : VectorSettingsBaseFragment() {
                         Glide.get(requireContext()).clearDiskCache()
 
                         newSize = getSizeOfFiles(File(requireContext().cacheDir, DiskCache.Factory.DEFAULT_DISK_CACHE_DIR))
-                        newSize += session.getCacheSize()
+                        newSize += session.fileService().getCacheSize()
                     }
 
                     it.summary = TextUtils.formatFileSize(requireContext(), newSize.toLong())

--- a/vector/src/main/java/im/vector/riotx/features/settings/VectorSettingsGeneralFragment.kt
+++ b/vector/src/main/java/im/vector/riotx/features/settings/VectorSettingsGeneralFragment.kt
@@ -237,7 +237,7 @@ class VectorSettingsGeneralFragment : VectorSettingsBaseFragment() {
 
         // clear medias cache
         findPreference<VectorPreference>(VectorPreferences.SETTINGS_CLEAR_MEDIA_CACHE_PREFERENCE_KEY)!!.let {
-            val size = getSizeOfFiles(File(requireContext().cacheDir, DiskCache.Factory.DEFAULT_DISK_CACHE_DIR))
+            val size = getSizeOfFiles(File(requireContext().cacheDir, DiskCache.Factory.DEFAULT_DISK_CACHE_DIR)) + session.getCacheSize()
 
             it.summary = TextUtils.formatFileSize(requireContext(), size.toLong())
 
@@ -247,6 +247,7 @@ class VectorSettingsGeneralFragment : VectorSettingsBaseFragment() {
                     displayLoadingView()
 
                     Glide.get(requireContext()).clearMemory()
+                    session.clearCache()
 
                     var newSize = 0
 
@@ -255,6 +256,7 @@ class VectorSettingsGeneralFragment : VectorSettingsBaseFragment() {
                         Glide.get(requireContext()).clearDiskCache()
 
                         newSize = getSizeOfFiles(File(requireContext().cacheDir, DiskCache.Factory.DEFAULT_DISK_CACHE_DIR))
+                        newSize += session.getCacheSize()
                     }
 
                     it.summary = TextUtils.formatFileSize(requireContext(), newSize.toLong())

--- a/vector/src/main/res/drawable/file_progress_bar.xml
+++ b/vector/src/main/res/drawable/file_progress_bar.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item android:id="@android:id/background">
+        <shape>
+            <corners android:radius="8dp" />
+            <solid android:color="?attr/riotx_room_active_widgets_banner_bg" />
+        </shape>
+    </item>
+
+    <item android:id="@android:id/progress">
+        <clip>
+            <shape>
+                <corners android:radius="8dp" />
+                <solid android:color="@color/riotx_notice_secondary_alpha12" />
+            </shape>
+        </clip>
+    </item>
+</layer-list>

--- a/vector/src/main/res/drawable/ic_cross.xml
+++ b/vector/src/main/res/drawable/ic_cross.xml
@@ -1,0 +1,20 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M18,6L6,18"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#2E2F32"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M6,6L18,18"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#2E2F32"
+      android:strokeLineCap="round"/>
+</vector>

--- a/vector/src/main/res/drawable/ic_download_anim.xml
+++ b/vector/src/main/res/drawable/ic_download_anim.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="utf-8"?>
+<animated-vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:aapt="http://schemas.android.com/aapt">
+    <aapt:attr name="android:drawable">
+        <vector
+            android:name="vector"
+            android:width="24dp"
+            android:height="24dp"
+            android:viewportWidth="24"
+            android:viewportHeight="24">
+            <path
+                android:name="path"
+                android:pathData="M 3 17 L 3 20 C 3 21.105 3.895 22 5 22 L 19 22 C 20.105 22 21 21.105 21 20 L 21 17"
+                android:fillColor="#00000000"
+                android:strokeColor="#2E2F32"
+                android:strokeWidth="2"
+                android:strokeLineCap="round"
+                android:strokeLineJoin="round"/>
+            <path
+                android:name="path_1"
+                android:pathData="M 8 12 L 12 16 L 16 12"
+                android:fillColor="#00000000"
+                android:strokeColor="#2E2F32"
+                android:strokeWidth="2"
+                android:strokeLineCap="round"
+                android:strokeLineJoin="round"/>
+            <path
+                android:name="path_2"
+                android:pathData="M 12 2 L 12 16"
+                android:fillColor="#00000000"
+                android:strokeColor="#2E2F32"
+                android:strokeWidth="2"
+                android:strokeLineCap="round"
+                android:strokeLineJoin="round"/>
+        </vector>
+    </aapt:attr>
+    <target android:name="path_2">
+        <aapt:attr name="android:animation">
+            <set>
+                <objectAnimator
+                    android:propertyName="pathData"
+                    android:duration="682"
+                    android:valueFrom="M 12 2 L 12 16"
+                    android:valueTo="M 12 14 L 12 16"
+                    android:valueType="pathType"
+                    android:interpolator="@android:anim/accelerate_decelerate_interpolator"/>
+                <objectAnimator
+                    android:propertyName="pathData"
+                    android:startOffset="682"
+                    android:duration="118"
+                    android:valueFrom="M 12 14 L 12 16"
+                    android:valueTo="M 12 2 L 12 16"
+                    android:valueType="pathType"
+                    android:interpolator="@android:interpolator/fast_out_slow_in"/>
+            </set>
+        </aapt:attr>
+    </target>
+    <target android:name="path_1">
+        <aapt:attr name="android:animation">
+            <set>
+                <objectAnimator
+                    android:propertyName="pathData"
+                    android:duration="682"
+                    android:valueFrom="M 8 12 L 12 16 L 16 12"
+                    android:valueTo="M 8 14 L 12 18 L 16 14"
+                    android:valueType="pathType"
+                    android:interpolator="@android:interpolator/fast_out_slow_in"/>
+                <objectAnimator
+                    android:propertyName="pathData"
+                    android:startOffset="682"
+                    android:duration="118"
+                    android:valueFrom="M 8 14 L 12 18 L 16 14"
+                    android:valueTo="M 8 12 L 12 16 L 16 12"
+                    android:valueType="pathType"
+                    android:interpolator="@android:interpolator/fast_out_slow_in"/>
+            </set>
+        </aapt:attr>
+    </target>
+    <target android:name="path">
+        <aapt:attr name="android:animation">
+            <set>
+                <objectAnimator
+                    android:propertyName="pathData"
+                    android:startOffset="3"
+                    android:duration="697"
+                    android:valueFrom="M 3 18 L 3 20 C 3 21.105 3.895 22 5 22 L 19 22 C 20.105 22 21 21.105 21 20 L 21 18"
+                    android:valueTo="M 3 15 L 3 20 C 3 21.105 3.895 22 5 22 L 19 22 C 20.105 22 21 21.105 21 20 L 21 15"
+                    android:valueType="pathType"
+                    android:interpolator="@android:interpolator/linear_out_slow_in"/>
+                <objectAnimator
+                    android:propertyName="pathData"
+                    android:startOffset="700"
+                    android:duration="100"
+                    android:valueFrom="M 3 15 L 3 20 C 3 21.105 3.895 22 5 22 L 19 22 C 20.105 22 21 21.105 21 20 L 21 15"
+                    android:valueTo="M 3 18 L 3 20 C 3 21.105 3.895 22 5 22 L 19 22 C 20.105 22 21 21.105 21 20 L 21 18"
+                    android:valueType="pathType"
+                    android:interpolator="@android:interpolator/fast_out_slow_in"/>
+            </set>
+        </aapt:attr>
+    </target>
+</animated-vector>

--- a/vector/src/main/res/drawable/ic_headphones.xml
+++ b/vector/src/main/res/drawable/ic_headphones.xml
@@ -1,0 +1,16 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M3,18V12C3,7.0294 7.0294,3 12,3C16.9706,3 21,7.0294 21,12V18"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#2E2F32"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M21,14H22C22,13.4477 21.5523,13 21,13V14ZM3,14V13C2.4477,13 2,13.4477 2,14H3ZM20,19C20,19.5523 19.5523,20 19,20V22C20.6569,22 22,20.6569 22,19H20ZM19,20H18V22H19V20ZM18,20C17.4477,20 17,19.5523 17,19H15C15,20.6569 16.3431,22 18,22V20ZM17,19V16H15V19H17ZM17,16C17,15.4477 17.4477,15 18,15V13C16.3431,13 15,14.3431 15,16H17ZM18,15H21V13H18V15ZM20,14V19H22V14H20ZM2,19C2,20.6569 3.3431,22 5,22V20C4.4477,20 4,19.5523 4,19H2ZM5,22H6V20H5V22ZM6,22C7.6568,22 9,20.6569 9,19H7C7,19.5523 6.5523,20 6,20V22ZM9,19V16H7V19H9ZM9,16C9,14.3431 7.6568,13 6,13V15C6.5523,15 7,15.4477 7,16H9ZM6,13H3V15H6V13ZM2,14V19H4V14H2Z"
+      android:fillColor="#2E2F32"/>
+</vector>

--- a/vector/src/main/res/drawable/ic_paperclip.xml
+++ b/vector/src/main/res/drawable/ic_paperclip.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M21.7184,11.4122L12.5284,20.6022C10.1839,22.9467 6.3828,22.9467 4.0384,20.6022C1.6939,18.2578 1.6939,14.4567 4.0384,12.1122L13.2284,2.9222C14.7913,1.3593 17.3254,1.3593 18.8884,2.9222C20.4513,4.4852 20.4513,7.0193 18.8884,8.5822L9.6884,17.7722C8.9069,18.5537 7.6399,18.5537 6.8584,17.7722C6.0769,16.9907 6.0769,15.7237 6.8584,14.9422L15.3484,6.4622"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#2E2F32"
+      android:strokeLineCap="round"/>
+</vector>

--- a/vector/src/main/res/layout/item_timeline_event_file_stub.xml
+++ b/vector/src/main/res/layout/item_timeline_event_file_stub.xml
@@ -12,22 +12,33 @@
         android:id="@+id/messageFilee2eIcon"
         android:layout_width="14dp"
         android:layout_height="14dp"
-        android:src="@drawable/e2e_verified"
+        android:src="@drawable/ic_shield_black"
         android:visibility="gone"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         tools:visibility="visible" />
 
     <!-- the media type -->
-    <ImageView
+    <RelativeLayout
         android:id="@+id/messageFileImageView"
-        android:layout_width="@dimen/chat_avatar_size"
-        android:layout_height="@dimen/chat_avatar_size"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
         android:layout_marginStart="4dp"
-        android:layout_marginLeft="4dp"
         app:layout_constraintStart_toEndOf="@+id/messageFilee2eIcon"
-        app:layout_constraintTop_toTopOf="parent"
-        tools:src="@drawable/filetype_attachment" />
+        app:layout_constraintTop_toTopOf="parent">
+
+        <include layout="@layout/view_file_icon" />
+    </RelativeLayout>
+
+    <!--    <ImageView-->
+    <!--        android:id="@+id/messageFileImageView"-->
+    <!--        android:layout_width="@dimen/chat_avatar_size"-->
+    <!--        android:layout_height="@dimen/chat_avatar_size"-->
+    <!--        android:layout_marginStart="4dp"-->
+    <!--        android:layout_marginLeft="4dp"-->
+    <!--        app:layout_constraintStart_toEndOf="@+id/messageFilee2eIcon"-->
+    <!--        app:layout_constraintTop_toTopOf="parent"-->
+    <!--        tools:src="@drawable/filetype_attachment" />-->
 
     <!-- the media -->
     <TextView

--- a/vector/src/main/res/layout/view_file_icon.xml
+++ b/vector/src/main/res/layout/view_file_icon.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:parentTag="android.widget.RelativeLayout"
+    android:layout_width="50dp"
+    android:layout_height="50dp">
+
+    <ProgressBar
+        android:id="@+id/messageFileProgressbar"
+        style="@style/FileProgressBar"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:progress="40" />
+
+    <ImageView
+        android:id="@+id/messageFileIconView"
+        android:layout_width="20dp"
+        android:layout_height="20dp"
+        android:layout_centerInParent="true"
+        android:src="@drawable/ic_download"
+        android:tint="?vctr_notice_secondary"
+        tools:src="@drawable/ic_paperclip" />
+
+</merge>

--- a/vector/src/main/res/values/colors_riotx.xml
+++ b/vector/src/main/res/values/colors_riotx.xml
@@ -21,6 +21,7 @@
 
     <color name="riotx_notice">#FFFF4B55</color>
     <color name="riotx_notice_secondary">#FF61708B</color>
+    <color name="riotx_notice_secondary_alpha12">#1E61708B</color>
     <color name="riotx_links">#FF368BD6</color>
 
     <color name="riotx_avatar_fill_1">#FF03b381</color>

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -2404,6 +2404,7 @@ Not all features in Riot are implemented in RiotX yet. Main missing (and coming 
 
     <string name="media_file_added_to_gallery">Media file added to the Gallery</string>
     <string name="error_adding_media_file_to_gallery">Could not add media file to the Gallery</string>
+    <string name="error_saving_media_file">Could not save media file</string>
     <string name="change_password_summary">Set a new account password…</string>
 
     <string name="use_other_session_content_description">Use the latest Riot on your other devices, Riot Web, Riot Desktop, Riot iOS, RiotX for Android, or another cross-signing capable Matrix client</string>

--- a/vector/src/main/res/values/styles_riot.xml
+++ b/vector/src/main/res/values/styles_riot.xml
@@ -378,4 +378,11 @@
         <item name="android:layout_marginTop">8dp</item>
     </style>
 
+    <style name="FileProgressBar" parent="android:Widget.ProgressBar.Horizontal">
+        <item name="android:indeterminateOnly">false</item>
+        <item name="android:progressDrawable">@drawable/file_progress_bar</item>
+        <item name="android:minHeight">10dp</item>
+        <item name="android:maxHeight">40dp</item>
+    </style>
+
 </resources>


### PR DESCRIPTION

Proper handling of file download and open.
## File service improvement:
-  to check if file is already downloaded
- Get a temporary shareable Uri via secure FileProvider with temporary access

## UX will now have multiple state for File items, first click will download, second will try top open with available system app


<img width="215" alt="image" src="https://user-images.githubusercontent.com/9841565/85676900-50e2a800-b6c7-11ea-85e4-3f3bf95d0340.png">




## Various Fixes
- Downloaded  sometimes truncated.
- Click on fileItems were only working on filename view

### Improvent:
- Clear media cache clears the downloaded files
- After upload of an attachement, the fileservice is notified to avoid download just after
- And also hard to find after download on recent android (because download manager has been deprecated, app has now to handle notification)
<img width="652" alt="image" src="https://user-images.githubusercontent.com/9841565/85412071-7a85bd00-b569-11ea-80ab-b014061dda45.png">


## Demo

![downloadOrOpen2](https://user-images.githubusercontent.com/9841565/85677154-91dabc80-b6c7-11ea-8f48-26b26fcc55c5.gif)

![dl_anim](https://user-images.githubusercontent.com/9841565/85833562-39bcbc80-b792-11ea-8667-c3f57889d642.gif)

