### PR TITLE
Use vendor prefix for non merged MSC (#1537)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Improvements 🙌:
 Bugfix 🐛:
  - Fix dark theme issue on login screen (#1097)
  - Incomplete predicate in RealmCryptoStore#getOutgoingRoomKeyRequest (#1519)
+ - Use vendor prefix for non merged MSC (#1537)
 
 Translations 🗣:
  -

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/events/model/RelationType.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/events/model/RelationType.kt
@@ -26,5 +26,5 @@ object RelationType {
     /** Lets you define an event which references an existing event.*/
     const val REFERENCE = "m.reference"
     /** Lets you define an event which adds a response to an existing event.*/
-    const val RESPONSE = "m.response"
+    const val RESPONSE = "org.matrix.response"
 }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/database/query/TimelineEventFilter.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/database/query/TimelineEventFilter.kt
@@ -25,7 +25,7 @@ internal object TimelineEventFilter {
      */
     internal object Content {
         internal const val EDIT = """{*"m.relates_to"*"rel_type":*"m.replace"*}"""
-        internal const val RESPONSE = """{*"m.relates_to"*"rel_type":*"m.response"*}"""
+        internal const val RESPONSE = """{*"m.relates_to"*"rel_type":*"org.matrix.response"*}"""
     }
 
     /**


### PR DESCRIPTION
Fixes #1537 

It has been forgotten in 32c4ad9ecba32e111aff9a7e98f2f6c76b6ea36a
