### PR TITLE
Fix IllegalArgumentException reported from store on HomeActivity aunch

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@ Improvements 🙌:
  -
 
 Bugfix 🐛:
- -
+ - Crash reported on playstore for HomeActivity launch (151 reports)
 
 SDK API changes ⚠️:
  -

--- a/vector/src/main/java/im/vector/riotx/features/crypto/quads/SharedSecureStorageViewModel.kt
+++ b/vector/src/main/java/im/vector/riotx/features/crypto/quads/SharedSecureStorageViewModel.kt
@@ -282,8 +282,8 @@ class SharedSecureStorageViewModel @AssistedInject constructor(
         @JvmStatic
         override fun create(viewModelContext: ViewModelContext, state: SharedSecureStorageViewState): SharedSecureStorageViewModel? {
             val activity: SharedSecureStorageActivity = viewModelContext.activity()
-            val args: SharedSecureStorageActivity.Args? = activity.intent.getParcelableExtra(MvRx.KEY_ARG)
-            return args?.let { activity.viewModelFactory.create(state, it) }
+            val args: SharedSecureStorageActivity.Args = activity.intent.getParcelableExtra(MvRx.KEY_ARG) ?: error("Missing args")
+            return activity.viewModelFactory.create(state, args)
         }
     }
 }

--- a/vector/src/main/java/im/vector/riotx/features/home/HomeActivityViewModel.kt
+++ b/vector/src/main/java/im/vector/riotx/features/home/HomeActivityViewModel.kt
@@ -62,7 +62,7 @@ class HomeActivityViewModel @AssistedInject constructor(
         override fun create(viewModelContext: ViewModelContext, state: HomeActivityViewState): HomeActivityViewModel? {
             val activity: HomeActivity = viewModelContext.activity()
             val args: HomeActivityArgs? = activity.intent.getParcelableExtra(MvRx.KEY_ARG)
-            return args?.let { activity.viewModelFactory.create(state, it) }
+            return activity.viewModelFactory.create(state, args ?: HomeActivityArgs(clearNotification = false, accountCreation = false))
         }
     }
 


### PR DESCRIPTION
We got several reports from store of an Illegal argument exception while getting view model
It's a bit defensive code, not sure how this could be called without proper args

````
Caused by: java.lang.IllegalArgumentException: 
  at com.airbnb.mvrx.MvRxFactory.create (MvRxFactory.kt:23)
  at com.airbnb.mvrx.MvRxViewModelProvider.get (MvRxViewModelProvider.kt:27)
  at com.airbnb.mvrx.MvRxViewModelProvider.get$default (MvRxViewModelProvider.kt:2)
  at im.vector.riotx.features.home.HomeActivity$$special$$inlined$viewModel$1.invoke (MvRxExtensions.kt:6)
  at im.vector.riotx.features.home.HomeActivity$$special$$inlined$viewModel$1.invoke (Unknown Source)
  at com.airbnb.mvrx.lifecycleAwareLazy.getValue (lifecycleAwareLazy.kt:6)
  at im.vector.riotx.features.home.HomeActivity.getHomeActivityViewModel (Unknown Source:2)
````
