### PR TITLE
Fix timeline non loading when there are lots of filtered events

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ Bugfix 🐛:
  - Fix 404 on EMS (#1761)
  - Fix Infinite loop at startup when migrating account from Riot (#1699)
  - Fix Element crashes in loop after initial sync (#1709)
+ - Fix timeline items not loading when there are only filtered events
 
 Translations 🗣:
  -

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/timeline/DefaultTimeline.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/session/room/timeline/DefaultTimeline.kt
@@ -169,7 +169,7 @@ internal class DefaultTimeline(
                 filteredEvents = nonFilteredEvents.where()
                         .filterEventsWithSettings()
                         .findAll()
-                filteredEvents.addChangeListener(eventsChangeListener)
+                nonFilteredEvents.addChangeListener(eventsChangeListener)
                 handleInitialLoad()
                 if (settings.shouldHandleHiddenReadReceipts()) {
                     hiddenReadReceipts.start(realm, filteredEvents, nonFilteredEvents, this)

--- a/vector/src/main/java/im/vector/riotx/core/epoxy/LoadingItem.kt
+++ b/vector/src/main/java/im/vector/riotx/core/epoxy/LoadingItem.kt
@@ -16,7 +16,9 @@
 
 package im.vector.riotx.core.epoxy
 
+import android.widget.ProgressBar
 import android.widget.TextView
+import androidx.core.view.isVisible
 import com.airbnb.epoxy.EpoxyAttribute
 import com.airbnb.epoxy.EpoxyModelClass
 import im.vector.riotx.R
@@ -26,14 +28,16 @@ import im.vector.riotx.core.extensions.setTextOrHide
 abstract class LoadingItem : VectorEpoxyModel<LoadingItem.Holder>() {
 
     @EpoxyAttribute var loadingText: String? = null
+    @EpoxyAttribute var showLoader: Boolean = true
 
     override fun bind(holder: Holder) {
         super.bind(holder)
-
+        holder.progressBar.isVisible = showLoader
         holder.textView.setTextOrHide(loadingText)
     }
 
     class Holder : VectorEpoxyHolder() {
         val textView by bind<TextView>(R.id.loadingText)
+        val progressBar by bind<ProgressBar>(R.id.loadingProgress)
     }
 }

--- a/vector/src/main/java/im/vector/riotx/features/home/room/detail/timeline/TimelineEventController.kt
+++ b/vector/src/main/java/im/vector/riotx/features/home/room/detail/timeline/TimelineEventController.kt
@@ -74,7 +74,8 @@ class TimelineEventController @Inject constructor(private val dateFormatter: Vec
         fun onEncryptedMessageClicked(informationData: MessageInformationData, view: View)
         fun onImageMessageClicked(messageImageContent: MessageImageInfoContent, mediaData: ImageContentRenderer.Data, view: View)
         fun onVideoMessageClicked(messageVideoContent: MessageVideoContent, mediaData: VideoContentRenderer.Data, view: View)
-//        fun onFileMessageClicked(eventId: String, messageFileContent: MessageFileContent)
+
+        //        fun onFileMessageClicked(eventId: String, messageFileContent: MessageFileContent)
 //        fun onAudioMessageClicked(messageAudioContent: MessageAudioContent)
         fun onEditedDecorationClicked(informationData: MessageInformationData)
 
@@ -107,7 +108,6 @@ class TimelineEventController @Inject constructor(private val dateFormatter: Vec
         fun onUrlLongClicked(url: String): Boolean
     }
 
-    private var showingForwardLoader = false
     // Map eventId to adapter position
     private val adapterPositionMapping = HashMap<String, Int>()
     private val modelCache = arrayListOf<CacheItemData?>()
@@ -233,7 +233,8 @@ class TimelineEventController @Inject constructor(private val dateFormatter: Vec
 
     override fun buildModels() {
         val timestamp = System.currentTimeMillis()
-        showingForwardLoader = LoadingItem_()
+
+        val showingForwardLoader = LoadingItem_()
                 .id("forward_loading_item_$timestamp")
                 .setVisibilityStateChangedListener(Timeline.Direction.FORWARDS)
                 .addWhenLoading(Timeline.Direction.FORWARDS)
@@ -242,12 +243,13 @@ class TimelineEventController @Inject constructor(private val dateFormatter: Vec
         add(timelineModels)
 
         // Avoid displaying two loaders if there is no elements between them
-        if (!showingForwardLoader || timelineModels.isNotEmpty()) {
-            LoadingItem_()
-                    .id("backward_loading_item_$timestamp")
-                    .setVisibilityStateChangedListener(Timeline.Direction.BACKWARDS)
-                    .addWhenLoading(Timeline.Direction.BACKWARDS)
-        }
+        val showBackwardsLoader = !showingForwardLoader || timelineModels.isNotEmpty()
+        // We can hide the loader but still add the item to controller so it can trigger backwards pagination
+        LoadingItem_()
+                .id("backward_loading_item_$timestamp")
+                .setVisibilityStateChangedListener(Timeline.Direction.BACKWARDS)
+                .showLoader(showBackwardsLoader)
+                .addWhenLoading(Timeline.Direction.BACKWARDS)
     }
 
 // Timeline.LISTENER ***************************************************************************

--- a/vector/src/main/res/layout/item_loading.xml
+++ b/vector/src/main/res/layout/item_loading.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:minHeight="1dp"
     android:background="?riotx_background"
     android:orientation="vertical">
 


### PR DESCRIPTION
Fix loading of timeline items when there are only filtered events