### PR TITLE
Catchup tab is removed temporarily (#1565)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ Improvements 🙌:
  - Update user avatar (#1054)
  - Allow self-signed certificate (#1564)
  - Improve file download and open in timeline
+ - Catchup tab is removed temporarily (#1565)
 
 Bugfix 🐛:
  - Fix dark theme issue on login screen (#1097)

--- a/vector/src/main/java/im/vector/riotx/features/home/HomeDetailViewModel.kt
+++ b/vector/src/main/java/im/vector/riotx/features/home/HomeDetailViewModel.kt
@@ -117,8 +117,12 @@ class HomeDetailViewModel @AssistedInject constructor(@Assisted initialState: Ho
                 .observeOn(Schedulers.computation())
                 .map { it.asSequence() }
                 .subscribe { summaries ->
-                    val invites = summaries
-                            .filter { it.membership == Membership.INVITE }
+                    val invitesDm = summaries
+                            .filter { it.membership == Membership.INVITE && it.isDirect }
+                            .count()
+
+                    val invitesRoom = summaries
+                            .filter { it.membership == Membership.INVITE && it.isDirect.not() }
                             .count()
 
                     val peopleNotifications = summaries
@@ -139,12 +143,12 @@ class HomeDetailViewModel @AssistedInject constructor(@Assisted initialState: Ho
 
                     setState {
                         copy(
-                                notificationCountCatchup = peopleNotifications + roomsNotifications + invites,
+                                notificationCountCatchup = peopleNotifications + roomsNotifications + invitesDm + invitesRoom,
                                 notificationHighlightCatchup = peopleHasHighlight || roomsHasHighlight,
-                                notificationCountPeople = peopleNotifications,
-                                notificationHighlightPeople = peopleHasHighlight,
-                                notificationCountRooms = roomsNotifications,
-                                notificationHighlightRooms = roomsHasHighlight
+                                notificationCountPeople = peopleNotifications + invitesDm,
+                                notificationHighlightPeople = peopleHasHighlight || invitesDm > 0,
+                                notificationCountRooms = roomsNotifications + invitesRoom,
+                                notificationHighlightRooms = roomsHasHighlight || invitesRoom > 0
                         )
                     }
                 }

--- a/vector/src/main/java/im/vector/riotx/features/home/HomeDetailViewState.kt
+++ b/vector/src/main/java/im/vector/riotx/features/home/HomeDetailViewState.kt
@@ -27,7 +27,7 @@ import im.vector.matrix.android.api.session.sync.SyncState
 data class HomeDetailViewState(
         val groupSummary: Option<GroupSummary> = Option.empty(),
         val asyncRooms: Async<List<RoomSummary>> = Uninitialized,
-        val displayMode: RoomListDisplayMode = RoomListDisplayMode.HOME,
+        val displayMode: RoomListDisplayMode = RoomListDisplayMode.PEOPLE,
         val notificationCountCatchup: Int = 0,
         val notificationHighlightCatchup: Boolean = false,
         val notificationCountPeople: Int = 0,

--- a/vector/src/main/java/im/vector/riotx/features/home/room/list/RoomListDisplayModeFilter.kt
+++ b/vector/src/main/java/im/vector/riotx/features/home/room/list/RoomListDisplayModeFilter.kt
@@ -30,8 +30,8 @@ class RoomListDisplayModeFilter(private val displayMode: RoomListDisplayMode) : 
         return when (displayMode) {
             RoomListDisplayMode.HOME     ->
                 roomSummary.notificationCount > 0 || roomSummary.membership == Membership.INVITE || roomSummary.userDrafts.isNotEmpty()
-            RoomListDisplayMode.PEOPLE   -> roomSummary.isDirect && roomSummary.membership == Membership.JOIN
-            RoomListDisplayMode.ROOMS    -> !roomSummary.isDirect && roomSummary.membership == Membership.JOIN
+            RoomListDisplayMode.PEOPLE   -> roomSummary.isDirect && roomSummary.membership.isActive()
+            RoomListDisplayMode.ROOMS    -> !roomSummary.isDirect && roomSummary.membership.isActive()
             RoomListDisplayMode.FILTERED -> roomSummary.membership == Membership.JOIN
         }
     }

--- a/vector/src/main/java/im/vector/riotx/features/themes/ThemeUtils.kt
+++ b/vector/src/main/java/im/vector/riotx/features/themes/ThemeUtils.kt
@@ -171,6 +171,7 @@ object ThemeUtils {
      * @param resourceId the resource id in the light theme
      * @return the resource Id for the current theme
      */
+    // TODO Now that we are API 21, this is not necessary anymore
     fun getResourceId(c: Context, resourceId: Int): Int {
         val theme = getApplicationTheme(c)
 

--- a/vector/src/main/java/im/vector/riotx/features/ui/SharedPreferencesUiStateRepository.kt
+++ b/vector/src/main/java/im/vector/riotx/features/ui/SharedPreferencesUiStateRepository.kt
@@ -36,7 +36,7 @@ class SharedPreferencesUiStateRepository @Inject constructor(private val sharedP
         return when (sharedPreferences.getInt(KEY_DISPLAY_MODE, VALUE_DISPLAY_MODE_CATCHUP)) {
             VALUE_DISPLAY_MODE_PEOPLE -> RoomListDisplayMode.PEOPLE
             VALUE_DISPLAY_MODE_ROOMS  -> RoomListDisplayMode.ROOMS
-            else                      -> RoomListDisplayMode.HOME
+            else                      -> RoomListDisplayMode.PEOPLE // RoomListDisplayMode.HOME
         }
     }
 

--- a/vector/src/main/res/menu/home_bottom_navigation.xml
+++ b/vector/src/main/res/menu/home_bottom_navigation.xml
@@ -5,7 +5,8 @@
         android:id="@+id/bottom_action_home"
         android:enabled="true"
         android:icon="@drawable/ic_home_bottom_catchup"
-        android:title="@string/bottom_action_home" />
+        android:title="@string/bottom_action_home"
+        android:visible="false" />
 
     <item
         android:id="@+id/bottom_action_people"


### PR DESCRIPTION
Invites are displayed in the corresponding DM or Room tab

Fixes #1565 

<img width="341" alt="image" src="https://user-images.githubusercontent.com/3940906/86254667-6fa8d900-bbb6-11ea-8712-616dc12e61ab.png">
