### PR TITLE
Feature/tab notification labs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Improvements 🙌:
  - Improve fullscreen media display (#327)
  - Setup server recovery banner (#1648)
  - Set up SSSS from security settings (#1567)
+ - New lab setting to add 'unread notifications' tab to main screen
 
 Bugfix 🐛:
  - Regression |  Share action menu do not work (#1647)

--- a/vector/src/main/java/im/vector/riotx/features/home/RoomListDisplayMode.kt
+++ b/vector/src/main/java/im/vector/riotx/features/home/RoomListDisplayMode.kt
@@ -20,7 +20,7 @@ import androidx.annotation.StringRes
 import im.vector.riotx.R
 
 enum class RoomListDisplayMode(@StringRes val titleRes: Int) {
-        HOME(R.string.bottom_action_home),
+        NOTIFICATIONS(R.string.bottom_action_notification),
         PEOPLE(R.string.bottom_action_people_x),
         ROOMS(R.string.bottom_action_rooms),
         FILTERED(/* Not used */ 0)

--- a/vector/src/main/java/im/vector/riotx/features/home/room/list/RoomListDisplayModeFilter.kt
+++ b/vector/src/main/java/im/vector/riotx/features/home/room/list/RoomListDisplayModeFilter.kt
@@ -28,9 +28,9 @@ class RoomListDisplayModeFilter(private val displayMode: RoomListDisplayMode) : 
             return false
         }
         return when (displayMode) {
-            RoomListDisplayMode.HOME     ->
+            RoomListDisplayMode.NOTIFICATIONS ->
                 roomSummary.notificationCount > 0 || roomSummary.membership == Membership.INVITE || roomSummary.userDrafts.isNotEmpty()
-            RoomListDisplayMode.PEOPLE   -> roomSummary.isDirect && roomSummary.membership.isActive()
+            RoomListDisplayMode.PEOPLE        -> roomSummary.isDirect && roomSummary.membership.isActive()
             RoomListDisplayMode.ROOMS    -> !roomSummary.isDirect && roomSummary.membership.isActive()
             RoomListDisplayMode.FILTERED -> roomSummary.membership == Membership.JOIN
         }

--- a/vector/src/main/java/im/vector/riotx/features/home/room/list/RoomListFragment.kt
+++ b/vector/src/main/java/im/vector/riotx/features/home/room/list/RoomListFragment.kt
@@ -138,8 +138,8 @@ class RoomListFragment @Inject constructor(
 
     private fun setupCreateRoomButton() {
         when (roomListParams.displayMode) {
-            RoomListDisplayMode.HOME   -> createChatFabMenu.isVisible = true
-            RoomListDisplayMode.PEOPLE -> createChatRoomButton.isVisible = true
+            RoomListDisplayMode.NOTIFICATIONS -> createChatFabMenu.isVisible = true
+            RoomListDisplayMode.PEOPLE        -> createChatRoomButton.isVisible = true
             RoomListDisplayMode.ROOMS  -> createGroupRoomButton.isVisible = true
             else                       -> Unit // No button in this mode
         }
@@ -164,8 +164,8 @@ class RoomListFragment @Inject constructor(
                             RecyclerView.SCROLL_STATE_DRAGGING,
                             RecyclerView.SCROLL_STATE_SETTLING -> {
                                 when (roomListParams.displayMode) {
-                                    RoomListDisplayMode.HOME   -> createChatFabMenu.hide()
-                                    RoomListDisplayMode.PEOPLE -> createChatRoomButton.hide()
+                                    RoomListDisplayMode.NOTIFICATIONS -> createChatFabMenu.hide()
+                                    RoomListDisplayMode.PEOPLE        -> createChatRoomButton.hide()
                                     RoomListDisplayMode.ROOMS  -> createGroupRoomButton.hide()
                                     else                       -> Unit
                                 }
@@ -207,8 +207,8 @@ class RoomListFragment @Inject constructor(
     private val showFabRunnable = Runnable {
         if (isAdded) {
             when (roomListParams.displayMode) {
-                RoomListDisplayMode.HOME   -> createChatFabMenu.show()
-                RoomListDisplayMode.PEOPLE -> createChatRoomButton.show()
+                RoomListDisplayMode.NOTIFICATIONS -> createChatFabMenu.show()
+                RoomListDisplayMode.PEOPLE        -> createChatRoomButton.show()
                 RoomListDisplayMode.ROOMS  -> createGroupRoomButton.show()
                 else                       -> Unit
             }
@@ -258,7 +258,7 @@ class RoomListFragment @Inject constructor(
         roomController.update(state)
         // Mark all as read menu
         when (roomListParams.displayMode) {
-            RoomListDisplayMode.HOME,
+            RoomListDisplayMode.NOTIFICATIONS,
             RoomListDisplayMode.PEOPLE,
             RoomListDisplayMode.ROOMS -> {
                 val newValue = state.hasUnread
@@ -288,7 +288,7 @@ class RoomListFragment @Inject constructor(
                 }
                 .isNullOrEmpty()
         val emptyState = when (roomListParams.displayMode) {
-            RoomListDisplayMode.HOME   -> {
+            RoomListDisplayMode.NOTIFICATIONS -> {
                 if (hasNoRoom) {
                     StateView.State.Empty(
                             getString(R.string.room_list_catchup_welcome_title),

--- a/vector/src/main/java/im/vector/riotx/features/settings/VectorPreferences.kt
+++ b/vector/src/main/java/im/vector/riotx/features/settings/VectorPreferences.kt
@@ -147,6 +147,7 @@ class VectorPreferences @Inject constructor(private val context: Context) {
         private const val SETTINGS_DEVELOPER_MODE_FAIL_FAST_PREFERENCE_KEY = "SETTINGS_DEVELOPER_MODE_FAIL_FAST_PREFERENCE_KEY"
         // SETTINGS_LABS_HIDE_TECHNICAL_E2E_ERRORS
         private const val SETTINGS_LABS_MERGE_E2E_ERRORS = "SETTINGS_LABS_MERGE_E2E_ERRORS"
+        const val SETTINGS_LABS_UNREAD_NOTIFICATIONS_AS_TAB = "SETTINGS_LABS_UNREAD_NOTIFICATIONS_AS_TAB"
 
         // analytics
         const val SETTINGS_USE_ANALYTICS_KEY = "SETTINGS_USE_ANALYTICS_KEY"
@@ -274,6 +275,10 @@ class VectorPreferences @Inject constructor(private val context: Context) {
 
     fun labAllowedExtendedLogging(): Boolean {
         return developerMode() && defaultPrefs.getBoolean(SETTINGS_LABS_ALLOW_EXTENDED_LOGS, false)
+    }
+
+    fun labAddNotificationTab(): Boolean {
+        return defaultPrefs.getBoolean(SETTINGS_LABS_UNREAD_NOTIFICATIONS_AS_TAB, false)
     }
 
     fun failFast(): Boolean {

--- a/vector/src/main/java/im/vector/riotx/features/settings/VectorSettingsLabsFragment.kt
+++ b/vector/src/main/java/im/vector/riotx/features/settings/VectorSettingsLabsFragment.kt
@@ -34,6 +34,10 @@ class VectorSettingsLabsFragment @Inject constructor(
             it.isChecked = vectorPreferences.labAllowedExtendedLogging()
         }
 
+        findPreference<VectorSwitchPreference>(VectorPreferences.SETTINGS_LABS_UNREAD_NOTIFICATIONS_AS_TAB)?.let {
+            it.isChecked = vectorPreferences.labAddNotificationTab()
+        }
+
 //        val useCryptoPref = findPreference(VectorPreferences.SETTINGS_ROOM_SETTINGS_LABS_END_TO_END_PREFERENCE_KEY) as SwitchPreference
 //        val cryptoIsEnabledPref = findPreference(VectorPreferences.SETTINGS_ROOM_SETTINGS_LABS_END_TO_END_IS_ACTIVE_PREFERENCE_KEY)
 

--- a/vector/src/main/java/im/vector/riotx/features/ui/SharedPreferencesUiStateRepository.kt
+++ b/vector/src/main/java/im/vector/riotx/features/ui/SharedPreferencesUiStateRepository.kt
@@ -19,12 +19,16 @@ package im.vector.riotx.features.ui
 import android.content.SharedPreferences
 import androidx.core.content.edit
 import im.vector.riotx.features.home.RoomListDisplayMode
+import im.vector.riotx.features.settings.VectorPreferences
 import javax.inject.Inject
 
 /**
  * This class is used to persist UI state across application restart
  */
-class SharedPreferencesUiStateRepository @Inject constructor(private val sharedPreferences: SharedPreferences) : UiStateRepository {
+class SharedPreferencesUiStateRepository @Inject constructor(
+        private val sharedPreferences: SharedPreferences,
+        private val vectorPreferences: VectorPreferences
+) : UiStateRepository {
 
     override fun reset() {
         sharedPreferences.edit {
@@ -36,7 +40,11 @@ class SharedPreferencesUiStateRepository @Inject constructor(private val sharedP
         return when (sharedPreferences.getInt(KEY_DISPLAY_MODE, VALUE_DISPLAY_MODE_CATCHUP)) {
             VALUE_DISPLAY_MODE_PEOPLE -> RoomListDisplayMode.PEOPLE
             VALUE_DISPLAY_MODE_ROOMS  -> RoomListDisplayMode.ROOMS
-            else                      -> RoomListDisplayMode.PEOPLE // RoomListDisplayMode.HOME
+            else                      -> if (vectorPreferences.labAddNotificationTab()) {
+                RoomListDisplayMode.NOTIFICATIONS
+            } else {
+                RoomListDisplayMode.PEOPLE
+            }
         }
     }
 

--- a/vector/src/main/res/menu/home_bottom_navigation.xml
+++ b/vector/src/main/res/menu/home_bottom_navigation.xml
@@ -2,13 +2,6 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
 
     <item
-        android:id="@+id/bottom_action_home"
-        android:enabled="true"
-        android:icon="@drawable/ic_home_bottom_catchup"
-        android:title="@string/bottom_action_home"
-        android:visible="false" />
-
-    <item
         android:id="@+id/bottom_action_people"
         android:enabled="true"
         android:icon="@drawable/ic_home_bottom_chat"
@@ -19,5 +12,12 @@
         android:enabled="true"
         android:icon="@drawable/ic_home_bottom_group"
         android:title="@string/bottom_action_rooms" />
+
+    <item
+        android:id="@+id/bottom_action_notification"
+        android:enabled="true"
+        android:icon="@drawable/ic_bell"
+        android:title="@string/bottom_action_notification"
+        android:visible="false" />
 
 </menu>

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -130,6 +130,7 @@
 
     <!-- Bottom navigation buttons -->
     <string name="bottom_action_home">Home</string>
+    <string name="bottom_action_notification">Notifications</string>
     <string name="bottom_action_favourites">Favourites</string>
     <string name="bottom_action_people">People</string>
     <string name="bottom_action_rooms">Rooms</string>
@@ -1760,6 +1761,7 @@ Not all features in Riot are implemented in RiotX yet. Main missing (and coming 
 
     <string name="labs_swipe_to_reply_in_timeline">Enable swipe to reply in timeline</string>
     <string name="labs_merge_e2e_in_timeline">Merge failed to decrypt message in timeline</string>
+    <string name="labs_show_unread_notifications_as_tab">Add a dedicated tab for unread notifications on main screen.</string>
 
     <string name="link_copied_to_clipboard">Link copied to clipboard</string>
 

--- a/vector/src/main/res/xml/vector_settings_labs.xml
+++ b/vector/src/main/res/xml/vector_settings_labs.xml
@@ -44,6 +44,12 @@
         android:defaultValue="false"
         android:key="SETTINGS_LABS_MERGE_E2E_ERRORS"
         android:title="@string/labs_merge_e2e_in_timeline" />
+
+
+    <im.vector.riotx.core.preference.VectorSwitchPreference
+        android:defaultValue="false"
+        android:key="SETTINGS_LABS_UNREAD_NOTIFICATIONS_AS_TAB"
+        android:title="@string/labs_show_unread_notifications_as_tab" />
     <!--</im.vector.riotx.core.preference.VectorPreferenceCategory>-->
 
 </androidx.preference.PreferenceScreen>


### PR DESCRIPTION
Proposal for a lab option to add a third tab that displays all rooms with unread notifications

False by default, users with lots of room can enable it;

+ Refactored bottom navigation bar to use the Compat Badges instead of adding custom views

<img width="401" alt="image" src="https://user-images.githubusercontent.com/9841565/87229167-38041300-c3a6-11ea-9ec3-5c6c834219be.png">


<img width="415" alt="image" src="https://user-images.githubusercontent.com/9841565/87229163-30446e80-c3a6-11ea-9a75-aba922a01eab.png">

