### PR TITLE
Fix reply fallback leaking sender locale

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ Improvements 🙌:
 Bugfix 🐛:
  - Fix crash when coming from a notification (#1601)
  - Fix Exception when importing keys (#1576)
+ - Fix reply fallback leaking sender locale (#429)
 
 Translations 🗣:
  -

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/send/LocalEchoEventFactory.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/send/LocalEchoEventFactory.kt
@@ -177,7 +177,6 @@ internal class LocalEchoEventFactory @Inject constructor(
         val body = bodyForReply(originalEvent.getLastMessageContent(), originalEvent.root.getClearContent().toModel())
         val replyFormatted = REPLY_PATTERN.format(
                 permalink,
-                stringProvider.getString(R.string.message_reply_to_prefix),
                 userLink,
                 originalEvent.senderInfo.disambiguatedDisplayName,
                 body.takeFormatted(),
@@ -372,7 +371,6 @@ internal class LocalEchoEventFactory @Inject constructor(
         val body = bodyForReply(eventReplied.getLastMessageContent(), eventReplied.root.getClearContent().toModel())
         val replyFormatted = REPLY_PATTERN.format(
                 permalink,
-                stringProvider.getString(R.string.message_reply_to_prefix),
                 userLink,
                 userId,
                 body.takeFormatted(),
@@ -434,10 +432,10 @@ internal class LocalEchoEventFactory @Inject constructor(
                     TextContent(content.body, formattedText)
                 }
             }
-            MessageType.MSGTYPE_FILE   -> return TextContent(stringProvider.getString(R.string.reply_to_a_file))
-            MessageType.MSGTYPE_AUDIO  -> return TextContent(stringProvider.getString(R.string.reply_to_an_audio_file))
-            MessageType.MSGTYPE_IMAGE  -> return TextContent(stringProvider.getString(R.string.reply_to_an_image))
-            MessageType.MSGTYPE_VIDEO  -> return TextContent(stringProvider.getString(R.string.reply_to_a_video))
+            MessageType.MSGTYPE_FILE   -> return TextContent("sent a file.")
+            MessageType.MSGTYPE_AUDIO  -> return TextContent("sent an audio file.")
+            MessageType.MSGTYPE_IMAGE  -> return TextContent("sent an image.")
+            MessageType.MSGTYPE_VIDEO  -> return TextContent("sent a video.")
             else                       -> return TextContent(content?.body ?: "")
         }
     }
@@ -489,6 +487,6 @@ internal class LocalEchoEventFactory @Inject constructor(
         //     </blockquote>
         // </mx-reply>
         // No whitespace because currently breaks temporary formatted text to Span
-        const val REPLY_PATTERN = """<mx-reply><blockquote><a href="%s">%s</a><a href="%s">%s</a><br />%s</blockquote></mx-reply>%s"""
+        const val REPLY_PATTERN = """<mx-reply><blockquote><a href="%s">In reply to</a> <a href="%s">%s</a><br />%s</blockquote></mx-reply>%s"""
     }
 }

--- a/matrix-sdk-android/src/main/res/values-ar/strings.xml
+++ b/matrix-sdk-android/src/main/res/values-ar/strings.xml
@@ -63,12 +63,6 @@
     <string name="summary_user_sent_sticker">أرسل ⁨%1$s⁩ ملصقا.</string>
 
     <string name="notice_avatar_changed_too">(تغيّرت الصورة أيضا)</string>
-    <string name="message_reply_to_prefix">ردا على</string>
-
-    <string name="reply_to_an_image">أرسل صورة.</string>
-    <string name="reply_to_a_video">أرسل فديوهًا.</string>
-    <string name="reply_to_an_audio_file">أرسل ملف صوت.</string>
-    <string name="reply_to_a_file">أرسل ملفًا.</string>
 
     <string name="room_displayname_invite_from">دعوة من ⁨%s⁩</string>
     <string name="room_displayname_empty_room">غرفة فارغة</string>

--- a/matrix-sdk-android/src/main/res/values-az/strings.xml
+++ b/matrix-sdk-android/src/main/res/values-az/strings.xml
@@ -52,8 +52,6 @@
     <string name="notice_crypto_unable_to_decrypt">** Şifrəni aça bilmir: %s **</string>
     <string name="notice_crypto_error_unkwown_inbound_session_id">Göndərənin cihazı bu mesaj üçün açarları bizə göndərməyib.</string>
 
-    <string name="message_reply_to_prefix">Cavab olaraq</string>
-
     <string name="could_not_redact">Redaktə etmək olmur</string>
     <string name="unable_to_send_message">Mesaj göndərmək olmur</string>
 
@@ -68,11 +66,6 @@
 
     <string name="medium_email">Elektron poçt ünvanı</string>
     <string name="medium_phone_number">Telefon nömrəsi</string>
-
-    <string name="reply_to_an_image">şəkil göndərdi.</string>
-    <string name="reply_to_a_video">video göndərdi.</string>
-    <string name="reply_to_an_audio_file">səs faylı göndərdi.</string>
-    <string name="reply_to_a_file">fayl göndərdi.</string>
 
     <string name="room_displayname_invite_from">%s-dən dəvət</string>
     <string name="room_displayname_room_invite">Otağa dəvət</string>

--- a/matrix-sdk-android/src/main/res/values-bg/strings.xml
+++ b/matrix-sdk-android/src/main/res/values-bg/strings.xml
@@ -63,13 +63,6 @@
 
     <string name="summary_user_sent_sticker">%1$s изпрати стикер.</string>
 
-    <string name="message_reply_to_prefix">В отговор на</string>
-
-    <string name="reply_to_an_image">изпрати снимка.</string>
-    <string name="reply_to_a_video">изпрати видео.</string>
-    <string name="reply_to_an_audio_file">изпрати аудио файл.</string>
-    <string name="reply_to_a_file">изпрати файл.</string>
-
     <string name="room_displayname_invite_from">Покана от %s</string>
     <string name="room_displayname_room_invite">Покана за стая</string>
     <string name="room_displayname_two_members">%1$s и %2$s</string>

--- a/matrix-sdk-android/src/main/res/values-ca/strings.xml
+++ b/matrix-sdk-android/src/main/res/values-ca/strings.xml
@@ -76,11 +76,4 @@
 
     <string name="summary_user_sent_sticker">%1$s ha enviat un adhesiu.</string>
 
-    <string name="message_reply_to_prefix">En resposta a</string>
-
-    <string name="reply_to_an_image">ha enviat una imatge.</string>
-    <string name="reply_to_a_video">ha enviat un vídeo.</string>
-    <string name="reply_to_an_audio_file">ha enviat un fitxer d\'àudio.</string>
-    <string name="reply_to_a_file">ha enviat un fitxer.</string>
-
 </resources>

--- a/matrix-sdk-android/src/main/res/values-cs/strings.xml
+++ b/matrix-sdk-android/src/main/res/values-cs/strings.xml
@@ -46,8 +46,6 @@
     <string name="notice_crypto_unable_to_decrypt">** Nelze dešifrovat: %s **</string>
     <string name="notice_crypto_error_unkwown_inbound_session_id">Odesílatelovo zařízení neposlalo klíče pro tuto zprávu.</string>
 
-    <string name="message_reply_to_prefix">V odpovědi na</string>
-
     <string name="could_not_redact">Nelze vymazat</string>
     <string name="unable_to_send_message">Zprávu nelze odeslat</string>
 
@@ -62,11 +60,6 @@
 
     <string name="medium_email">E-mailová adresa</string>
     <string name="medium_phone_number">Telefonní číslo</string>
-
-    <string name="reply_to_an_image">odeslal obrázek.</string>
-    <string name="reply_to_a_video">odeslal video.</string>
-    <string name="reply_to_an_audio_file">odeslal zvukový soubor.</string>
-    <string name="reply_to_a_file">odeslal soubor.</string>
 
     <string name="room_displayname_invite_from">Pozvání od %s</string>
     <string name="room_displayname_room_invite">Pozvání do místnosti</string>

--- a/matrix-sdk-android/src/main/res/values-de/strings.xml
+++ b/matrix-sdk-android/src/main/res/values-de/strings.xml
@@ -73,13 +73,6 @@
 
     <string name="summary_user_sent_sticker">%1$s sandte einen Sticker.</string>
 
-    <string name="message_reply_to_prefix">Als Antwort auf</string>
-
-    <string name="reply_to_an_image">hat ein Bild gesendet.</string>
-    <string name="reply_to_a_video">hat ein Video gesendet.</string>
-    <string name="reply_to_an_audio_file">hat eine Audio-Datei gesendet.</string>
-    <string name="reply_to_a_file">sandte eine Datei.</string>
-
     <!-- Room display name -->
     <string name="room_displayname_invite_from">Einladung von %s</string>
     <string name="room_displayname_room_invite">Raumeinladung</string>

--- a/matrix-sdk-android/src/main/res/values-el/strings.xml
+++ b/matrix-sdk-android/src/main/res/values-el/strings.xml
@@ -40,8 +40,6 @@
     <string name="notice_crypto_unable_to_decrypt">** Αδυναμία αποκρυπτογράφησης: %s **</string>
     <string name="notice_crypto_error_unkwown_inbound_session_id">Η συσκευή του/της αποστολέα δεν μας έχει στείλει τα κλειδιά για αυτό το μήνυμα.</string>
 
-    <string name="message_reply_to_prefix">Προς απάντηση στο</string>
-
     <string name="unable_to_send_message">Αποτυχία αποστολής μηνύματος</string>
 
     <string name="message_failed_to_upload">Αποτυχία αναφόρτωσης εικόνας</string>
@@ -56,10 +54,6 @@
     <string name="notice_voip_finished">Η VoIP διάσκεψη έληξε</string>
 
     <string name="notice_room_join">Ο/Η %1$s εισήλθε στο δωμάτιο</string>
-    <string name="reply_to_an_image">έστειλε μία εικόνα.</string>
-    <string name="reply_to_a_video">έστειλε ένα βίντεο.</string>
-    <string name="reply_to_an_audio_file">έστειλε ένα αρχείο ήχου.</string>
-    <string name="reply_to_a_file">έστειλε ένα αρχείο.</string>
 
     <string name="room_displayname_invite_from">Πρόσκληση από %s</string>
     <string name="room_displayname_room_invite">Πρόσκληση στο δωμάτιο</string>

--- a/matrix-sdk-android/src/main/res/values-eo/strings.xml
+++ b/matrix-sdk-android/src/main/res/values-eo/strings.xml
@@ -17,8 +17,6 @@
     <string name="notice_crypto_unable_to_decrypt">** Ne eblas malĉifri: %s **</string>
     <string name="notice_crypto_error_unkwown_inbound_session_id">La aparato de la sendanto ne sendis al ni la ŝlosilojn por tiu mesaĝo.</string>
 
-    <string name="message_reply_to_prefix">Responde al</string>
-
     <string name="summary_message">%1$s: %2$s</string>
     <string name="notice_display_name_set">%1$s ŝanĝis sian vidigan nomon al %2$s</string>
     <string name="notice_display_name_changed_from">%1$s ŝanĝis sian vidigan nomon de %2$s al %3$s</string>
@@ -61,11 +59,6 @@
 
     <string name="medium_email">Retpoŝtadreso</string>
     <string name="medium_phone_number">Telefonnumero</string>
-
-    <string name="reply_to_an_image">sendis bildon.</string>
-    <string name="reply_to_a_video">sendis filmon.</string>
-    <string name="reply_to_an_audio_file">sendis sondosieron.</string>
-    <string name="reply_to_a_file">sendis dosieron.</string>
 
     <string name="room_displayname_invite_from">Invito de %s</string>
     <string name="room_displayname_room_invite">Ĉambra invito</string>

--- a/matrix-sdk-android/src/main/res/values-es-rMX/strings.xml
+++ b/matrix-sdk-android/src/main/res/values-es-rMX/strings.xml
@@ -73,13 +73,6 @@
 
     <string name="summary_user_sent_sticker">%1$s envió una calcomanía.</string>
 
-    <string name="message_reply_to_prefix">En respuesta a</string>
-
-    <string name="reply_to_an_image">envió una imagen.</string>
-    <string name="reply_to_a_video">envió un video.</string>
-    <string name="reply_to_an_audio_file">envió un archivo de audio.</string>
-    <string name="reply_to_a_file">envió un archivo.</string>
-
     <!-- Room display name -->
     <string name="room_displayname_invite_from">Invitación de %s</string>
     <string name="room_displayname_room_invite">Invitación de Sala</string>

--- a/matrix-sdk-android/src/main/res/values-es/strings.xml
+++ b/matrix-sdk-android/src/main/res/values-es/strings.xml
@@ -73,13 +73,6 @@
 
     <string name="summary_user_sent_sticker">%1$s envió una pegatina.</string>
 
-    <string name="message_reply_to_prefix">En respuesta a</string>
-
-    <string name="reply_to_an_image">envió una imagen.</string>
-    <string name="reply_to_a_video">envió un vídeo.</string>
-    <string name="reply_to_an_audio_file">envió un archivo de audio.</string>
-    <string name="reply_to_a_file">envió un archivo.</string>
-
     <!-- Room display name -->
     <string name="room_displayname_invite_from">Invitación de %s</string>
     <string name="room_displayname_room_invite">Invitación a Sala</string>

--- a/matrix-sdk-android/src/main/res/values-et/strings.xml
+++ b/matrix-sdk-android/src/main/res/values-et/strings.xml
@@ -50,8 +50,6 @@
     <string name="notice_crypto_unable_to_decrypt">** Ei õnnestu dekrüptida: %s **</string>
     <string name="notice_crypto_error_unkwown_inbound_session_id">Sõnumi saatja seade ei ole selle sõnumi jaoks saatnud dekrüptimisvõtmeid.</string>
 
-    <string name="message_reply_to_prefix">Vastuseks kasutajale</string>
-
     <string name="could_not_redact">Ei saanud muuta sõnumit</string>
     <string name="unable_to_send_message">Sõnumi saatmine ei õnnestunud</string>
 
@@ -66,11 +64,6 @@
 
     <string name="medium_email">E-posti aadress</string>
     <string name="medium_phone_number">Telefoninumber</string>
-
-    <string name="reply_to_an_image">saatis pildi.</string>
-    <string name="reply_to_a_video">saatis video.</string>
-    <string name="reply_to_an_audio_file">saatis helifaili.</string>
-    <string name="reply_to_a_file">saatis faili.</string>
 
     <string name="room_displayname_invite_from">Kutse kasutajalt %s</string>
     <string name="room_displayname_room_invite">Kutse jututuppa</string>

--- a/matrix-sdk-android/src/main/res/values-eu/strings.xml
+++ b/matrix-sdk-android/src/main/res/values-eu/strings.xml
@@ -63,13 +63,6 @@
 
     <string name="summary_user_sent_sticker">%1$s erabiltzaileak eranskailu bat bidali du.</string>
 
-    <string name="message_reply_to_prefix">Honi erantzunez</string>
-
-    <string name="reply_to_an_image">irudi bat bidali du.</string>
-    <string name="reply_to_a_video">bideo bat bidali du.</string>
-    <string name="reply_to_an_audio_file">audio fitxategi bat bidali du.</string>
-    <string name="reply_to_a_file">fitxategi bat bidali du.</string>
-
     <string name="room_displayname_invite_from">%s gelarako gonbidapena</string>
     <string name="room_displayname_room_invite">Gela gonbidapena</string>
     <string name="room_displayname_two_members">%1$s eta %2$s</string>

--- a/matrix-sdk-android/src/main/res/values-fa/strings.xml
+++ b/matrix-sdk-android/src/main/res/values-fa/strings.xml
@@ -51,8 +51,6 @@
     <string name="notice_crypto_unable_to_decrypt">** ناتوان در رمزگشایی: %s **</string>
     <string name="notice_crypto_error_unkwown_inbound_session_id">دستگاه فرستنده، کلیدهای این پیام را برایمان نفرستاده است.</string>
 
-    <string name="message_reply_to_prefix">در پاسخ به</string>
-
     <string name="unable_to_send_message">ناتوان در فرستادن پیام</string>
 
     <string name="message_failed_to_upload">شکست در بارگذاری تصویر</string>
@@ -66,11 +64,6 @@
 
     <string name="medium_email">نشانی رایانامه</string>
     <string name="medium_phone_number">شماره تلفن</string>
-
-    <string name="reply_to_an_image">تصویری فرستاد.</string>
-    <string name="reply_to_a_video">ویدیویی فرستاد.</string>
-    <string name="reply_to_an_audio_file">پرونده‌ای صوتی فرستاد.</string>
-    <string name="reply_to_a_file">پرونده‌ای فرستاد.</string>
 
     <string name="room_displayname_invite_from">دعوت از %s</string>
     <string name="room_displayname_room_invite">دعوت اتاق</string>

--- a/matrix-sdk-android/src/main/res/values-fi/strings.xml
+++ b/matrix-sdk-android/src/main/res/values-fi/strings.xml
@@ -70,13 +70,6 @@
 
     <string name="summary_user_sent_sticker">%1$s lähetti tarran.</string>
 
-    <string name="message_reply_to_prefix">Vastauksena käyttäjälle</string>
-
-    <string name="reply_to_an_image">oli lähettänyt kuvan.</string>
-    <string name="reply_to_a_video">lähetti videon.</string>
-    <string name="reply_to_an_audio_file">lähetti äänitiedoston.</string>
-    <string name="reply_to_a_file">lähetti tiedoston.</string>
-
     <plurals name="room_displayname_three_and_more_members">
         <item quantity="one">%1$s ja yksi muu</item>
         <item quantity="other">%1$s ja %2$d muuta</item>

--- a/matrix-sdk-android/src/main/res/values-fr/strings.xml
+++ b/matrix-sdk-android/src/main/res/values-fr/strings.xml
@@ -63,13 +63,6 @@
 
     <string name="summary_user_sent_sticker">%1$s a envoyé un sticker.</string>
 
-    <string name="message_reply_to_prefix">En réponse à</string>
-
-    <string name="reply_to_an_image">a envoyé une image.</string>
-    <string name="reply_to_a_video">a envoyé une vidéo.</string>
-    <string name="reply_to_an_audio_file">a envoyé un fichier audio.</string>
-    <string name="reply_to_a_file">a envoyé un fichier.</string>
-
     <string name="room_displayname_invite_from">Invitation de %s</string>
     <string name="room_displayname_room_invite">Invitation au salon</string>
     <string name="room_displayname_empty_room">Salon vide</string>

--- a/matrix-sdk-android/src/main/res/values-gl/strings.xml
+++ b/matrix-sdk-android/src/main/res/values-gl/strings.xml
@@ -50,8 +50,6 @@
     <string name="notice_crypto_unable_to_decrypt">** Imposíbel descifrar: %s **</string>
     <string name="notice_crypto_error_unkwown_inbound_session_id">O dispositivo do que envía non enviou as chaves desta mensaxe.</string>
 
-    <string name="message_reply_to_prefix">Respondéndolle a</string>
-
     <string name="could_not_redact">Non se puido redactar</string>
     <string name="unable_to_send_message">Non foi posíbel enviar a mensaxe</string>
 
@@ -63,11 +61,6 @@
     <string name="encrypted_message">Mensaxe cifrada</string>
 
     <string name="medium_phone_number">Número de teléfono</string>
-
-    <string name="reply_to_an_image">Responder a</string>
-    <string name="reply_to_a_video">enviar un vídeo.</string>
-    <string name="reply_to_an_audio_file">enviar un ficheiro de son.</string>
-    <string name="reply_to_a_file">enviar un ficheiro.</string>
 
     <string name="room_displayname_two_members">%1$s e %2$s</string>
 

--- a/matrix-sdk-android/src/main/res/values-hu/strings.xml
+++ b/matrix-sdk-android/src/main/res/values-hu/strings.xml
@@ -62,13 +62,6 @@
 
     <string name="summary_user_sent_sticker">%1$s küldött egy matricát.</string>
 
-    <string name="message_reply_to_prefix">Válasz erre:</string>
-
-    <string name="reply_to_an_image">képet küldött.</string>
-    <string name="reply_to_a_video">videót küldött.</string>
-    <string name="reply_to_an_audio_file">hangfájlt küldött.</string>
-    <string name="reply_to_a_file">fájlt küldött.</string>
-
     <string name="room_displayname_invite_from">Meghívó tőle: %s</string>
     <string name="room_displayname_room_invite">Meghívó egy szobába</string>
     <string name="room_displayname_two_members">%1$s és %2$s</string>

--- a/matrix-sdk-android/src/main/res/values-is/strings.xml
+++ b/matrix-sdk-android/src/main/res/values-is/strings.xml
@@ -24,7 +24,6 @@
 
     <string name="notice_avatar_changed_too">(einnig var skipt um auðkennismynd)</string>
     <string name="notice_crypto_unable_to_decrypt">** Mistókst að afkóða: %s **</string>
-    <string name="message_reply_to_prefix">Sem svar til</string>
 
     <string name="unable_to_send_message">Gat ekki sent skilaboð</string>
 

--- a/matrix-sdk-android/src/main/res/values-it/strings.xml
+++ b/matrix-sdk-android/src/main/res/values-it/strings.xml
@@ -62,13 +62,6 @@
 
     <string name="summary_user_sent_sticker">%1$s ha inviato un adesivo.</string>
 
-    <string name="message_reply_to_prefix">In risposta a</string>
-
-    <string name="reply_to_an_image">inviata un\'immagine.</string>
-    <string name="reply_to_a_video">inviato un video.</string>
-    <string name="reply_to_an_audio_file">inviato un file audio.</string>
-    <string name="reply_to_a_file">inviato un file.</string>
-
     <!-- Room display name -->
     <string name="room_displayname_invite_from">Invito da %s</string>
     <string name="room_displayname_room_invite">Invito nella stanza</string>

--- a/matrix-sdk-android/src/main/res/values-ja/strings.xml
+++ b/matrix-sdk-android/src/main/res/values-ja/strings.xml
@@ -56,8 +56,6 @@
     <string name="notice_crypto_unable_to_decrypt">** 解読できません: %s **</string>
     <string name="notice_crypto_error_unkwown_inbound_session_id">送信者の端末からこのメッセージのキーが送信されていません。</string>
 
-    <string name="message_reply_to_prefix">に返信</string>
-
     <string name="could_not_redact">修正できませんでした</string>
     <string name="unable_to_send_message">メッセージを送信できません</string>
 
@@ -72,10 +70,5 @@
 
     <string name="medium_email">メールアドレス</string>
     <string name="medium_phone_number">電話番号</string>
-
-    <string name="reply_to_an_image">画像を送信しました。</string>
-    <string name="reply_to_a_video">動画を送りました。</string>
-    <string name="reply_to_an_audio_file">音声ファイルを送信しました。</string>
-    <string name="reply_to_a_file">ファイルを送信しました。</string>
 
 </resources>

--- a/matrix-sdk-android/src/main/res/values-ko/strings.xml
+++ b/matrix-sdk-android/src/main/res/values-ko/strings.xml
@@ -52,8 +52,6 @@
     <string name="notice_crypto_unable_to_decrypt">** 암호를 복호화할 수 없음: %s **</string>
     <string name="notice_crypto_error_unkwown_inbound_session_id">발신인의 기기에서 이 메시지의 키를 보내지 않았습니다.</string>
 
-    <string name="message_reply_to_prefix">관련 대화</string>
-
     <string name="could_not_redact">검열할 수 없습니다</string>
     <string name="unable_to_send_message">메시지를 보낼 수 없습니다</string>
 
@@ -68,11 +66,6 @@
 
     <string name="medium_email">이메일 주소</string>
     <string name="medium_phone_number">전화번호</string>
-
-    <string name="reply_to_an_image">사진을 보냈습니다.</string>
-    <string name="reply_to_a_video">동영상을 보냈습니다.</string>
-    <string name="reply_to_an_audio_file">오디오 파일을 보냈습니다.</string>
-    <string name="reply_to_a_file">파일을 보냈습니다.</string>
 
     <string name="room_displayname_invite_from">%s에서 초대함</string>
     <string name="room_displayname_room_invite">방 초대</string>

--- a/matrix-sdk-android/src/main/res/values-nl/strings.xml
+++ b/matrix-sdk-android/src/main/res/values-nl/strings.xml
@@ -71,13 +71,6 @@
 
     <string name="summary_user_sent_sticker">%1$s heeft een sticker gestuurd.</string>
 
-    <string name="message_reply_to_prefix">Als antwoord op</string>
-
-    <string name="reply_to_an_image">heeft een afbeelding gestuurd.</string>
-    <string name="reply_to_a_video">heeft een video gestuurd.</string>
-    <string name="reply_to_an_audio_file">heeft een audiobestand gestuurd.</string>
-    <string name="reply_to_a_file">heeft een bestand gestuurd.</string>
-
     <!-- Room display name -->
     <string name="room_displayname_invite_from">Uitnodiging van %s</string>
     <string name="room_displayname_room_invite">Gespreksuitnodiging</string>

--- a/matrix-sdk-android/src/main/res/values-nn/strings.xml
+++ b/matrix-sdk-android/src/main/res/values-nn/strings.xml
@@ -49,8 +49,6 @@
     <string name="notice_crypto_unable_to_decrypt">** Fekk ikkje til å dekryptera: %s **</string>
     <string name="notice_crypto_error_unkwown_inbound_session_id">Avsendareiningi hev ikkje sendt oss nyklane fyr denna meldingi.</string>
 
-    <string name="message_reply_to_prefix">Som svar til</string>
-
     <string name="could_not_redact">Kunde ikkje gjera um</string>
     <string name="unable_to_send_message">Fekk ikkje å senda meldingi</string>
 
@@ -63,11 +61,6 @@
 
     <string name="medium_email">Epostadresse</string>
     <string name="medium_phone_number">Telefonnummer</string>
-
-    <string name="reply_to_an_image">sende eit bilæte.</string>
-    <string name="reply_to_a_video">sende ein video.</string>
-    <string name="reply_to_an_audio_file">sende ei ljodfil.</string>
-    <string name="reply_to_a_file">sende ei fil.</string>
 
     <string name="room_displayname_invite_from">Innbjoding frå %s</string>
     <string name="room_displayname_room_invite">Rominnbjoding</string>

--- a/matrix-sdk-android/src/main/res/values-pl/strings.xml
+++ b/matrix-sdk-android/src/main/res/values-pl/strings.xml
@@ -42,7 +42,6 @@
     <string name="notice_room_withdraw">%1$s wycofał(a) zaproszenie %2$s</string>
     <string name="notice_answered_call">%s odebrał(a) połączenie.</string>
     <string name="notice_avatar_changed_too">(awatar też został zmieniony)</string>
-    <string name="message_reply_to_prefix">W odpowiedzi do</string>
 
     <string name="room_displayname_invite_from">Zaproszenie od %s</string>
     <string name="room_displayname_room_invite">Zaproszenie do pokoju</string>
@@ -75,11 +74,6 @@
 
     <string name="could_not_redact">Nie można zredagować</string>
     <string name="room_error_join_failed_empty_room">Obecnie nie jest możliwe ponowne dołączenie do pustego pokoju.</string>
-
-    <string name="reply_to_an_image">wyślij zdjęcie.</string>
-    <string name="reply_to_a_video">wyślij wideo.</string>
-    <string name="reply_to_an_audio_file">wyślij plik audio.</string>
-    <string name="reply_to_a_file">wyślij plik.</string>
 
     <string name="notice_event_redacted">Wiadomość usunięta</string>
     <string name="notice_event_redacted_by">Wiadomość usunięta przez %1$s</string>

--- a/matrix-sdk-android/src/main/res/values-pt-rBR/strings.xml
+++ b/matrix-sdk-android/src/main/res/values-pt-rBR/strings.xml
@@ -74,13 +74,6 @@
 
     <string name="summary_user_sent_sticker">%1$s enviou um sticker.</string>
 
-    <string name="message_reply_to_prefix">Em resposta a</string>
-
-    <string name="reply_to_an_image">enviou uma imagem.</string>
-    <string name="reply_to_a_video">enviou um vídeo.</string>
-    <string name="reply_to_an_audio_file">enviou um arquivo de áudio.</string>
-    <string name="reply_to_a_file">enviou um arquivo.</string>
-
     <!-- Room display name -->
     <string name="room_displayname_invite_from">Convite de %s</string>
     <string name="room_displayname_room_invite">Convite para sala</string>

--- a/matrix-sdk-android/src/main/res/values-ru/strings.xml
+++ b/matrix-sdk-android/src/main/res/values-ru/strings.xml
@@ -73,13 +73,6 @@
 
     <string name="summary_user_sent_sticker">%1$s отправил стикер.</string>
 
-    <string name="message_reply_to_prefix">В ответ на</string>
-
-    <string name="reply_to_an_image">отправил изображение.</string>
-    <string name="reply_to_a_video">отправил видео.</string>
-    <string name="reply_to_an_audio_file">отправил аудиофайл.</string>
-    <string name="reply_to_a_file">отправил файл.</string>
-
     <!-- Room display name -->
     <string name="room_displayname_invite_from">Приглашение от %s</string>
     <string name="room_displayname_room_invite">Приглашение в комнату</string>

--- a/matrix-sdk-android/src/main/res/values-sk/strings.xml
+++ b/matrix-sdk-android/src/main/res/values-sk/strings.xml
@@ -62,13 +62,6 @@
 
     <string name="summary_user_sent_sticker">%1$s poslal nálepku.</string>
 
-    <string name="message_reply_to_prefix">Odpoveď na</string>
-
-    <string name="reply_to_an_image">odoslal obrázok.</string>
-    <string name="reply_to_a_video">odoslal video.</string>
-    <string name="reply_to_an_audio_file">odoslal zvukový súbor.</string>
-    <string name="reply_to_a_file">Odoslal súbor.</string>
-
     <string name="room_displayname_invite_from">Pozvanie od %s</string>
     <string name="room_displayname_room_invite">Pozvanie do miestnosti</string>
     <string name="room_displayname_two_members">%1$s a %2$s</string>

--- a/matrix-sdk-android/src/main/res/values-sq/strings.xml
+++ b/matrix-sdk-android/src/main/res/values-sq/strings.xml
@@ -34,8 +34,6 @@
     <string name="notice_crypto_unable_to_decrypt">** S’arrihet të shfshehtëzohet: %s **</string>
     <string name="notice_crypto_error_unkwown_inbound_session_id">Pajisja e dërguesit nuk na ka dërguar kyçet për këtë mesazh.</string>
 
-    <string name="message_reply_to_prefix">Në përgjigje të</string>
-
     <string name="could_not_redact">S’u redaktua dot</string>
     <string name="unable_to_send_message">S’arrihet të dërgohet mesazh</string>
 
@@ -50,11 +48,6 @@
 
     <string name="medium_email">Adresë email</string>
     <string name="medium_phone_number">Numër telefoni</string>
-
-    <string name="reply_to_an_image">dërgoi një figurë.</string>
-    <string name="reply_to_a_video">dërgoi një video.</string>
-    <string name="reply_to_an_audio_file">dërgoi një kartelë audio.</string>
-    <string name="reply_to_a_file">dërgoi një kartelë.</string>
 
     <string name="room_displayname_invite_from">Ftesë nga %s</string>
     <string name="room_displayname_room_invite">Ftesë Dhome</string>

--- a/matrix-sdk-android/src/main/res/values-uk/strings.xml
+++ b/matrix-sdk-android/src/main/res/values-uk/strings.xml
@@ -56,8 +56,6 @@
     <string name="notice_crypto_unable_to_decrypt">** Неможливо розшифрувати: %s **</string>
     <string name="notice_crypto_error_unkwown_inbound_session_id">Пристрій відправника не надіслав нам ключ для цього повідомлення.</string>
 
-    <string name="message_reply_to_prefix">У відповідь на</string>
-
     <string name="could_not_redact">Неможливо відредагувати</string>
     <string name="unable_to_send_message">Не вдалося надіслати повідомлення</string>
 
@@ -70,11 +68,6 @@
 
     <string name="medium_email">Адреса електронної пошти</string>
     <string name="medium_phone_number">Номер телефону</string>
-
-    <string name="reply_to_an_image">надіслав зображення.</string>
-    <string name="reply_to_a_video">надіслав відео.</string>
-    <string name="reply_to_an_audio_file">надіслав аудіо файл.</string>
-    <string name="reply_to_a_file">надіслав файл.</string>
 
     <plurals name="room_displayname_three_and_more_members">
         <item quantity="one">%1$s та 1 інший</item>

--- a/matrix-sdk-android/src/main/res/values-vls/strings.xml
+++ b/matrix-sdk-android/src/main/res/values-vls/strings.xml
@@ -50,8 +50,6 @@
     <string name="notice_crypto_unable_to_decrypt">** Kun nie ountsleuteln: %s **</string>
     <string name="notice_crypto_error_unkwown_inbound_session_id">’t Toestel van den afzender èt geen sleutels vo da bericht hier gesteurd.</string>
 
-    <string name="message_reply_to_prefix">Als antwoord ip</string>
-
     <string name="could_not_redact">Kosteg nie verwyderd wordn</string>
     <string name="unable_to_send_message">Kosteg ’t bericht nie verzendn</string>
 
@@ -66,11 +64,6 @@
 
     <string name="medium_email">E-mailadresse</string>
     <string name="medium_phone_number">Telefongnumero</string>
-
-    <string name="reply_to_an_image">èt e fotootje gesteurd.</string>
-    <string name="reply_to_a_video">èt e filmtje gesteurd.</string>
-    <string name="reply_to_an_audio_file">èt e geluudsfragment gesteurd.</string>
-    <string name="reply_to_a_file">èt e bestand gesteurd.</string>
 
     <string name="room_displayname_invite_from">Uutnodigienge van %s</string>
     <string name="room_displayname_room_invite">Gespreksuutnodigienge</string>

--- a/matrix-sdk-android/src/main/res/values-zh-rCN/strings.xml
+++ b/matrix-sdk-android/src/main/res/values-zh-rCN/strings.xml
@@ -63,13 +63,6 @@
     <string name="summary_message">%1$s：%2$s</string>
     <string name="summary_user_sent_sticker">%1$s 发送了一张贴纸。</string>
 
-    <string name="reply_to_an_image">发送了一张图片。</string>
-    <string name="reply_to_a_video">发送了一个视频。</string>
-    <string name="reply_to_an_audio_file">发送了一段音频。</string>
-    <string name="reply_to_a_file">发送了一个文件。</string>
-
-    <string name="message_reply_to_prefix">回复</string>
-
     <string name="room_displayname_empty_room">空聊天室</string>
     <string name="room_displayname_invite_from">来自 %s 的邀请</string>
     <string name="room_displayname_room_invite">聊天室邀请</string>

--- a/matrix-sdk-android/src/main/res/values-zh-rTW/strings.xml
+++ b/matrix-sdk-android/src/main/res/values-zh-rTW/strings.xml
@@ -62,13 +62,6 @@
 
     <string name="summary_user_sent_sticker">%1$s 傳送了一張貼圖。</string>
 
-    <string name="message_reply_to_prefix">回覆</string>
-
-    <string name="reply_to_an_image">傳送了圖片。</string>
-    <string name="reply_to_a_video">傳送了影片。</string>
-    <string name="reply_to_an_audio_file">傳送了音訊檔案。</string>
-    <string name="reply_to_a_file">傳送了檔案。</string>
-
     <string name="room_displayname_invite_from">來自%s 的邀請</string>
     <string name="room_displayname_room_invite">聊天室邀請</string>
     <string name="room_displayname_two_members">%1$s 和 %2$s</string>

--- a/matrix-sdk-android/src/main/res/values/strings.xml
+++ b/matrix-sdk-android/src/main/res/values/strings.xml
@@ -112,7 +112,6 @@
     <string name="notice_crypto_error_unkwown_inbound_session_id">The sender\'s device has not sent us the keys for this message.</string>
 
     <!-- Messages -->
-    <string name="message_reply_to_prefix">In reply to</string>
 
     <!-- Room Screen -->
     <string name="could_not_redact">Could not redact</string>
@@ -138,12 +137,6 @@
     <!-- medium friendly name -->
     <string name="medium_email">Email address</string>
     <string name="medium_phone_number">Phone number</string>
-
-    <!-- Reply to -->
-    <string name="reply_to_an_image">sent an image.</string>
-    <string name="reply_to_a_video">sent a video.</string>
-    <string name="reply_to_an_audio_file">sent an audio file.</string>
-    <string name="reply_to_a_file">sent a file.</string>
 
     <!-- Room display name -->
     <string name="room_displayname_invite_from">Invite from %s</string>


### PR DESCRIPTION
This pull request fixes the privacy issue where the sender's locale leaks whenever they reply to a message. It is also more conforming to the spec, as the spec does not state that clients should translate the fallback.

Receiver-side translations should be added in #174

Signed-off-by: Tulir Asokan &lt;tulir@maunium.net&gt;

### Pull Request Checklist

<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/riotX-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->

- [ ] Changes has been tested on an Android device or Android emulator with API 16
- [ ] UI change has been tested on both light and dark themes
- [x] Pull request is based on the develop branch
- [x] Pull request updates [CHANGES.md](https://github.com/vector-im/riotX-android/blob/develop/CHANGES.md)
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
