### PR TITLE
Feature/fix 1613

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@ Improvements 🙌:
  -
 
 Bugfix 🐛:
- -
+ - Fix theme issue on Room directory screen (#1613)
 
 Translations 🗣:
  -

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/sync/SyncResponseHandler.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/sync/SyncResponseHandler.kt
@@ -116,11 +116,11 @@ internal class SyncResponseHandler @Inject constructor(@SessionDatabase private 
             tokenStore.saveToken(realm, syncResponse.nextBatch)
         }
         // Everything else we need to do outside the transaction
-        syncResponse.rooms?.also {
+        syncResponse.rooms?.let {
             checkPushRules(it, isInitialSync)
             userAccountDataSyncHandler.synchronizeWithServerIfNeeded(it.invite)
         }
-        syncResponse.groups?.also {
+        syncResponse.groups?.let {
             scheduleGroupDataFetchingIfNeeded(it)
         }
 

--- a/vector/src/main/java/im/vector/riotx/features/roomdirectory/picker/RoomDirectoryItem.kt
+++ b/vector/src/main/java/im/vector/riotx/features/roomdirectory/picker/RoomDirectoryItem.kt
@@ -19,6 +19,7 @@ package im.vector.riotx.features.roomdirectory.picker
 import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.TextView
+import androidx.core.view.isInvisible
 import com.airbnb.epoxy.EpoxyAttribute
 import com.airbnb.epoxy.EpoxyModelClass
 import im.vector.riotx.R
@@ -58,6 +59,7 @@ abstract class RoomDirectoryItem : VectorEpoxyModel<RoomDirectoryItem.Holder>() 
                     }
                 }
                 .into(holder.avatarView)
+        holder.avatarView.isInvisible = directoryAvatarUrl.isNullOrBlank() && includeAllNetworks
 
         holder.nameView.text = directoryName
         holder.descritionView.setTextOrHide(directoryDescription)

--- a/vector/src/main/java/im/vector/riotx/features/roomdirectory/picker/RoomDirectoryPickerFragment.kt
+++ b/vector/src/main/java/im/vector/riotx/features/roomdirectory/picker/RoomDirectoryPickerFragment.kt
@@ -26,6 +26,7 @@ import im.vector.matrix.android.api.session.room.model.thirdparty.RoomDirectoryD
 import im.vector.riotx.R
 import im.vector.riotx.core.extensions.cleanup
 import im.vector.riotx.core.extensions.configureWith
+import im.vector.riotx.core.platform.VectorBaseActivity
 import im.vector.riotx.core.platform.VectorBaseFragment
 import im.vector.riotx.features.roomdirectory.RoomDirectoryAction
 import im.vector.riotx.features.roomdirectory.RoomDirectorySharedAction
@@ -35,7 +36,6 @@ import kotlinx.android.synthetic.main.fragment_room_directory_picker.*
 import timber.log.Timber
 import javax.inject.Inject
 
-// TODO Set title to R.string.select_room_directory
 // TODO Menu to add custom room directory (not done in RiotWeb so far...)
 class RoomDirectoryPickerFragment @Inject constructor(val roomDirectoryPickerViewModelFactory: RoomDirectoryPickerViewModel.Factory,
                                                       private val roomDirectoryPickerController: RoomDirectoryPickerController
@@ -89,6 +89,11 @@ class RoomDirectoryPickerFragment @Inject constructor(val roomDirectoryPickerVie
         viewModel.handle(RoomDirectoryAction.SetRoomDirectoryData(roomDirectoryData))
 
         sharedActionViewModel.post(RoomDirectorySharedAction.Back)
+    }
+
+    override fun onResume() {
+        super.onResume()
+        (activity as? VectorBaseActivity)?.supportActionBar?.setTitle(R.string.select_room_directory)
     }
 
     override fun retry() {

--- a/vector/src/main/res/layout/item_room_directory.xml
+++ b/vector/src/main/res/layout/item_room_directory.xml
@@ -19,6 +19,8 @@
         android:layout_marginLeft="8dp"
         android:layout_marginTop="4dp"
         android:layout_marginBottom="4dp"
+        android:background="@drawable/circle"
+        android:padding="8dp"
         app:layout_constraintBottom_toTopOf="@+id/itemRoomDirectoryBottomSeparator"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"

--- a/vector/src/main/res/menu/menu_directory_server_picker.xml
+++ b/vector/src/main/res/menu/menu_directory_server_picker.xml
@@ -6,6 +6,7 @@
         android:id="@+id/action_add_custom_hs"
         android:icon="@drawable/ic_add_black"
         android:title="@string/action_open"
+        android:visible="@bool/false_not_implemented"
         app:iconTint="?colorAccent"
         app:showAsAction="always" />
 

--- a/vector/src/main/res/menu/menu_directory_server_picker.xml
+++ b/vector/src/main/res/menu/menu_directory_server_picker.xml
@@ -6,6 +6,7 @@
         android:id="@+id/action_add_custom_hs"
         android:icon="@drawable/ic_add_black"
         android:title="@string/action_open"
+        app:iconTint="?colorAccent"
         app:showAsAction="always" />
 
 </menu>


### PR DESCRIPTION
Fixes #1613 

The + menu has been removed because it not supported yet. Seems that on Element-Web this is not supported anymore as well.
The title is now "Select room directory" (remaining TODO)

Rendering (not including the new title):

Dark:

<img width="442" alt="image" src="https://user-images.githubusercontent.com/3940906/87546083-3fc6fe80-c6a9-11ea-862c-eaa3f504fab5.png">

Light:

<img width="449" alt="image" src="https://user-images.githubusercontent.com/3940906/87546164-6127ea80-c6a9-11ea-9856-2b91226a7cff.png">

