### PR TITLE
Fix / view attachment crash + freeze when offline

### DIFF
--- a/vector/src/main/java/im/vector/riotx/features/media/ImageContentRenderer.kt
+++ b/vector/src/main/java/im/vector/riotx/features/media/ImageContentRenderer.kt
@@ -151,7 +151,10 @@ class ImageContentRenderer @Inject constructor(private val activeSessionHolder: 
                 .into(imageView)
     }
 
-    fun renderThumbnailDontTransform(data: Data, imageView: ImageView, callback: ((Boolean) -> Unit)? = null) {
+    /**
+     * onlyRetrieveFromCache is true!
+     */
+    fun renderForSharedElementTransition(data: Data, imageView: ImageView, callback: ((Boolean) -> Unit)? = null) {
         // a11y
         imageView.contentDescription = data.filename
 
@@ -186,7 +189,8 @@ class ImageContentRenderer @Inject constructor(private val activeSessionHolder: 
                 return false
             }
         })
-                .dontTransform()
+                .onlyRetrieveFromCache(true)
+                .fitCenter()
                 .into(imageView)
     }
 

--- a/vector/src/main/java/im/vector/riotx/features/media/VectorAttachmentViewerActivity.kt
+++ b/vector/src/main/java/im/vector/riotx/features/media/VectorAttachmentViewerActivity.kt
@@ -96,7 +96,7 @@ class VectorAttachmentViewerActivity : AttachmentViewerActivity(), BaseAttachmen
                     // will be shown at end of transition
                     pager2.isInvisible = true
                     supportPostponeEnterTransition()
-                    imageContentRenderer.renderThumbnailDontTransform(mediaData, imageTransitionView) {
+                    imageContentRenderer.renderForSharedElementTransition(mediaData, imageTransitionView) {
                         // Proceed with transaction
                         scheduleStartPostponedTransition(imageTransitionView)
                     }
@@ -104,7 +104,7 @@ class VectorAttachmentViewerActivity : AttachmentViewerActivity(), BaseAttachmen
                     // will be shown at end of transition
                     pager2.isInvisible = true
                     supportPostponeEnterTransition()
-                    imageContentRenderer.renderThumbnailDontTransform(mediaData.thumbnailMediaData, imageTransitionView) {
+                    imageContentRenderer.renderForSharedElementTransition(mediaData.thumbnailMediaData, imageTransitionView) {
                         // Proceed with transaction
                         scheduleStartPostponedTransition(imageTransitionView)
                     }


### PR DESCRIPTION
Fix a crash when images have a very thin ration, e.g 10px*500px , due to bad resize policy, the height was trying match target height leading to a big multiplicator, that when applied to the width would cause OOM
https://github.com/matrix-org/riot-android-rageshakes/issues/12383

Fix, delay or freeze (when offline) when opening image viewer pager -> updated glide to only take image from cache to avoid delaying shared element transition for too long
