### PR TITLE
Allow call in all 2 participants rooms

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,8 @@ Bugfix 🐛:
  - Fix 404 on EMS (#1761)
  - Fix Infinite loop at startup when migrating account from Riot (#1699)
  - Fix Element crashes in loop after initial sync (#1709)
+ - Fix "Voice & Video" grayed out in Settings (#1733)
+ - Fix Allow VOIP call in all rooms with 2 participants (even if not DM)
 
 Translations 🗣:
  -

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/model/RoomSummary.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/session/room/model/RoomSummary.kt
@@ -67,7 +67,7 @@ data class RoomSummary constructor(
         get() = tags.any { it.name == RoomTag.ROOM_TAG_FAVOURITE }
 
     val canStartCall: Boolean
-        get() = isDirect && joinedMembersCount == 2
+        get() = joinedMembersCount == 2
 
     companion object {
         const val NOT_IN_BREADCRUMBS = -1

--- a/vector/src/main/res/xml/vector_settings_root.xml
+++ b/vector/src/main/res/xml/vector_settings_root.xml
@@ -24,6 +24,7 @@
         app:fragment="im.vector.riotx.features.settings.VectorSettingsPreferencesFragment" />
 
     <im.vector.riotx.core.preference.VectorPreference
+        app:isPreferenceVisible="@bool/false_not_implemented"
         android:enabled="@bool/false_not_implemented"
         android:icon="@drawable/ic_settings_root_call"
         android:title="@string/preference_voice_and_video"


### PR DESCRIPTION
Show VOIP call icons for all 2 participants room (even if not DM)
+ Hide for now the VOIP settings category until implemented Fixes #1733
