### PR TITLE
Re-activate Wellknown support with updated UI (#1614)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@ Changes in Riot.imX 0.91.4 (2020-XX-XX)
 ===================================================
 
 Features ✨:
- -
+ - Re-activate Wellknown support with updated UI (#1614)
 
 Improvements 🙌:
  -

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,7 +18,7 @@ SDK API changes ⚠️:
  - 
 
 Build 🧱:
- - Fix lint false-positive about WorkManger (#1012)
+ - Fix lint false-positive about WorkManager (#1012)
  - Upgrade build-tools from 3.5.3 to 3.6.6
  - Upgrade gradle from 5.4.1 to 5.6.4
 

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/auth/login/DirectLoginTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/auth/login/DirectLoginTask.kt
@@ -19,6 +19,7 @@ package im.vector.matrix.android.internal.auth.login
 import dagger.Lazy
 import im.vector.matrix.android.api.auth.data.Credentials
 import im.vector.matrix.android.api.auth.data.HomeServerConnectionConfig
+import im.vector.matrix.android.api.failure.Failure
 import im.vector.matrix.android.api.session.Session
 import im.vector.matrix.android.internal.auth.AuthAPI
 import im.vector.matrix.android.internal.auth.SessionCreator
@@ -27,6 +28,7 @@ import im.vector.matrix.android.internal.di.Unauthenticated
 import im.vector.matrix.android.internal.network.RetrofitFactory
 import im.vector.matrix.android.internal.network.executeRequest
 import im.vector.matrix.android.internal.network.httpclient.addSocketFactory
+import im.vector.matrix.android.internal.network.ssl.UnrecognizedCertificateException
 import im.vector.matrix.android.internal.task.Task
 import okhttp3.OkHttpClient
 import javax.inject.Inject
@@ -49,13 +51,28 @@ internal class DefaultDirectLoginTask @Inject constructor(
 
     override suspend fun execute(params: DirectLoginTask.Params): Session {
         val client = buildClient(params.homeServerConnectionConfig)
-        val authAPI = retrofitFactory.create(client, params.homeServerConnectionConfig.homeServerUri.toString())
+        val homeServerUrl = params.homeServerConnectionConfig.homeServerUri.toString()
+
+        val authAPI = retrofitFactory.create(client, homeServerUrl)
                 .create(AuthAPI::class.java)
 
         val loginParams = PasswordLoginParams.userIdentifier(params.userId, params.password, params.deviceName)
 
-        val credentials = executeRequest<Credentials>(null) {
-            apiCall = authAPI.login(loginParams)
+        val credentials = try {
+            executeRequest<Credentials>(null) {
+                apiCall = authAPI.login(loginParams)
+            }
+        } catch (throwable: Throwable) {
+            when (throwable) {
+                is UnrecognizedCertificateException -> {
+                    throw Failure.UnrecognizedCertificateFailure(
+                            homeServerUrl,
+                            throwable.fingerprint
+                    )
+                }
+                else                                ->
+                    throw throwable
+            }
         }
 
         return sessionCreator.createSession(credentials, params.homeServerConnectionConfig)

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/wellknown/GetWellknownTask.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/wellknown/GetWellknownTask.kt
@@ -27,6 +27,7 @@ import im.vector.matrix.android.internal.di.Unauthenticated
 import im.vector.matrix.android.internal.network.RetrofitFactory
 import im.vector.matrix.android.internal.network.executeRequest
 import im.vector.matrix.android.internal.network.httpclient.addSocketFactory
+import im.vector.matrix.android.internal.network.ssl.UnrecognizedCertificateException
 import im.vector.matrix.android.internal.session.homeserver.CapabilitiesAPI
 import im.vector.matrix.android.internal.session.identity.IdentityAuthAPI
 import im.vector.matrix.android.internal.task.Task
@@ -106,6 +107,12 @@ internal class DefaultGetWellknownTask @Inject constructor(
             }
         } catch (throwable: Throwable) {
             when (throwable) {
+                is UnrecognizedCertificateException        -> {
+                    throw Failure.UnrecognizedCertificateFailure(
+                            "https://$domain",
+                            throwable.fingerprint
+                    )
+                }
                 is Failure.NetworkConnection               -> {
                     WellknownResult.Ignore
                 }

--- a/vector/src/main/java/im/vector/riotx/core/utils/UrlUtils.kt
+++ b/vector/src/main/java/im/vector/riotx/core/utils/UrlUtils.kt
@@ -37,3 +37,11 @@ internal fun String.ensureProtocol(): String {
         else                -> this
     }
 }
+
+internal fun String.ensureTrailingSlash(): String {
+    return when {
+        isEmpty()      -> this
+        !endsWith("/") -> "$this/"
+        else           -> this
+    }
+}

--- a/vector/src/main/java/im/vector/riotx/features/login/AbstractLoginFragment.kt
+++ b/vector/src/main/java/im/vector/riotx/features/login/AbstractLoginFragment.kt
@@ -73,6 +73,9 @@ abstract class AbstractLoginFragment : VectorBaseFragment(), OnBackPressed {
 
     override fun showFailure(throwable: Throwable) {
         when (throwable) {
+            is Failure.Cancelled                      ->
+                /* Ignore this error, user has cancelled the action */
+                Unit
             is Failure.ServerError                    ->
                 if (throwable.error.code == MatrixError.M_FORBIDDEN
                         && throwable.httpCode == HttpsURLConnection.HTTP_FORBIDDEN /* 403 */) {

--- a/vector/src/main/java/im/vector/riotx/features/login/LoginActivity.kt
+++ b/vector/src/main/java/im/vector/riotx/features/login/LoginActivity.kt
@@ -235,6 +235,7 @@ open class LoginActivity : VectorBaseActivity(), ToolbarConfigurable {
             ServerType.Other     -> addFragmentToBackstack(R.id.loginFragmentContainer,
                     LoginServerUrlFormFragment::class.java,
                     option = commonOption)
+            ServerType.Unknown   -> Unit /* Should not happen */
         }
     }
 

--- a/vector/src/main/java/im/vector/riotx/features/login/LoginActivity.kt
+++ b/vector/src/main/java/im/vector/riotx/features/login/LoginActivity.kt
@@ -151,8 +151,8 @@ open class LoginActivity : VectorBaseActivity(), ToolbarConfigurable {
                             // TODO Disabled because it provokes a flickering
                             // ft.setCustomAnimations(enterAnim, exitAnim, popEnterAnim, popExitAnim)
                         })
-            is LoginViewEvents.OnServerSelectionDone                      -> onServerSelectionDone()
-            is LoginViewEvents.OnSignModeSelected                         -> onSignModeSelected()
+            is LoginViewEvents.OnServerSelectionDone                      -> onServerSelectionDone(loginViewEvents)
+            is LoginViewEvents.OnSignModeSelected                         -> onSignModeSelected(loginViewEvents)
             is LoginViewEvents.OnLoginFlowRetrieved                       ->
                 addFragmentToBackstack(R.id.loginFragmentContainer,
                         if (loginViewEvents.isSso) {
@@ -228,8 +228,8 @@ open class LoginActivity : VectorBaseActivity(), ToolbarConfigurable {
                 .show()
     }
 
-    private fun onServerSelectionDone() = withState(loginViewModel) { state ->
-        when (state.serverType) {
+    private fun onServerSelectionDone(loginViewEvents: LoginViewEvents.OnServerSelectionDone) {
+        when (loginViewEvents.serverType) {
             ServerType.MatrixOrg -> Unit // In this case, we wait for the login flow
             ServerType.Modular,
             ServerType.Other     -> addFragmentToBackstack(R.id.loginFragmentContainer,
@@ -239,8 +239,9 @@ open class LoginActivity : VectorBaseActivity(), ToolbarConfigurable {
         }
     }
 
-    private fun onSignModeSelected() = withState(loginViewModel) { state ->
-        when (state.signMode) {
+    private fun onSignModeSelected(loginViewEvents: LoginViewEvents.OnSignModeSelected) = withState(loginViewModel) { state ->
+        // state.signMode could not be ready yet. So use value from the ViewEvent
+        when (loginViewEvents.signMode) {
             SignMode.Unknown            -> error("Sign mode has to be set before calling this method")
             SignMode.SignUp             -> {
                 // This is managed by the LoginViewEvents

--- a/vector/src/main/java/im/vector/riotx/features/login/LoginFragment.kt
+++ b/vector/src/main/java/im/vector/riotx/features/login/LoginFragment.kt
@@ -166,6 +166,7 @@ class LoginFragment @Inject constructor() : AbstractLoginFragment() {
                     loginTitle.text = getString(resId, state.homeServerUrl.toReducedUrl())
                     loginNotice.text = getString(R.string.login_server_other_text)
                 }
+                ServerType.Unknown   -> Unit /* Should not happen */
             }
             loginPasswordNotice.isVisible = false
         }

--- a/vector/src/main/java/im/vector/riotx/features/login/LoginFragment.kt
+++ b/vector/src/main/java/im/vector/riotx/features/login/LoginFragment.kt
@@ -54,6 +54,7 @@ class LoginFragment @Inject constructor() : AbstractLoginFragment() {
 
     private var passwordShown = false
     private var isSignupMode = false
+
     // Temporary patch for https://github.com/vector-im/riotX-android/issues/1410,
     // waiting for https://github.com/matrix-org/synapse/issues/7576
     private var isNumericOnlyUserIdForbidden = false
@@ -138,6 +139,7 @@ class LoginFragment @Inject constructor() : AbstractLoginFragment() {
             loginServerIcon.isVisible = false
             loginTitle.text = getString(R.string.login_signin_matrix_id_title)
             loginNotice.text = getString(R.string.login_signin_matrix_id_notice)
+            loginPasswordNotice.isVisible = true
         } else {
             val resId = when (state.signMode) {
                 SignMode.Unknown            -> error("developer error")
@@ -165,6 +167,7 @@ class LoginFragment @Inject constructor() : AbstractLoginFragment() {
                     loginNotice.text = getString(R.string.login_server_other_text)
                 }
             }
+            loginPasswordNotice.isVisible = false
         }
     }
 

--- a/vector/src/main/java/im/vector/riotx/features/login/LoginServerSelectionFragment.kt
+++ b/vector/src/main/java/im/vector/riotx/features/login/LoginServerSelectionFragment.kt
@@ -19,7 +19,6 @@ package im.vector.riotx.features.login
 import android.os.Bundle
 import android.view.View
 import butterknife.OnClick
-import com.airbnb.mvrx.withState
 import im.vector.riotx.R
 import im.vector.riotx.core.utils.openUrlInChromeCustomTab
 import kotlinx.android.synthetic.main.fragment_login_server_selection.*
@@ -40,11 +39,7 @@ class LoginServerSelectionFragment @Inject constructor() : AbstractLoginFragment
     }
 
     private fun updateSelectedChoice(state: LoginViewState) {
-        state.serverType.let {
-            loginServerChoiceMatrixOrg.isChecked = it == ServerType.MatrixOrg
-            loginServerChoiceModular.isChecked = it == ServerType.Modular
-            loginServerChoiceOther.isChecked = it == ServerType.Other
-        }
+        loginServerChoiceMatrixOrg.isChecked = state.serverType == ServerType.MatrixOrg
     }
 
     private fun initTextViews() {
@@ -61,42 +56,17 @@ class LoginServerSelectionFragment @Inject constructor() : AbstractLoginFragment
 
     @OnClick(R.id.loginServerChoiceMatrixOrg)
     fun selectMatrixOrg() {
-        if (loginServerChoiceMatrixOrg.isChecked) {
-            // Consider this is a submit
-            submit()
-        } else {
-            loginViewModel.handle(LoginAction.UpdateServerType(ServerType.MatrixOrg))
-        }
+        loginViewModel.handle(LoginAction.UpdateServerType(ServerType.MatrixOrg))
     }
 
     @OnClick(R.id.loginServerChoiceModular)
     fun selectModular() {
-        if (loginServerChoiceModular.isChecked) {
-            // Consider this is a submit
-            submit()
-        } else {
-            loginViewModel.handle(LoginAction.UpdateServerType(ServerType.Modular))
-        }
+        loginViewModel.handle(LoginAction.UpdateServerType(ServerType.Modular))
     }
 
     @OnClick(R.id.loginServerChoiceOther)
     fun selectOther() {
-        if (loginServerChoiceOther.isChecked) {
-            // Consider this is a submit
-            submit()
-        } else {
-            loginViewModel.handle(LoginAction.UpdateServerType(ServerType.Other))
-        }
-    }
-
-    @OnClick(R.id.loginServerSubmit)
-    fun submit() = withState(loginViewModel) { state ->
-        if (state.serverType == ServerType.MatrixOrg) {
-            // Request login flow here
-            loginViewModel.handle(LoginAction.UpdateHomeServer(getString(R.string.matrix_org_server_url)))
-        } else {
-            loginViewModel.handle(LoginAction.PostViewEvent(LoginViewEvents.OnServerSelectionDone))
-        }
+        loginViewModel.handle(LoginAction.UpdateServerType(ServerType.Other))
     }
 
     @OnClick(R.id.loginServerIKnowMyIdSubmit)

--- a/vector/src/main/java/im/vector/riotx/features/login/LoginServerUrlFormFragment.kt
+++ b/vector/src/main/java/im/vector/riotx/features/login/LoginServerUrlFormFragment.kt
@@ -70,7 +70,7 @@ class LoginServerUrlFormFragment @Inject constructor() : AbstractLoginFragment()
                 loginServerUrlFormHomeServerUrlTil.hint = getText(R.string.login_server_url_form_modular_hint)
                 loginServerUrlFormNotice.text = getString(R.string.login_server_url_form_modular_notice)
             }
-            ServerType.Other   -> {
+            else               -> {
                 loginServerUrlFormIcon.isVisible = false
                 loginServerUrlFormTitle.text = getString(R.string.login_server_other_title)
                 loginServerUrlFormText.text = getString(R.string.login_connect_to_a_custom_server)
@@ -78,7 +78,6 @@ class LoginServerUrlFormFragment @Inject constructor() : AbstractLoginFragment()
                 loginServerUrlFormHomeServerUrlTil.hint = getText(R.string.login_server_url_form_other_hint)
                 loginServerUrlFormNotice.text = getString(R.string.login_server_url_form_other_notice)
             }
-            else               -> error("This fragment should not be displayed in matrix.org mode")
         }
     }
 

--- a/vector/src/main/java/im/vector/riotx/features/login/LoginSignUpSignInSelectionFragment.kt
+++ b/vector/src/main/java/im/vector/riotx/features/login/LoginSignUpSignInSelectionFragment.kt
@@ -49,6 +49,7 @@ open class LoginSignUpSignInSelectionFragment @Inject constructor() : AbstractLo
                 loginSignupSigninTitle.text = getString(R.string.login_server_other_title)
                 loginSignupSigninText.text = getString(R.string.login_connect_to, state.homeServerUrl.toReducedUrl())
             }
+            ServerType.Unknown   -> Unit /* Should not happen */
         }
     }
 

--- a/vector/src/main/java/im/vector/riotx/features/login/LoginViewEvents.kt
+++ b/vector/src/main/java/im/vector/riotx/features/login/LoginViewEvents.kt
@@ -33,9 +33,9 @@ sealed class LoginViewEvents : VectorViewEvents {
     // Navigation event
 
     object OpenServerSelection : LoginViewEvents()
-    object OnServerSelectionDone : LoginViewEvents()
+    data class OnServerSelectionDone(val serverType: ServerType) : LoginViewEvents()
     data class OnLoginFlowRetrieved(val isSso: Boolean) : LoginViewEvents()
-    object OnSignModeSelected : LoginViewEvents()
+    data class OnSignModeSelected(val signMode: SignMode) : LoginViewEvents()
     object OnForgetPasswordClicked : LoginViewEvents()
     object OnResetPasswordSendThreePidDone : LoginViewEvents()
     object OnResetPasswordMailConfirmationSuccess : LoginViewEvents()

--- a/vector/src/main/java/im/vector/riotx/features/login/LoginViewModel.kt
+++ b/vector/src/main/java/im/vector/riotx/features/login/LoginViewModel.kt
@@ -19,6 +19,7 @@ package im.vector.riotx.features.login
 import android.content.Context
 import android.net.Uri
 import androidx.fragment.app.FragmentActivity
+import androidx.lifecycle.viewModelScope
 import com.airbnb.mvrx.ActivityViewModelContext
 import com.airbnb.mvrx.Fail
 import com.airbnb.mvrx.Loading
@@ -53,6 +54,8 @@ import im.vector.riotx.features.call.WebRtcPeerConnectionManager
 import im.vector.riotx.features.notifications.PushRuleTriggerListener
 import im.vector.riotx.features.session.SessionListener
 import im.vector.riotx.features.signout.soft.SoftLogoutActivity
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import timber.log.Timber
 import java.util.concurrent.CancellationException
 
@@ -399,9 +402,16 @@ class LoginViewModel @AssistedInject constructor(
         when (action.signMode) {
             SignMode.SignUp             -> startRegistrationFlow()
             SignMode.SignIn             -> startAuthenticationFlow()
-            SignMode.SignInWithMatrixId -> _viewEvents.post(LoginViewEvents.OnSignModeSelected)
+            SignMode.SignInWithMatrixId -> {
+                viewModelScope.launch {
+                    // Add a delay to avoid crash
+                    delay(50)
+                    _viewEvents.post(LoginViewEvents.OnSignModeSelected)
+                }
+                Unit
+            }
             SignMode.Unknown            -> Unit
-        }.exhaustive
+        }
     }
 
     private fun handleUpdateServerType(action: LoginAction.UpdateServerType) {

--- a/vector/src/main/java/im/vector/riotx/features/login/LoginViewModel.kt
+++ b/vector/src/main/java/im/vector/riotx/features/login/LoginViewModel.kt
@@ -436,7 +436,6 @@ class LoginViewModel @AssistedInject constructor(
                 }
 
                 override fun onFailure(failure: Throwable) {
-                    // TODO Handled JobCancellationException
                     setState {
                         copy(
                                 asyncResetPassword = Fail(failure)
@@ -478,7 +477,6 @@ class LoginViewModel @AssistedInject constructor(
                 }
 
                 override fun onFailure(failure: Throwable) {
-                    // TODO Handled JobCancellationException
                     setState {
                         copy(
                                 asyncResetMailConfirmed = Fail(failure)
@@ -593,7 +591,6 @@ class LoginViewModel @AssistedInject constructor(
                         }
 
                         override fun onFailure(failure: Throwable) {
-                            // TODO Handled JobCancellationException
                             setState {
                                 copy(
                                         asyncLoginAction = Fail(failure)

--- a/vector/src/main/java/im/vector/riotx/features/login/LoginViewModel.kt
+++ b/vector/src/main/java/im/vector/riotx/features/login/LoginViewModel.kt
@@ -19,7 +19,6 @@ package im.vector.riotx.features.login
 import android.content.Context
 import android.net.Uri
 import androidx.fragment.app.FragmentActivity
-import androidx.lifecycle.viewModelScope
 import com.airbnb.mvrx.ActivityViewModelContext
 import com.airbnb.mvrx.Fail
 import com.airbnb.mvrx.Loading
@@ -54,8 +53,6 @@ import im.vector.riotx.features.call.WebRtcPeerConnectionManager
 import im.vector.riotx.features.notifications.PushRuleTriggerListener
 import im.vector.riotx.features.session.SessionListener
 import im.vector.riotx.features.signout.soft.SoftLogoutActivity
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 import timber.log.Timber
 import java.util.concurrent.CancellationException
 
@@ -402,14 +399,7 @@ class LoginViewModel @AssistedInject constructor(
         when (action.signMode) {
             SignMode.SignUp             -> startRegistrationFlow()
             SignMode.SignIn             -> startAuthenticationFlow()
-            SignMode.SignInWithMatrixId -> {
-                viewModelScope.launch {
-                    // Add a delay to avoid crash
-                    delay(50)
-                    _viewEvents.post(LoginViewEvents.OnSignModeSelected)
-                }
-                Unit
-            }
+            SignMode.SignInWithMatrixId -> _viewEvents.post(LoginViewEvents.OnSignModeSelected(SignMode.SignInWithMatrixId))
             SignMode.Unknown            -> Unit
         }
     }
@@ -427,7 +417,7 @@ class LoginViewModel @AssistedInject constructor(
                 // Request login flow here
                 handle(LoginAction.UpdateHomeServer(matrixOrgUrl))
             ServerType.Modular,
-            ServerType.Other     -> _viewEvents.post(LoginViewEvents.OnServerSelectionDone)
+            ServerType.Other     -> _viewEvents.post(LoginViewEvents.OnServerSelectionDone(action.serverType))
         }.exhaustive
     }
 
@@ -661,7 +651,7 @@ class LoginViewModel @AssistedInject constructor(
         // Ensure Wizard is ready
         loginWizard
 
-        _viewEvents.post(LoginViewEvents.OnSignModeSelected)
+        _viewEvents.post(LoginViewEvents.OnSignModeSelected(SignMode.SignIn))
     }
 
     private fun onFlowResponse(flowResult: FlowResult) {

--- a/vector/src/main/java/im/vector/riotx/features/login/LoginViewModel.kt
+++ b/vector/src/main/java/im/vector/riotx/features/login/LoginViewModel.kt
@@ -321,7 +321,7 @@ class LoginViewModel @AssistedInject constructor(
             LoginAction.ResetHomeServerType -> {
                 setState {
                     copy(
-                            serverType = ServerType.MatrixOrg
+                            serverType = ServerType.Unknown
                     )
                 }
             }
@@ -390,6 +390,15 @@ class LoginViewModel @AssistedInject constructor(
                     serverType = action.serverType
             )
         }
+
+        when (action.serverType) {
+            ServerType.Unknown   -> Unit /* Should not happen */
+            ServerType.MatrixOrg ->
+                // Request login flow here
+                handle(LoginAction.UpdateHomeServer(stringProvider.getString(R.string.matrix_org_server_url)))
+            ServerType.Modular,
+            ServerType.Other     -> _viewEvents.post(LoginViewEvents.OnServerSelectionDone)
+        }.exhaustive
     }
 
     private fun handleInitWith(action: LoginAction.InitWith) {
@@ -682,7 +691,9 @@ class LoginViewModel @AssistedInject constructor(
                 _viewEvents.post(LoginViewEvents.Failure(failure))
                 setState {
                     copy(
-                            asyncHomeServerLoginFlowRequest = Uninitialized
+                            asyncHomeServerLoginFlowRequest = Uninitialized,
+                            // If we were trying to retrieve matrix.org login flow, also reset the serverType
+                            serverType = if (serverType == ServerType.MatrixOrg) ServerType.Unknown else serverType
                     )
                 }
             }

--- a/vector/src/main/java/im/vector/riotx/features/login/LoginViewState.kt
+++ b/vector/src/main/java/im/vector/riotx/features/login/LoginViewState.kt
@@ -35,7 +35,7 @@ data class LoginViewState(
 
         // User choices
         @PersistState
-        val serverType: ServerType = ServerType.MatrixOrg,
+        val serverType: ServerType = ServerType.Unknown,
         @PersistState
         val signMode: SignMode = SignMode.Unknown,
         @PersistState

--- a/vector/src/main/java/im/vector/riotx/features/login/ServerType.kt
+++ b/vector/src/main/java/im/vector/riotx/features/login/ServerType.kt
@@ -17,6 +17,7 @@
 package im.vector.riotx.features.login
 
 enum class ServerType {
+    Unknown,
     MatrixOrg,
     Modular,
     Other

--- a/vector/src/main/java/im/vector/riotx/features/signout/soft/SoftLogoutFragment.kt
+++ b/vector/src/main/java/im/vector/riotx/features/signout/soft/SoftLogoutFragment.kt
@@ -93,8 +93,9 @@ class SoftLogoutFragment @Inject constructor(
         softLogoutViewModel.handle(SoftLogoutAction.SignInAgain(password))
     }
 
-    override fun signinFallbackSubmit() {
-        loginViewModel.handle(LoginAction.PostViewEvent(LoginViewEvents.OnSignModeSelected))
+    override fun signinFallbackSubmit() = withState(loginViewModel) { state ->
+        // The loginViewModel has been prepared for a SSO/login fallback recovery (above)
+        loginViewModel.handle(LoginAction.PostViewEvent(LoginViewEvents.OnSignModeSelected(state.signMode)))
     }
 
     override fun clearData() {

--- a/vector/src/main/res/drawable/bg_login_server_selector.xml
+++ b/vector/src/main/res/drawable/bg_login_server_selector.xml
@@ -2,6 +2,7 @@
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
 
     <item android:drawable="@drawable/bg_login_server_checked" android:state_checked="true" />
+    <item android:drawable="@drawable/bg_login_server_checked" android:state_pressed="true" />
 
     <item android:drawable="@drawable/bg_login_server" />
 

--- a/vector/src/main/res/layout/fragment_login.xml
+++ b/vector/src/main/res/layout/fragment_login.xml
@@ -106,6 +106,16 @@
 
             </FrameLayout>
 
+            <TextView
+                android:id="@+id/loginPasswordNotice"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:gravity="start"
+                android:text="@string/login_signin_matrix_id_password_notice"
+                android:textAppearance="@style/TextAppearance.Vector.Login.Text.Small"
+                android:visibility="gone"
+                tools:visibility="visible" />
+
             <androidx.constraintlayout.widget.ConstraintLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"

--- a/vector/src/main/res/layout/fragment_login_server_selection.xml
+++ b/vector/src/main/res/layout/fragment_login_server_selection.xml
@@ -188,35 +188,23 @@
                 android:layout_marginTop="24dp"
                 android:text="@string/login_continue"
                 android:transitionName="loginSubmitTransition"
-                app:layout_constraintBottom_toTopOf="@+id/loginServerIKnowMyIdNotice"
+                app:layout_constraintBottom_toTopOf="@+id/loginServerIKnowMyIdSubmit"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/loginServerChoiceOther" />
-
-            <TextView
-                android:id="@+id/loginServerIKnowMyIdNotice"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="24dp"
-                android:gravity="start"
-                android:text="@string/login_connect_using_matrix_id_notice"
-                android:textAppearance="@style/TextAppearance.Vector.Login.Text.Small"
-                android:visibility="gone"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/loginServerSubmit" />
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/loginServerIKnowMyIdSubmit"
                 style="@style/Style.Vector.Login.Button.Text"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
+                android:layout_marginTop="32dp"
+                android:layout_marginBottom="32dp"
                 android:text="@string/login_connect_using_matrix_id_submit"
-                android:visibility="gone"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/loginServerIKnowMyIdNotice" />
+                app:layout_constraintTop_toBottomOf="@+id/loginServerSubmit" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/vector/src/main/res/layout/fragment_login_server_selection.xml
+++ b/vector/src/main/res/layout/fragment_login_server_selection.xml
@@ -43,6 +43,7 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/loginServerTitle" />
 
+            <!-- Use a CheckableConstraintLayout to keep the pressed state when retrieving login flow -->
             <im.vector.riotx.core.platform.CheckableConstraintLayout
                 android:id="@+id/loginServerChoiceMatrixOrg"
                 android:layout_width="match_parent"
@@ -84,7 +85,7 @@
 
             </im.vector.riotx.core.platform.CheckableConstraintLayout>
 
-            <im.vector.riotx.core.platform.CheckableConstraintLayout
+            <androidx.constraintlayout.widget.ConstraintLayout
                 android:id="@+id/loginServerChoiceModular"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -135,9 +136,9 @@
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintTop_toTopOf="@+id/loginServerChoiceModularText" />
 
-            </im.vector.riotx.core.platform.CheckableConstraintLayout>
+            </androidx.constraintlayout.widget.ConstraintLayout>
 
-            <im.vector.riotx.core.platform.CheckableConstraintLayout
+            <androidx.constraintlayout.widget.ConstraintLayout
                 android:id="@+id/loginServerChoiceOther"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -178,20 +179,7 @@
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@+id/loginServerChoiceOtherTitle" />
 
-            </im.vector.riotx.core.platform.CheckableConstraintLayout>
-
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/loginServerSubmit"
-                style="@style/Style.Vector.Login.Button"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="24dp"
-                android:text="@string/login_continue"
-                android:transitionName="loginSubmitTransition"
-                app:layout_constraintBottom_toTopOf="@+id/loginServerIKnowMyIdSubmit"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/loginServerChoiceOther" />
+            </androidx.constraintlayout.widget.ConstraintLayout>
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/loginServerIKnowMyIdSubmit"
@@ -204,7 +192,7 @@
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/loginServerSubmit" />
+                app:layout_constraintTop_toBottomOf="@+id/loginServerChoiceOther" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -1995,10 +1995,11 @@ Not all features in Riot are implemented in RiotX yet. Main missing (and coming 
     </plurals>
 
     <string name="login_connect_using_matrix_id_notice">Alternatively, if you already have an account and you know your Matrix identifier and your password, you can use this method:</string>
-    <string name="login_connect_using_matrix_id_submit">Sign in with my Matrix identifier</string>
-    <string name="login_signin_matrix_id_title">Sign in</string>
-    <string name="login_signin_matrix_id_notice">Enter your identifier and your password</string>
-    <string name="login_signin_matrix_id_hint">User identifier</string>
+    <string name="login_connect_using_matrix_id_submit">Sign in with Matrix ID</string>
+    <string name="login_signin_matrix_id_title">Sign in with Matrix ID</string>
+    <string name="login_signin_matrix_id_notice">If you set up an account on a homeserver, use your Matrix ID (e.g. @user:domain.com) and password below.</string>
+    <string name="login_signin_matrix_id_hint">Matrix ID</string>
+    <string name="login_signin_matrix_id_password_notice">If you don’t know your password, go back to reset it.</string>
     <string name="login_signin_matrix_id_error_invalid_matrix_id">This is not a valid user identifier. Expected format: \'@user:homeserver.org\'</string>
     <string name="autodiscover_well_known_error">Unable to find a valid homeserver. Please check your identifier</string>
 


### PR DESCRIPTION
Figma: https://www.figma.com/file/S6e3YKA1OB7lWGYrOLEZBq/.well-known-quick-wins

Fixes #1614 

New screen:

<img width="382" alt="image" src="https://user-images.githubusercontent.com/3940906/86593875-52994f00-bf96-11ea-897f-7aaf3b7dbc5c.png">

The "continue" button as been removed, for a straight forward navigation. It was strange to be able to click twice on the element to validate the choice.

Also now, when selecting "modular" or "other" and typing "matrix.org" as the homeserver url, RiotX will display the matrix.org form

Tested OK: 
- Account creation on matrix.org
- login on matrix.org
- direct login on matrix.org account
