### PR TITLE
RiotX -> Element

### DIFF
--- a/docs/signin.md
+++ b/docs/signin.md
@@ -155,9 +155,9 @@ Not supported yet in RiotX
 
 In this case, the user can click on "Sign in with SSO" and the native web browser, or a ChromeCustomTab if the device supports it, will be launched on the page
 
-> https://homeserver.with.sso/_matrix/client/r0/login/sso/redirect?redirectUrl=riotx%3A%2F%2Friotx
+> https://homeserver.with.sso/_matrix/client/r0/login/sso/redirect?redirectUrl=element%3A%2F%element
 
-The parameter `redirectUrl` is set to `riotx://riotx`.
+The parameter `redirectUrl` is set to `element://element`.
 
 ChromeCustomTabs are an intermediate way to display a WebPage, between a WebView and using the external browser. More info can be found [here](https://developer.chrome.com/multidevice/android/customtabs)
 
@@ -167,9 +167,9 @@ During the process, user may be asked to validate an email by clicking on a link
 
 Once the process is finished, the web page will call the `redirectUrl` with an extra parameter `loginToken`
 
-> riotx://riotx?loginToken=MDAxOWxvY2F0aW9uIG1vemlsbGEub3JnCjAwMTNpZGVudGlmaWVy
+> element://element?loginToken=MDAxOWxvY2F0aW9uIG1vemlsbGEub3JnCjAwMTNpZGVudGlmaWVy
 
-This navigation is intercepted by RiotX by the `LoginActivity`, which will then ask the homeserver to convert this `loginToken` to an access token
+This navigation is intercepted by Element by the `LoginActivity`, which will then ask the homeserver to convert this `loginToken` to an access token
 
 > curl -X POST --data $'{"type":"m.login.token","token":"MDAxOWxvY2F0aW9uIG1vemlsbGEub3JnCjAwMTNpZGVudGlmaWVy"}' 'https://homeserver.with.sso/_matrix/client/r0/login'
 

--- a/docs/signin.md
+++ b/docs/signin.md
@@ -132,7 +132,7 @@ It's worth noting that the response from the homeserver contains the userId of A
 
 ### Login with Msisdn
 
-Not supported yet in RiotX
+Not supported yet in Element
 
 ### Login with SSO
 

--- a/vector/src/main/AndroidManifest.xml
+++ b/vector/src/main/AndroidManifest.xml
@@ -80,8 +80,8 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
 
-                <data android:scheme="riotx" />
-                <data android:host="riotx" />
+                <data android:scheme="element" />
+                <data android:host="element" />
             </intent-filter>
         </activity>
         <activity android:name=".features.media.ImageMediaViewerActivity" />

--- a/vector/src/main/assets/open_source_licenses.html
+++ b/vector/src/main/assets/open_source_licenses.html
@@ -28,7 +28,7 @@
 </head>
 <body>
 <div>
-    <p>RiotX Android</p>
+    <p>Element Android</p>
     <p>Third Party Licenses</p>
 </div>
 

--- a/vector/src/main/java/im/vector/riotx/core/resources/AppNameProvider.kt
+++ b/vector/src/main/java/im/vector/riotx/core/resources/AppNameProvider.kt
@@ -36,7 +36,7 @@ class AppNameProvider @Inject constructor(private val context: Context) {
             return appName
         } catch (e: Exception) {
             Timber.e(e, "## AppNameProvider() : failed")
-            return "RiotXAndroid"
+            return "ElementAndroid"
         }
     }
 }

--- a/vector/src/main/java/im/vector/riotx/features/call/telecom/VectorConnectionService.kt
+++ b/vector/src/main/java/im/vector/riotx/features/call/telecom/VectorConnectionService.kt
@@ -66,7 +66,7 @@ import im.vector.riotx.core.services.CallService
         connection.connectionCapabilities = Connection.CAPABILITY_MUTE
         connection.audioModeIsVoip = true
         connection.setAddress(Uri.fromParts("tel", "+905000000000", null), TelecomManager.PRESENTATION_ALLOWED)
-        connection.setCallerDisplayName("RiotX Caller", TelecomManager.PRESENTATION_ALLOWED)
+        connection.setCallerDisplayName("Element Caller", TelecomManager.PRESENTATION_ALLOWED)
         connection.statusHints = StatusHints("Testing Hint...", null, null)
 
         bindService(Intent(applicationContext, CallService::class.java), CallServiceConnection(connection), 0)

--- a/vector/src/main/java/im/vector/riotx/features/login/LoginViewState.kt
+++ b/vector/src/main/java/im/vector/riotx/features/login/LoginViewState.kt
@@ -73,7 +73,7 @@ data class LoginViewState(
             append(homeServerUrl?.trim { it == '/' })
             append(SSO_REDIRECT_PATH)
             // Set a redirect url we will intercept later
-            appendParamToUrl(SSO_REDIRECT_URL_PARAM, RIOTX_REDIRECT_URL)
+            appendParamToUrl(SSO_REDIRECT_URL_PARAM, VECTOR_REDIRECT_URL)
             deviceId?.takeIf { it.isNotBlank() }?.let {
                 // But https://github.com/matrix-org/synapse/issues/5755
                 appendParamToUrl("device_id", it)
@@ -83,6 +83,6 @@ data class LoginViewState(
 
     companion object {
         // Note that the domain can be displayed to the user for confirmation that he trusts it. So use a human readable string
-        private const val RIOTX_REDIRECT_URL = "riotx://riotx"
+        private const val VECTOR_REDIRECT_URL = "element://element"
     }
 }

--- a/vector/src/main/java/im/vector/riotx/features/rageshake/VectorUncaughtExceptionHandler.kt
+++ b/vector/src/main/java/im/vector/riotx/features/rageshake/VectorUncaughtExceptionHandler.kt
@@ -65,7 +65,7 @@ class VectorUncaughtExceptionHandler @Inject constructor(private val bugReporter
             putBoolean(PREFS_CRASH_KEY, true)
         }
         val b = StringBuilder()
-        val appName = "RiotX" // TODO Matrix.getApplicationName()
+        val appName = "Element" // TODO Matrix.getApplicationName()
 
         b.append(appName + " Build : " + versionCodeProvider.getVersionCode() + "\n")
         b.append("$appName Version : ${versionProvider.getVersion(longFormat = true, useBuildNumber = true)}\n")

--- a/vector/src/main/res/values/donottranslate.xml
+++ b/vector/src/main/res/values/donottranslate.xml
@@ -10,6 +10,6 @@
     <string name="password_hint" translatable="false">********</string>
 
     <!-- Temporary string -->
-    <string name="not_implemented" translatable="false">Not implemented yet in RiotX</string>
+    <string name="not_implemented" translatable="false">Not implemented yet in Element</string>
 
 </resources>


### PR DESCRIPTION
Change all visible in the app mention of "RiotX" to "Element".

There are still lots of mention of RiotX in comments, and internal files, as well as in some of .md file, which will be updated later.

Login with SSO tested OK