### PR TITLE
Improve splash screen

### DIFF
--- a/vector/src/main/res/values-v21/theme_common.xml
+++ b/vector/src/main/res/values-v21/theme_common.xml
@@ -1,6 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
+    <style name="AppTheme.Launcher.v21" parent="AppTheme.Launcher.Base">
+        <item name="android:statusBarColor">@color/riotx_accent</item>
+        <item name="android:navigationBarColor">@color/riotx_accent</item>
+    </style>
+
+    <style name="AppTheme.Launcher" parent="AppTheme.Launcher.v21"/>
+
     <style name="AppTheme.AttachmentsPreview" parent="AppTheme.Base.Black">
         <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="android:navigationBarColor">@android:color/transparent</item>

--- a/vector/src/main/res/values/theme_common.xml
+++ b/vector/src/main/res/values/theme_common.xml
@@ -2,7 +2,9 @@
 <resources>
 
     <!-- Launcher Theme, only used for VectorLauncherActivity (will be use even before the Activity is started) -->
-    <style name="AppTheme.Launcher" parent="Theme.MaterialComponents.Light.NoActionBar">
+    <style name="AppTheme.Launcher" parent="AppTheme.Launcher.Base"/>
+
+    <style name="AppTheme.Launcher.Base" parent="Theme.MaterialComponents.Light.NoActionBar">
         <item name="android:windowBackground">@drawable/splash</item>
 
         <item name="colorPrimaryDark">@color/primary_color_dark</item>


### PR DESCRIPTION
Use accent color to tint status and navigation bar, on devices which support it.

Before:

<img width="221" alt="image" src="https://user-images.githubusercontent.com/3940906/87548792-4ce5ec80-c6ad-11ea-9afd-d652f5c42b7c.png">

After:

<img width="220" alt="image" src="https://user-images.githubusercontent.com/3940906/87548845-5c653580-c6ad-11ea-8ced-cf1b5d141c6b.png">
